### PR TITLE
rust-rewrite: add phase 1b.1 config crate skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11,6 +17,12 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cloudflared-cli"
@@ -22,6 +34,14 @@ dependencies = [
 [[package]]
 name = "cloudflared-config"
 version = "2026.2.0-alpha.202603"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "cloudflared-core"
@@ -38,10 +58,170 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -61,6 +241,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "mimalloc"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,7 +262,354 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,8 +6,9 @@ This repository is currently a rewrite planning and scaffolding repository with
 a frozen Go reference implementation.
 
 It is not yet a Rust implementation workspace in the substantive sense. The
-repository now contains a Cargo workspace skeleton, but no subsystem behavior
-has been ported yet.
+repository now contains a Cargo workspace skeleton plus a first-slice domain
+skeleton in `crates/cloudflared-config/`, but no subsystem behavior has been
+ported yet.
 
 The scaffold is intentionally real but minimal:
 
@@ -70,8 +71,9 @@ The following top-level rewrite decisions are part of the active scaffold:
 Current crate intent:
 
 - `crates/cloudflared-cli`: runnable binary scaffold only
-- `crates/cloudflared-config`: future config, credentials, and ingress
-  normalization boundary
+- `crates/cloudflared-config`: owning crate for the accepted first-slice
+  domain skeleton and future config, credentials, and ingress normalization
+  behavior
 - `crates/cloudflared-config/tests/`: first-slice parity harness and fixtures
 - `crates/cloudflared-core`: future shared types and cross-cutting primitives
 - `crates/cloudflared-proto`: future wire-format and RPC boundary
@@ -144,6 +146,31 @@ Implication:
 - the repo can now inventory and mechanically gate the first-slice parity
   contract
 - the repo still must not claim first-slice parity is complete
+
+## Phase 1B.1 Domain Skeleton
+
+Phase 1B.1 groundwork now exists in `crates/cloudflared-config/`.
+
+What exists now:
+
+- admitted first-slice crate dependencies only in `crates/cloudflared-config/Cargo.toml`
+- explicit module layout for discovery, raw config, normalized config,
+  credentials, ingress, and error taxonomy
+- honest public APIs for raw YAML loading, credential JSON loading, and raw to
+  normalized config conversion boundaries
+- narrow unit tests covering shape-level parsing and invariants
+
+What does not exist yet:
+
+- parity-complete config discovery behavior
+- origin-cert PEM decoding behavior
+- ingress validation and deterministic matching behavior
+- Rust actual artifact emission for the Phase 1A harness
+
+Implication:
+
+- `cloudflared-config` is now a real owning crate for the accepted first slice
+- the crate still must not be described as a completed first-slice port
 
 ## First Implementation Gate
 

--- a/crates/cloudflared-config/Cargo.toml
+++ b/crates/cloudflared-config/Cargo.toml
@@ -6,5 +6,13 @@ publish.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", default-features = false, features = ["std"] }
+serde_yaml = "0.9"
+thiserror = "2.0"
+url = { version = "2.5", features = ["serde"] }
+uuid = { version = "1.17", default-features = false, features = ["serde", "std"] }
+
 [lints]
 workspace = true

--- a/crates/cloudflared-config/src/credentials.rs
+++ b/crates/cloudflared-config/src/credentials.rs
@@ -1,0 +1,141 @@
+#![forbid(unsafe_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{ConfigError, Result};
+
+pub const DEFAULT_ORIGIN_CERT_FILE: &str = "cert.pem";
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TunnelReference {
+    pub raw: String,
+    pub uuid: Option<Uuid>,
+}
+
+impl TunnelReference {
+    pub fn from_raw(raw: String) -> Self {
+        let uuid = Uuid::parse_str(&raw).ok();
+        Self { raw, uuid }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum OriginCertLocator {
+    ConfiguredPath(PathBuf),
+    DefaultSearchPath(PathBuf),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct CredentialSurface {
+    pub credentials_file: Option<PathBuf>,
+    pub origin_cert: Option<OriginCertLocator>,
+    pub tunnel: Option<TunnelReference>,
+}
+
+impl CredentialSurface {
+    pub fn configured(
+        credentials_file: Option<PathBuf>,
+        origin_cert: Option<PathBuf>,
+        tunnel: Option<TunnelReference>,
+    ) -> Self {
+        Self {
+            credentials_file,
+            origin_cert: origin_cert.map(OriginCertLocator::ConfiguredPath),
+            tunnel,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TunnelCredentialsFile {
+    #[serde(rename = "AccountTag")]
+    pub account_tag: String,
+    #[serde(rename = "TunnelSecret")]
+    pub tunnel_secret: String,
+    #[serde(rename = "TunnelID")]
+    pub tunnel_id: Uuid,
+    #[serde(rename = "Endpoint", default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+}
+
+impl TunnelCredentialsFile {
+    pub fn from_json_str(contents: &str) -> Result<Self> {
+        serde_json::from_str(contents).map_err(|source| ConfigError::json_parse("tunnel credentials", source))
+    }
+
+    pub fn from_json_path(path: &Path) -> Result<Self> {
+        let contents = fs::read_to_string(path).map_err(|source| ConfigError::read(path, source))?;
+        Self::from_json_str(&contents)
+    }
+
+    pub fn to_pretty_json(&self) -> Result<String> {
+        serde_json::to_string_pretty(self)
+            .map_err(|source| ConfigError::json_serialize("tunnel credentials", source))
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OriginCertToken {
+    #[serde(rename = "zoneID")]
+    pub zone_id: String,
+    #[serde(rename = "accountID")]
+    pub account_id: String,
+    #[serde(rename = "apiToken")]
+    pub api_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+}
+
+impl OriginCertToken {
+    pub fn from_json_str(contents: &str) -> Result<Self> {
+        let mut token: Self = serde_json::from_str(contents)
+            .map_err(|source| ConfigError::json_parse("origin cert token", source))?;
+        token.endpoint = token.endpoint.map(|value| value.to_ascii_lowercase());
+        Ok(token)
+    }
+
+    pub fn from_json_path(path: &Path) -> Result<Self> {
+        let contents = fs::read_to_string(path).map_err(|source| ConfigError::read(path, source))?;
+        Self::from_json_str(&contents)
+    }
+
+    pub fn from_pem_blocks(_blocks: &[u8]) -> Result<Self> {
+        Err(ConfigError::deferred("origin cert PEM decoding"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OriginCertToken, TunnelCredentialsFile};
+
+    fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("unexpected error: {error}"),
+        }
+    }
+
+    #[test]
+    fn tunnel_credentials_json_round_trips() {
+        let creds = ok(TunnelCredentialsFile::from_json_str(
+            r#"{"AccountTag":"account","TunnelSecret":"secret","TunnelID":"11111111-1111-1111-1111-111111111111"}"#,
+        ));
+        let serialized = ok(creds.to_pretty_json());
+
+        assert!(serialized.contains("AccountTag"));
+        assert!(serialized.contains("11111111-1111-1111-1111-111111111111"));
+    }
+
+    #[test]
+    fn origin_cert_json_normalizes_endpoint_case() {
+        let token = ok(OriginCertToken::from_json_str(
+            r#"{"zoneID":"zone","accountID":"account","apiToken":"token","endpoint":"FED"}"#,
+        ));
+
+        assert_eq!(token.endpoint.as_deref(), Some("fed"));
+    }
+}

--- a/crates/cloudflared-config/src/discovery.rs
+++ b/crates/cloudflared-config/src/discovery.rs
@@ -1,0 +1,140 @@
+#![forbid(unsafe_code)]
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_CONFIG_FILES: [&str; 2] = ["config.yml", "config.yaml"];
+const DEFAULT_NIX_SEARCH_DIRECTORIES: [&str; 5] = [
+    "~/.cloudflared",
+    "~/.cloudflare-warp",
+    "~/cloudflare-warp",
+    "/etc/cloudflared",
+    "/usr/local/etc/cloudflared",
+];
+const DEFAULT_NIX_PRIMARY_CONFIG_DIR: &str = "/usr/local/etc/cloudflared";
+const DEFAULT_NIX_PRIMARY_LOG_DIR: &str = "/var/log/cloudflared";
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum DiscoveryOrigin {
+    Explicit,
+    Search,
+    AutoCreateDefault,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ConfigSource {
+    ExplicitPath(PathBuf),
+    DiscoveredPath(PathBuf),
+    AutoCreatedPath(PathBuf),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DiscoveryCandidate {
+    pub origin: DiscoveryOrigin,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DiscoveryPlan {
+    pub path: PathBuf,
+    pub log_directory: PathBuf,
+    pub create_config_directory: bool,
+    pub create_config_file: bool,
+    pub create_log_directory: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DiscoveryDefaults {
+    pub config_filenames: Vec<String>,
+    pub search_directories: Vec<PathBuf>,
+    pub primary_config_path: PathBuf,
+    pub primary_log_directory: PathBuf,
+}
+
+impl Default for DiscoveryDefaults {
+    fn default() -> Self {
+        Self {
+            config_filenames: DEFAULT_CONFIG_FILES.into_iter().map(str::to_owned).collect(),
+            search_directories: default_nix_search_directories(),
+            primary_config_path: default_nix_primary_config_path(),
+            primary_log_directory: default_nix_log_directory(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct DiscoveryRequest {
+    pub explicit_config: Option<PathBuf>,
+    pub defaults: DiscoveryDefaults,
+}
+
+impl DiscoveryRequest {
+    pub fn candidate_paths(&self) -> Vec<DiscoveryCandidate> {
+        if let Some(explicit_config) = &self.explicit_config {
+            return vec![DiscoveryCandidate {
+                origin: DiscoveryOrigin::Explicit,
+                path: explicit_config.clone(),
+            }];
+        }
+
+        self.defaults
+            .search_directories
+            .iter()
+            .flat_map(|directory| {
+                self.defaults
+                    .config_filenames
+                    .iter()
+                    .map(|filename| DiscoveryCandidate {
+                        origin: DiscoveryOrigin::Search,
+                        path: directory.join(filename),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    pub fn auto_create_plan(&self) -> DiscoveryPlan {
+        DiscoveryPlan {
+            path: self.defaults.primary_config_path.clone(),
+            log_directory: self.defaults.primary_log_directory.clone(),
+            create_config_directory: true,
+            create_config_file: true,
+            create_log_directory: true,
+        }
+    }
+}
+
+pub fn default_nix_search_directories() -> Vec<PathBuf> {
+    DEFAULT_NIX_SEARCH_DIRECTORIES
+        .into_iter()
+        .map(PathBuf::from)
+        .collect()
+}
+
+pub fn default_nix_primary_config_path() -> PathBuf {
+    PathBuf::from(DEFAULT_NIX_PRIMARY_CONFIG_DIR).join(DEFAULT_CONFIG_FILES[0])
+}
+
+pub fn default_nix_log_directory() -> PathBuf {
+    PathBuf::from(DEFAULT_NIX_PRIMARY_LOG_DIR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DiscoveryOrigin, DiscoveryRequest};
+
+    #[test]
+    fn candidate_paths_follow_known_search_order() {
+        let request = DiscoveryRequest::default();
+        let candidates = request.candidate_paths();
+
+        assert_eq!(candidates[0].origin, DiscoveryOrigin::Search);
+        assert_eq!(candidates[0].path.to_string_lossy(), "~/.cloudflared/config.yml");
+        assert_eq!(candidates[1].path.to_string_lossy(), "~/.cloudflared/config.yaml");
+        assert_eq!(
+            candidates[2].path.to_string_lossy(),
+            "~/.cloudflare-warp/config.yml"
+        );
+    }
+}

--- a/crates/cloudflared-config/src/error.rs
+++ b/crates/cloudflared-config/src/error.rs
@@ -1,0 +1,103 @@
+#![forbid(unsafe_code)]
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("failed to read {path}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse YAML from {source_name}")]
+    Yaml {
+        source_name: String,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error("failed to parse JSON for {subject}")]
+    JsonParse {
+        subject: &'static str,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to serialize JSON for {subject}")]
+    JsonSerialize {
+        subject: &'static str,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("invalid URL for {field}: {value}")]
+    InvalidUrl {
+        field: &'static str,
+        value: String,
+        #[source]
+        source: url::ParseError,
+    },
+    #[error("invalid UUID for {field}: {value}")]
+    InvalidUuid {
+        field: &'static str,
+        value: String,
+        #[source]
+        source: uuid::Error,
+    },
+    #[error("{message}")]
+    InvariantViolation { message: String },
+    #[error("{operation} is deferred beyond phase 1B.1")]
+    Deferred { operation: &'static str },
+}
+
+pub type Result<T> = std::result::Result<T, ConfigError>;
+
+impl ConfigError {
+    pub fn read(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        Self::Io {
+            path: path.into(),
+            source,
+        }
+    }
+
+    pub fn yaml(source_name: impl Into<String>, source: serde_yaml::Error) -> Self {
+        Self::Yaml {
+            source_name: source_name.into(),
+            source,
+        }
+    }
+
+    pub fn json_parse(subject: &'static str, source: serde_json::Error) -> Self {
+        Self::JsonParse { subject, source }
+    }
+
+    pub fn json_serialize(subject: &'static str, source: serde_json::Error) -> Self {
+        Self::JsonSerialize { subject, source }
+    }
+
+    pub fn invalid_url(field: &'static str, value: impl Into<String>, source: url::ParseError) -> Self {
+        Self::InvalidUrl {
+            field,
+            value: value.into(),
+            source,
+        }
+    }
+
+    pub fn invalid_uuid(field: &'static str, value: impl Into<String>, source: uuid::Error) -> Self {
+        Self::InvalidUuid {
+            field,
+            value: value.into(),
+            source,
+        }
+    }
+
+    pub fn invariant(message: impl Into<String>) -> Self {
+        Self::InvariantViolation {
+            message: message.into(),
+        }
+    }
+
+    pub fn deferred(operation: &'static str) -> Self {
+        Self::Deferred { operation }
+    }
+}

--- a/crates/cloudflared-config/src/ingress.rs
+++ b/crates/cloudflared-config/src/ingress.rs
@@ -1,0 +1,181 @@
+#![forbid(unsafe_code)]
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::error::{ConfigError, Result};
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[serde(transparent)]
+pub struct DurationSpec(pub String);
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct AccessConfig {
+    #[serde(default)]
+    pub required: bool,
+    #[serde(rename = "teamName", default)]
+    pub team_name: String,
+    #[serde(rename = "audTag", default)]
+    pub aud_tag: Vec<String>,
+    #[serde(default)]
+    pub environment: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct IngressIpRule {
+    #[serde(default)]
+    pub prefix: Option<String>,
+    #[serde(default)]
+    pub ports: Vec<u16>,
+    #[serde(default)]
+    pub allow: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct OriginRequestConfig {
+    #[serde(rename = "connectTimeout", default)]
+    pub connect_timeout: Option<DurationSpec>,
+    #[serde(rename = "tlsTimeout", default)]
+    pub tls_timeout: Option<DurationSpec>,
+    #[serde(rename = "tcpKeepAlive", default)]
+    pub tcp_keep_alive: Option<DurationSpec>,
+    #[serde(rename = "noHappyEyeballs", default)]
+    pub no_happy_eyeballs: Option<bool>,
+    #[serde(rename = "keepAliveConnections", default)]
+    pub keep_alive_connections: Option<u32>,
+    #[serde(rename = "keepAliveTimeout", default)]
+    pub keep_alive_timeout: Option<DurationSpec>,
+    #[serde(rename = "httpHostHeader", default)]
+    pub http_host_header: Option<String>,
+    #[serde(rename = "originServerName", default)]
+    pub origin_server_name: Option<String>,
+    #[serde(rename = "matchSNItoHost", default)]
+    pub match_sni_to_host: Option<bool>,
+    #[serde(rename = "caPool", default)]
+    pub ca_pool: Option<PathBuf>,
+    #[serde(rename = "noTLSVerify", default)]
+    pub no_tls_verify: Option<bool>,
+    #[serde(rename = "disableChunkedEncoding", default)]
+    pub disable_chunked_encoding: Option<bool>,
+    #[serde(rename = "bastionMode", default)]
+    pub bastion_mode: Option<bool>,
+    #[serde(rename = "proxyAddress", default)]
+    pub proxy_address: Option<String>,
+    #[serde(rename = "proxyPort", default)]
+    pub proxy_port: Option<u16>,
+    #[serde(rename = "proxyType", default)]
+    pub proxy_type: Option<String>,
+    #[serde(rename = "ipRules", default)]
+    pub ip_rules: Vec<IngressIpRule>,
+    #[serde(rename = "http2Origin", default)]
+    pub http2_origin: Option<bool>,
+    #[serde(default)]
+    pub access: Option<AccessConfig>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct RawIngressRule {
+    #[serde(default)]
+    pub hostname: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub service: Option<String>,
+    #[serde(rename = "originRequest", default)]
+    pub origin_request: OriginRequestConfig,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum IngressService {
+    Uri(Url),
+    UnixSocket(PathBuf),
+    UnixSocketTls(PathBuf),
+    NamedToken(String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct IngressMatch {
+    pub hostname: Option<String>,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct IngressRule {
+    pub matcher: IngressMatch,
+    pub service: IngressService,
+    pub origin_request: OriginRequestConfig,
+}
+
+impl IngressService {
+    pub fn parse(field: &'static str, value: &str) -> Result<Self> {
+        if let Some(path) = value.strip_prefix("unix+tls:") {
+            return Ok(Self::UnixSocketTls(PathBuf::from(path)));
+        }
+
+        if let Some(path) = value.strip_prefix("unix:") {
+            return Ok(Self::UnixSocket(PathBuf::from(path)));
+        }
+
+        match Url::parse(value) {
+            Ok(url) => Ok(Self::Uri(url)),
+            Err(url::ParseError::RelativeUrlWithoutBase) => Ok(Self::NamedToken(value.to_owned())),
+            Err(source) => Err(ConfigError::invalid_url(field, value, source)),
+        }
+    }
+}
+
+impl IngressRule {
+    pub fn from_raw(raw: RawIngressRule) -> Result<Self> {
+        let service = match raw.service {
+            Some(service) => IngressService::parse("service", &service)?,
+            None => return Err(ConfigError::invariant("ingress rule is missing service")),
+        };
+
+        Ok(Self {
+            matcher: IngressMatch {
+                hostname: raw.hostname,
+                path: raw.path,
+            },
+            service,
+            origin_request: raw.origin_request,
+        })
+    }
+
+    pub fn is_catch_all(&self) -> bool {
+        self.matcher.hostname.is_none() && self.matcher.path.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IngressRule, IngressService, RawIngressRule};
+
+    fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("unexpected error: {error}"),
+        }
+    }
+
+    #[test]
+    fn service_parser_recognizes_url_services() {
+        let service = ok(IngressService::parse("service", "https://localhost:8080"));
+
+        match service {
+            IngressService::Uri(url) => assert_eq!(url.scheme(), "https"),
+            other => panic!("expected URI service, found {other:?}"),
+        }
+    }
+
+    #[test]
+    fn raw_rule_without_hostname_or_path_is_catch_all() {
+        let rule = ok(IngressRule::from_raw(RawIngressRule {
+            service: Some("https://localhost:8080".to_owned()),
+            ..RawIngressRule::default()
+        }));
+
+        assert!(rule.is_catch_all());
+    }
+}

--- a/crates/cloudflared-config/src/lib.rs
+++ b/crates/cloudflared-config/src/lib.rs
@@ -1,11 +1,45 @@
 #![forbid(unsafe_code)]
 
-//! Config and credential parsing boundary for the rewrite.
+//! Domain boundary for the accepted first slice.
 //!
-//! The accepted first subsystem slice will land here:
+//! This crate now owns the Phase 1B.1 domain skeleton for:
 //!
-//! - config discovery and parsing
-//! - credentials handling
-//! - ingress normalization
+//! - config discovery inputs and sources
+//! - raw YAML-backed config representation
+//! - normalized config representation
+//! - credentials and origin-cert surface types
+//! - ingress rule representation
+//! - explicit error taxonomy
 //!
-//! Intentionally minimal for now. No subsystem behavior is implemented yet.
+//! Externally visible first-slice behavior is still incomplete. This crate is a
+//! synchronous domain skeleton, not a parity-complete implementation.
+
+pub mod credentials;
+pub mod discovery;
+pub mod error;
+pub mod ingress;
+pub mod normalized;
+pub mod raw_config;
+
+pub use crate::credentials::{
+    CredentialSurface, OriginCertLocator, OriginCertToken, TunnelCredentialsFile, TunnelReference,
+};
+pub use crate::discovery::{
+    ConfigSource, DiscoveryCandidate, DiscoveryDefaults, DiscoveryOrigin, DiscoveryPlan, DiscoveryRequest,
+    default_nix_log_directory, default_nix_primary_config_path, default_nix_search_directories,
+};
+pub use crate::error::{ConfigError, Result};
+pub use crate::ingress::{
+    AccessConfig, DurationSpec, IngressIpRule, IngressMatch, IngressRule, IngressService,
+    OriginRequestConfig, RawIngressRule,
+};
+pub use crate::normalized::{NormalizationWarning, NormalizedConfig};
+pub use crate::raw_config::{RawConfig, WarpRoutingConfig};
+
+pub fn parse_raw_config(source_name: &str, contents: &str) -> Result<RawConfig> {
+    RawConfig::from_yaml_str(source_name, contents)
+}
+
+pub fn normalize_config(source: ConfigSource, raw: RawConfig) -> Result<NormalizedConfig> {
+    NormalizedConfig::from_raw(source, raw)
+}

--- a/crates/cloudflared-config/src/normalized.rs
+++ b/crates/cloudflared-config/src/normalized.rs
@@ -1,0 +1,98 @@
+#![forbid(unsafe_code)]
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::credentials::{CredentialSurface, TunnelReference};
+use crate::discovery::ConfigSource;
+use crate::error::Result;
+use crate::ingress::IngressRule;
+use crate::raw_config::{RawConfig, WarpRoutingConfig};
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum NormalizationWarning {
+    UnknownTopLevelKeys(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NormalizedConfig {
+    pub source: ConfigSource,
+    pub tunnel: Option<TunnelReference>,
+    pub credentials: CredentialSurface,
+    pub ingress: Vec<IngressRule>,
+    pub origin_request: crate::ingress::OriginRequestConfig,
+    pub warp_routing: WarpRoutingConfig,
+    pub log_directory: Option<PathBuf>,
+    pub warnings: Vec<NormalizationWarning>,
+}
+
+impl NormalizedConfig {
+    pub fn from_raw(source: ConfigSource, raw: RawConfig) -> Result<Self> {
+        let unknown_top_level_keys = raw.unknown_top_level_keys();
+        let warnings = if unknown_top_level_keys.is_empty() {
+            Vec::new()
+        } else {
+            vec![NormalizationWarning::UnknownTopLevelKeys(unknown_top_level_keys)]
+        };
+        let tunnel = raw.tunnel.map(TunnelReference::from_raw);
+
+        let ingress = raw
+            .ingress
+            .into_iter()
+            .map(IngressRule::from_raw)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            source,
+            tunnel: tunnel.clone(),
+            credentials: CredentialSurface::configured(raw.credentials_file, raw.origin_cert, tunnel),
+            ingress,
+            origin_request: raw.origin_request,
+            warp_routing: raw.warp_routing,
+            log_directory: raw.log_directory,
+            warnings,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::credentials::TunnelReference;
+    use crate::discovery::ConfigSource;
+    use crate::normalized::{NormalizationWarning, NormalizedConfig};
+    use crate::raw_config::RawConfig;
+
+    fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("unexpected error: {error}"),
+        }
+    }
+
+    #[test]
+    fn normalization_carries_unknown_top_level_key_warning() {
+        let raw = ok(RawConfig::from_yaml_str(
+            "fixture.yaml",
+            "tunnel: config-file-test\ningress:\n  - service: https://localhost:8080\nextraKey: true\n",
+        ));
+        let normalized = ok(NormalizedConfig::from_raw(
+            ConfigSource::DiscoveredPath("/tmp/config.yml".into()),
+            raw,
+        ));
+
+        assert_eq!(
+            normalized.warnings,
+            vec![NormalizationWarning::UnknownTopLevelKeys(vec![
+                "extraKey".to_owned(),
+            ])]
+        );
+        assert_eq!(
+            normalized.tunnel,
+            Some(TunnelReference {
+                raw: "config-file-test".to_owned(),
+                uuid: None,
+            })
+        );
+    }
+}

--- a/crates/cloudflared-config/src/raw_config.rs
+++ b/crates/cloudflared-config/src/raw_config.rs
@@ -1,0 +1,77 @@
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ConfigError, Result};
+use crate::ingress::{OriginRequestConfig, RawIngressRule};
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct WarpRoutingConfig {
+    #[serde(rename = "connectTimeout", default)]
+    pub connect_timeout: Option<crate::ingress::DurationSpec>,
+    #[serde(rename = "maxActiveFlows", default)]
+    pub max_active_flows: Option<u64>,
+    #[serde(rename = "tcpKeepAlive", default)]
+    pub tcp_keep_alive: Option<crate::ingress::DurationSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct RawConfig {
+    #[serde(default)]
+    pub tunnel: Option<String>,
+    #[serde(rename = "credentials-file", default)]
+    pub credentials_file: Option<PathBuf>,
+    #[serde(rename = "origincert", default)]
+    pub origin_cert: Option<PathBuf>,
+    #[serde(default)]
+    pub ingress: Vec<RawIngressRule>,
+    #[serde(rename = "warp-routing", default)]
+    pub warp_routing: WarpRoutingConfig,
+    #[serde(rename = "originRequest", default)]
+    pub origin_request: OriginRequestConfig,
+    #[serde(rename = "logDirectory", default)]
+    pub log_directory: Option<PathBuf>,
+    #[serde(flatten)]
+    pub additional_fields: BTreeMap<String, serde_yaml::Value>,
+}
+
+impl RawConfig {
+    pub fn from_yaml_str(source_name: &str, contents: &str) -> Result<Self> {
+        serde_yaml::from_str(contents).map_err(|source| ConfigError::yaml(source_name, source))
+    }
+
+    pub fn from_yaml_path(path: &Path) -> Result<Self> {
+        let contents = fs::read_to_string(path).map_err(|source| ConfigError::read(path, source))?;
+        Self::from_yaml_str(&path.display().to_string(), &contents)
+    }
+
+    pub fn unknown_top_level_keys(&self) -> Vec<String> {
+        self.additional_fields.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RawConfig;
+
+    fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("unexpected error: {error}"),
+        }
+    }
+
+    #[test]
+    fn unknown_top_level_keys_are_retained() {
+        let raw = ok(RawConfig::from_yaml_str(
+            "fixture.yaml",
+            "ingress:\n  - service: https://localhost:8080\nextraKey: true\n",
+        ));
+
+        assert_eq!(raw.unknown_top_level_keys(), vec!["extraKey".to_owned()]);
+    }
+}

--- a/crates/cloudflared-config/tests/parity_harness_inventory.rs
+++ b/crates/cloudflared-config/tests/parity_harness_inventory.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![allow(unused_crate_dependencies)]
 
 use cloudflared_config as _;
 

--- a/crates/cloudflared-config/tests/phase_1a_parity_scaffold.rs
+++ b/crates/cloudflared-config/tests/phase_1a_parity_scaffold.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![allow(unused_crate_dependencies)]
 
 use cloudflared_config as _;
 use std::process::Command;


### PR DESCRIPTION
## What this PR does

This PR turns `cloudflared-config` from a placeholder into a real first-slice crate.

It adds the approved config-related dependencies, sets up the internal module layout, and defines the main types for config discovery, raw/normalized config, credentials, ingress, and local errors.

## Included in this PR

- approved first-slice config dependencies
- `cloudflared-config` module structure
- core domain types for config-related work
- minimal parsing / normalization-facing API shape
- narrow tests and small status/doc updates

## Scope

This stays within the accepted first slice, focused on crate structure and config-domain boundaries.

## Not included

This PR does not cover:
- transport or proxying
- supervisor/runtime work
- metrics or management APIs
- broad CLI parity
- full first-slice behavior
- Go-vs-Rust parity completion

## Why now

Phase 1A #1 set up the harness and fixture groundwork.

This PR gives the config slice a proper home so the next step can start implementing behavior in a structured way.

## Current status after this PR

What exists after this:
- Phase 1A groundwork
- first-slice fixture structure
- `cloudflared-config` domain skeleton
- approved config-slice dependencies

What still comes next:
- actual first-slice behavior
- captured Go truth for relevant cases
- passing parity comparisons