### PR TITLE
rust-rewrite: add phase 1b.2 config loading path

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -172,6 +172,30 @@ Implication:
 - `cloudflared-config` is now a real owning crate for the accepted first slice
 - the crate still must not be described as a completed first-slice port
 
+## Phase 1B.2 Config Loading Path
+
+Phase 1B.2 behavior now exists for the targeted config-loading fixtures.
+
+What exists now:
+
+- deterministic config discovery with default search order and auto-create side effects
+- YAML file loading into the crate's raw config representation
+- raw-to-normalized conversion for the currently targeted config surface
+- narrow ingress validation for the current invalid and unicode config fixtures
+- Rust actual artifact emission for targeted config discovery and config loading fixtures
+
+What does not exist yet:
+
+- Go truth outputs for comparison
+- full credentials and origin-cert behavior parity
+- full ingress validation and deterministic matching behavior
+- CLI-origin ingress normalization artifacts
+
+Implication:
+
+- the accepted first slice now has a real config-loading path in Rust
+- the repository still must not claim first-slice parity is complete
+
 ## First Implementation Gate
 
 No large-scale subsystem implementation should begin until all of the following

--- a/crates/cloudflared-config/examples/first_slice_emit.rs
+++ b/crates/cloudflared-config/examples/first_slice_emit.rs
@@ -1,0 +1,123 @@
+#![allow(unused_crate_dependencies)]
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use cloudflared_config::artifact::{
+    DiscoveryCase, DiscoveryReportPayload, EmissionPlan, FixtureSpec, discovery_envelope, error_envelope,
+    normalized_config_envelope,
+};
+use cloudflared_config::{
+    ConfigSource, DiscoveryDefaults, DiscoveryRequest, discover_config, load_normalized_config,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let plan = read_plan()?;
+    fs::create_dir_all(&plan.output_dir)?;
+
+    for fixture in &plan.fixtures {
+        let envelope = match fixture.category.as_str() {
+            "config-discovery" => emit_discovery_fixture(fixture)?,
+            "yaml-config" | "ordering-defaulting" | "invalid-input" => {
+                emit_config_fixture(&plan.fixture_root, fixture)?
+            }
+            other => return Err(format!("unsupported fixture category for Phase 1B.2: {other}").into()),
+        };
+
+        let output_path = plan.output_dir.join(format!("{}.json", fixture.fixture_id));
+        fs::write(output_path, serde_json::to_string_pretty(&envelope)?)?;
+    }
+
+    Ok(())
+}
+
+fn read_plan() -> Result<EmissionPlan, Box<dyn std::error::Error>> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    Ok(serde_json::from_str(&input)?)
+}
+
+fn emit_discovery_fixture(
+    fixture: &FixtureSpec,
+) -> Result<cloudflared_config::artifact::ArtifactEnvelope, Box<dyn std::error::Error>> {
+    let Some(discovery_case) = fixture.discovery_case.as_ref() else {
+        return Err(format!("fixture {} is missing discovery case data", fixture.fixture_id).into());
+    };
+
+    let sandbox_root = build_discovery_sandbox(discovery_case)?;
+    let request = DiscoveryRequest {
+        explicit_config: explicit_config_path(discovery_case, &sandbox_root),
+        defaults: discovery_defaults(&sandbox_root),
+    };
+
+    let outcome = discover_config(&request)?;
+    let payload = DiscoveryReportPayload::from_outcome(&outcome, &sandbox_root);
+    let envelope = discovery_envelope(fixture, payload)?;
+    fs::remove_dir_all(&sandbox_root)?;
+    Ok(envelope)
+}
+
+fn emit_config_fixture(
+    fixture_root: &Path,
+    fixture: &FixtureSpec,
+) -> Result<cloudflared_config::artifact::ArtifactEnvelope, Box<dyn std::error::Error>> {
+    let input_path = fixture_root.join(&fixture.input);
+    let source = ConfigSource::DiscoveredPath(PathBuf::from(&fixture.input));
+
+    match load_normalized_config(&input_path, source) {
+        Ok(normalized) => Ok(normalized_config_envelope(
+            fixture,
+            Path::new(&fixture.input),
+            &normalized,
+        )?),
+        Err(error) => Ok(error_envelope(fixture, &error)?),
+    }
+}
+
+fn build_discovery_sandbox(case: &DiscoveryCase) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let unique = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let sandbox_root = std::env::temp_dir().join(format!("cloudflared-config-discovery-{unique}"));
+    fs::create_dir_all(&sandbox_root)?;
+
+    for logical_path in &case.present {
+        let actual_path = logical_to_sandbox_path(&sandbox_root, logical_path);
+        if let Some(parent) = actual_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(actual_path, "logDirectory: /var/log/cloudflared\n")?;
+    }
+
+    Ok(sandbox_root)
+}
+
+fn explicit_config_path(case: &DiscoveryCase, sandbox_root: &Path) -> Option<PathBuf> {
+    if case.explicit_config {
+        Some(logical_to_sandbox_path(
+            sandbox_root,
+            "home/.cloudflared/config.yml",
+        ))
+    } else {
+        None
+    }
+}
+
+fn discovery_defaults(sandbox_root: &Path) -> DiscoveryDefaults {
+    DiscoveryDefaults {
+        config_filenames: vec!["config.yml".to_owned(), "config.yaml".to_owned()],
+        search_directories: vec![
+            logical_to_sandbox_path(sandbox_root, "home/.cloudflared"),
+            logical_to_sandbox_path(sandbox_root, "home/.cloudflare-warp"),
+            logical_to_sandbox_path(sandbox_root, "home/cloudflare-warp"),
+            logical_to_sandbox_path(sandbox_root, "etc/cloudflared"),
+            logical_to_sandbox_path(sandbox_root, "usr/local/etc/cloudflared"),
+        ],
+        primary_config_path: logical_to_sandbox_path(sandbox_root, "usr/local/etc/cloudflared/config.yml"),
+        primary_log_directory: logical_to_sandbox_path(sandbox_root, "var/log/cloudflared"),
+    }
+}
+
+fn logical_to_sandbox_path(sandbox_root: &Path, logical_path: &str) -> PathBuf {
+    sandbox_root.join(logical_path.trim_start_matches('/'))
+}

--- a/crates/cloudflared-config/src/artifact.rs
+++ b/crates/cloudflared-config/src/artifact.rs
@@ -1,0 +1,352 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::credentials::{CredentialSurface, OriginCertLocator, TunnelReference};
+use crate::discovery::{ConfigSource, DiscoveryAction, DiscoveryOutcome};
+use crate::error::ConfigError;
+use crate::ingress::{IngressRule, IngressService, OriginRequestConfig};
+use crate::normalized::{NormalizationWarning, NormalizedConfig};
+use crate::raw_config::WarpRoutingConfig;
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EmissionPlan {
+    pub fixture_root: PathBuf,
+    pub output_dir: PathBuf,
+    pub fixtures: Vec<FixtureSpec>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureSpec {
+    pub fixture_id: String,
+    pub category: String,
+    pub comparison: String,
+    pub input: String,
+    pub source_refs: Vec<String>,
+    #[serde(default)]
+    pub discovery_case: Option<DiscoveryCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DiscoveryCase {
+    pub explicit_config: bool,
+    pub present: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ArtifactEnvelope {
+    pub schema_version: u32,
+    pub fixture_id: String,
+    pub producer: &'static str,
+    pub report_kind: &'static str,
+    pub comparison: String,
+    pub source_refs: Vec<String>,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoveryReportPayload {
+    pub action: &'static str,
+    pub source_kind: &'static str,
+    pub resolved_path: String,
+    pub created_paths: Vec<String>,
+    pub written_config: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ErrorReportPayload {
+    pub category: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct NormalizedConfigPayload {
+    pub source_kind: &'static str,
+    pub source_path: String,
+    pub tunnel: Option<TunnelReferencePayload>,
+    pub credentials: CredentialSurfacePayload,
+    pub ingress: Vec<IngressRulePayload>,
+    pub origin_request: OriginRequestConfig,
+    pub warp_routing: WarpRoutingConfig,
+    pub log_directory: Option<String>,
+    pub warnings: Vec<WarningPayload>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TunnelReferencePayload {
+    pub raw: String,
+    pub uuid: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CredentialSurfacePayload {
+    pub credentials_file: Option<String>,
+    pub origin_cert: Option<OriginCertLocatorPayload>,
+    pub tunnel: Option<TunnelReferencePayload>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OriginCertLocatorPayload {
+    pub kind: &'static str,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IngressRulePayload {
+    pub hostname: Option<String>,
+    pub punycode_hostname: Option<String>,
+    pub path: Option<String>,
+    pub service: IngressServicePayload,
+    pub origin_request: OriginRequestConfig,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IngressServicePayload {
+    pub kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<u16>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WarningPayload {
+    pub kind: &'static str,
+    pub keys: Vec<String>,
+}
+
+pub fn discovery_envelope(
+    fixture: &FixtureSpec,
+    payload: DiscoveryReportPayload,
+) -> Result<ArtifactEnvelope, serde_json::Error> {
+    Ok(ArtifactEnvelope {
+        schema_version: SCHEMA_VERSION,
+        fixture_id: fixture.fixture_id.clone(),
+        producer: "rust-actual",
+        report_kind: "discovery-report.v1",
+        comparison: fixture.comparison.clone(),
+        source_refs: fixture.source_refs.clone(),
+        payload: serde_json::to_value(payload)?,
+    })
+}
+
+pub fn normalized_config_envelope(
+    fixture: &FixtureSpec,
+    source_path: &Path,
+    normalized: &NormalizedConfig,
+) -> Result<ArtifactEnvelope, serde_json::Error> {
+    Ok(ArtifactEnvelope {
+        schema_version: SCHEMA_VERSION,
+        fixture_id: fixture.fixture_id.clone(),
+        producer: "rust-actual",
+        report_kind: "normalized-config.v1",
+        comparison: fixture.comparison.clone(),
+        source_refs: fixture.source_refs.clone(),
+        payload: serde_json::to_value(NormalizedConfigPayload::from_normalized(source_path, normalized))?,
+    })
+}
+
+pub fn error_envelope(
+    fixture: &FixtureSpec,
+    error: &ConfigError,
+) -> Result<ArtifactEnvelope, serde_json::Error> {
+    Ok(ArtifactEnvelope {
+        schema_version: SCHEMA_VERSION,
+        fixture_id: fixture.fixture_id.clone(),
+        producer: "rust-actual",
+        report_kind: "error-report.v1",
+        comparison: fixture.comparison.clone(),
+        source_refs: fixture.source_refs.clone(),
+        payload: serde_json::to_value(ErrorReportPayload {
+            category: error.category(),
+            message: error.to_string(),
+        })?,
+    })
+}
+
+impl DiscoveryReportPayload {
+    pub fn from_outcome(outcome: &DiscoveryOutcome, sandbox_root: &Path) -> Self {
+        Self {
+            action: match outcome.action {
+                DiscoveryAction::UseExisting => "use-existing",
+                DiscoveryAction::CreateDefaultConfig => "create-default-config",
+            },
+            source_kind: match &outcome.source {
+                ConfigSource::ExplicitPath(_) => "explicit-path",
+                ConfigSource::DiscoveredPath(_) => "discovered-path",
+                ConfigSource::AutoCreatedPath(_) => "auto-created-path",
+            },
+            resolved_path: display_path(&outcome.path, sandbox_root),
+            created_paths: outcome
+                .created_paths
+                .iter()
+                .map(|path| display_path(path, sandbox_root))
+                .collect(),
+            written_config: outcome.written_config.clone(),
+        }
+    }
+}
+
+impl NormalizedConfigPayload {
+    pub fn from_normalized(source_path: &Path, normalized: &NormalizedConfig) -> Self {
+        Self {
+            source_kind: match normalized.source {
+                ConfigSource::ExplicitPath(_) => "explicit-path",
+                ConfigSource::DiscoveredPath(_) => "discovered-path",
+                ConfigSource::AutoCreatedPath(_) => "auto-created-path",
+            },
+            source_path: source_path.display().to_string(),
+            tunnel: normalized
+                .tunnel
+                .as_ref()
+                .map(TunnelReferencePayload::from_tunnel),
+            credentials: CredentialSurfacePayload::from_credentials(&normalized.credentials),
+            ingress: normalized
+                .ingress
+                .iter()
+                .map(IngressRulePayload::from_rule)
+                .collect(),
+            origin_request: normalized.origin_request.clone(),
+            warp_routing: normalized.warp_routing.clone(),
+            log_directory: normalized
+                .log_directory
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            warnings: normalized
+                .warnings
+                .iter()
+                .map(WarningPayload::from_warning)
+                .collect(),
+        }
+    }
+}
+
+impl TunnelReferencePayload {
+    fn from_tunnel(tunnel: &TunnelReference) -> Self {
+        Self {
+            raw: tunnel.raw.clone(),
+            uuid: tunnel.uuid.map(|value| value.to_string()),
+        }
+    }
+}
+
+impl CredentialSurfacePayload {
+    fn from_credentials(credentials: &CredentialSurface) -> Self {
+        Self {
+            credentials_file: credentials
+                .credentials_file
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            origin_cert: credentials
+                .origin_cert
+                .as_ref()
+                .map(OriginCertLocatorPayload::from_locator),
+            tunnel: credentials
+                .tunnel
+                .as_ref()
+                .map(TunnelReferencePayload::from_tunnel),
+        }
+    }
+}
+
+impl OriginCertLocatorPayload {
+    fn from_locator(locator: &OriginCertLocator) -> Self {
+        match locator {
+            OriginCertLocator::ConfiguredPath(path) => Self {
+                kind: "configured-path",
+                path: path.display().to_string(),
+            },
+            OriginCertLocator::DefaultSearchPath(path) => Self {
+                kind: "default-search-path",
+                path: path.display().to_string(),
+            },
+        }
+    }
+}
+
+impl IngressRulePayload {
+    fn from_rule(rule: &IngressRule) -> Self {
+        Self {
+            hostname: rule.matcher.hostname.clone(),
+            punycode_hostname: rule.matcher.punycode_hostname.clone(),
+            path: rule.matcher.path.clone(),
+            service: IngressServicePayload::from_service(&rule.service),
+            origin_request: rule.origin_request.clone(),
+        }
+    }
+}
+
+impl IngressServicePayload {
+    fn from_service(service: &IngressService) -> Self {
+        match service {
+            IngressService::Uri(uri) => Self {
+                kind: "uri",
+                uri: Some(uri.to_string()),
+                path: None,
+                name: None,
+                status_code: None,
+            },
+            IngressService::UnixSocket(path) => Self {
+                kind: "unix-socket",
+                uri: None,
+                path: Some(path.display().to_string()),
+                name: None,
+                status_code: None,
+            },
+            IngressService::UnixSocketTls(path) => Self {
+                kind: "unix-socket-tls",
+                uri: None,
+                path: Some(path.display().to_string()),
+                name: None,
+                status_code: None,
+            },
+            IngressService::HttpStatus(status_code) => Self {
+                kind: "http-status",
+                uri: None,
+                path: None,
+                name: None,
+                status_code: Some(*status_code),
+            },
+            IngressService::HelloWorld => Self {
+                kind: "hello-world",
+                uri: None,
+                path: None,
+                name: None,
+                status_code: None,
+            },
+            IngressService::NamedToken(name) => Self {
+                kind: "named-token",
+                uri: None,
+                path: None,
+                name: Some(name.clone()),
+                status_code: None,
+            },
+        }
+    }
+}
+
+impl WarningPayload {
+    fn from_warning(warning: &NormalizationWarning) -> Self {
+        match warning {
+            NormalizationWarning::UnknownTopLevelKeys(keys) => Self {
+                kind: "unknown-top-level-keys",
+                keys: keys.clone(),
+            },
+        }
+    }
+}
+
+fn display_path(path: &Path, sandbox_root: &Path) -> String {
+    if let Ok(relative) = path.strip_prefix(sandbox_root) {
+        format!("/{}", relative.display())
+    } else {
+        path.display().to_string()
+    }
+}

--- a/crates/cloudflared-config/src/credentials.rs
+++ b/crates/cloudflared-config/src/credentials.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/crates/cloudflared-config/src/discovery.rs
+++ b/crates/cloudflared-config/src/discovery.rs
@@ -1,8 +1,9 @@
-#![forbid(unsafe_code)]
-
+use std::fs;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+
+use crate::error::{ConfigError, Result};
 
 const DEFAULT_CONFIG_FILES: [&str; 2] = ["config.yml", "config.yaml"];
 const DEFAULT_NIX_SEARCH_DIRECTORIES: [&str; 5] = [
@@ -23,6 +24,12 @@ pub enum DiscoveryOrigin {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum DiscoveryAction {
+    UseExisting,
+    CreateDefaultConfig,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ConfigSource {
     ExplicitPath(PathBuf),
     DiscoveredPath(PathBuf),
@@ -33,6 +40,15 @@ pub enum ConfigSource {
 pub struct DiscoveryCandidate {
     pub origin: DiscoveryOrigin,
     pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DiscoveryOutcome {
+    pub action: DiscoveryAction,
+    pub source: ConfigSource,
+    pub path: PathBuf,
+    pub created_paths: Vec<PathBuf>,
+    pub written_config: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -103,6 +119,61 @@ impl DiscoveryRequest {
             create_log_directory: true,
         }
     }
+
+    pub fn find_default_config_path(&self) -> Option<PathBuf> {
+        self.candidate_paths().into_iter().find_map(|candidate| {
+            if candidate.path.exists() {
+                Some(candidate.path)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn find_or_create_config_path(&self) -> Result<DiscoveryOutcome> {
+        if let Some(explicit_config) = &self.explicit_config {
+            return Ok(DiscoveryOutcome {
+                action: DiscoveryAction::UseExisting,
+                source: ConfigSource::ExplicitPath(explicit_config.clone()),
+                path: explicit_config.clone(),
+                created_paths: Vec::new(),
+                written_config: None,
+            });
+        }
+
+        if let Some(path) = self.find_default_config_path() {
+            return Ok(DiscoveryOutcome {
+                action: DiscoveryAction::UseExisting,
+                source: ConfigSource::DiscoveredPath(path.clone()),
+                path,
+                created_paths: Vec::new(),
+                written_config: None,
+            });
+        }
+
+        let plan = self.auto_create_plan();
+        let config_directory = plan.path.parent().unwrap_or(plan.path.as_path()).to_path_buf();
+        fs::create_dir_all(&config_directory)
+            .map_err(|source| ConfigError::create_directory(config_directory.clone(), source))?;
+        fs::create_dir_all(&plan.log_directory)
+            .map_err(|source| ConfigError::create_directory(plan.log_directory.clone(), source))?;
+
+        let contents = minimal_auto_create_config(&plan.log_directory);
+        fs::write(&plan.path, &contents)
+            .map_err(|source| ConfigError::write_file(plan.path.clone(), source))?;
+
+        Ok(DiscoveryOutcome {
+            action: DiscoveryAction::CreateDefaultConfig,
+            source: ConfigSource::AutoCreatedPath(plan.path.clone()),
+            path: plan.path.clone(),
+            created_paths: vec![config_directory, plan.path, plan.log_directory],
+            written_config: Some(contents),
+        })
+    }
+}
+
+pub fn minimal_auto_create_config(log_directory: &std::path::Path) -> String {
+    format!("logDirectory: {}\n", log_directory.display())
 }
 
 pub fn default_nix_search_directories() -> Vec<PathBuf> {
@@ -122,7 +193,20 @@ pub fn default_nix_log_directory() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{DiscoveryOrigin, DiscoveryRequest};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{DiscoveryAction, DiscoveryDefaults, DiscoveryOrigin, DiscoveryRequest};
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("cloudflared-config-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("temp directory should be created");
+        path
+    }
 
     #[test]
     fn candidate_paths_follow_known_search_order() {
@@ -136,5 +220,32 @@ mod tests {
             candidates[2].path.to_string_lossy(),
             "~/.cloudflare-warp/config.yml"
         );
+    }
+
+    #[test]
+    fn find_or_create_writes_minimal_config() {
+        let root = temp_dir("discovery");
+        let request = DiscoveryRequest {
+            explicit_config: None,
+            defaults: DiscoveryDefaults {
+                config_filenames: vec!["config.yml".to_owned()],
+                search_directories: vec![root.join("home/.cloudflared")],
+                primary_config_path: root.join("usr/local/etc/cloudflared/config.yml"),
+                primary_log_directory: root.join("var/log/cloudflared"),
+            },
+        };
+
+        let outcome = request
+            .find_or_create_config_path()
+            .expect("auto-create should succeed");
+
+        assert_eq!(outcome.action, DiscoveryAction::CreateDefaultConfig);
+        assert!(outcome.path.exists());
+        assert_eq!(
+            fs::read_to_string(&outcome.path).expect("config should be written"),
+            format!("logDirectory: {}\n", root.join("var/log/cloudflared").display())
+        );
+
+        fs::remove_dir_all(root).expect("temp directory should be removable");
     }
 }

--- a/crates/cloudflared-config/src/error.rs
+++ b/crates/cloudflared-config/src/error.rs
@@ -1,11 +1,12 @@
-#![forbid(unsafe_code)]
-
 use std::path::PathBuf;
 
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
+    #[error("no config file could be resolved")]
+    NoConfigFile,
+
     #[error("failed to read {path}")]
     Io {
         path: PathBuf,
@@ -44,9 +45,47 @@ pub enum ConfigError {
         #[source]
         source: uuid::Error,
     },
+
+    #[error("failed to create directory {path}")]
+    CreateDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to create file {path}")]
+    CreateFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to write file {path}")]
+    WriteFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("the last ingress rule must match all URLs")]
+    IngressLastRuleNotCatchAll,
+
+    #[error("hostname wildcard must appear only at the start")]
+    IngressBadWildcard,
+
+    #[error("hostname cannot contain a port")]
+    IngressHostnameContainsPort,
+
+    #[error("rule #{index} is a catch-all before the final rule")]
+    IngressCatchAllNotLast { index: usize, hostname: String },
+
+    #[error("invalid ingress service {value}: {reason}")]
+    InvalidIngressService { value: String, reason: String },
+
     #[error("{message}")]
     InvariantViolation { message: String },
-    #[error("{operation} is deferred beyond phase 1B.1")]
+
+    #[error("{operation} is deferred beyond phase 1B.2")]
     Deferred { operation: &'static str },
 }
 
@@ -91,6 +130,34 @@ impl ConfigError {
         }
     }
 
+    pub fn create_directory(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        Self::CreateDirectory {
+            path: path.into(),
+            source,
+        }
+    }
+
+    pub fn create_file(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        Self::CreateFile {
+            path: path.into(),
+            source,
+        }
+    }
+
+    pub fn write_file(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        Self::WriteFile {
+            path: path.into(),
+            source,
+        }
+    }
+
+    pub fn invalid_ingress_service(value: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::InvalidIngressService {
+            value: value.into(),
+            reason: reason.into(),
+        }
+    }
+
     pub fn invariant(message: impl Into<String>) -> Self {
         Self::InvariantViolation {
             message: message.into(),
@@ -99,5 +166,27 @@ impl ConfigError {
 
     pub fn deferred(operation: &'static str) -> Self {
         Self::Deferred { operation }
+    }
+
+    pub fn category(&self) -> &'static str {
+        match self {
+            Self::NoConfigFile => "no-config-file",
+            Self::Io { .. } => "io",
+            Self::Yaml { .. } => "yaml-parse",
+            Self::JsonParse { .. } => "json-parse",
+            Self::JsonSerialize { .. } => "json-serialize",
+            Self::InvalidUrl { .. } => "invalid-url",
+            Self::InvalidUuid { .. } => "invalid-uuid",
+            Self::CreateDirectory { .. } => "create-directory",
+            Self::CreateFile { .. } => "create-file",
+            Self::WriteFile { .. } => "write-file",
+            Self::IngressLastRuleNotCatchAll => "ingress-last-rule-not-catch-all",
+            Self::IngressBadWildcard => "ingress-bad-wildcard",
+            Self::IngressHostnameContainsPort => "ingress-hostname-contains-port",
+            Self::IngressCatchAllNotLast { .. } => "ingress-catch-all-not-last",
+            Self::InvalidIngressService { .. } => "invalid-ingress-service",
+            Self::InvariantViolation { .. } => "invariant-violation",
+            Self::Deferred { .. } => "deferred",
+        }
     }
 }

--- a/crates/cloudflared-config/src/ingress.rs
+++ b/crates/cloudflared-config/src/ingress.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -92,12 +90,15 @@ pub enum IngressService {
     Uri(Url),
     UnixSocket(PathBuf),
     UnixSocketTls(PathBuf),
+    HttpStatus(u16),
+    HelloWorld,
     NamedToken(String),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct IngressMatch {
     pub hostname: Option<String>,
+    pub punycode_hostname: Option<String>,
     pub path: Option<String>,
 }
 
@@ -118,8 +119,39 @@ impl IngressService {
             return Ok(Self::UnixSocket(PathBuf::from(path)));
         }
 
+        if let Some(code) = value.strip_prefix("http_status:") {
+            let parsed = code
+                .parse::<u16>()
+                .map_err(|_| ConfigError::invalid_ingress_service(value, "status code must be an integer"))?;
+            if !(100..=999).contains(&parsed) {
+                return Err(ConfigError::invalid_ingress_service(
+                    value,
+                    "status code must be between 100 and 999",
+                ));
+            }
+            return Ok(Self::HttpStatus(parsed));
+        }
+
+        if value == "hello_world" {
+            return Ok(Self::HelloWorld);
+        }
+
         match Url::parse(value) {
-            Ok(url) => Ok(Self::Uri(url)),
+            Ok(url) => {
+                if url.scheme().is_empty() || url.host_str().is_none() {
+                    return Err(ConfigError::invalid_ingress_service(
+                        value,
+                        "address must include a scheme and hostname",
+                    ));
+                }
+                if !url.path().is_empty() && url.path() != "/" {
+                    return Err(ConfigError::invalid_ingress_service(
+                        value,
+                        "origin service addresses must not include a path",
+                    ));
+                }
+                Ok(Self::Uri(url))
+            }
             Err(url::ParseError::RelativeUrlWithoutBase) => Ok(Self::NamedToken(value.to_owned())),
             Err(source) => Err(ConfigError::invalid_url(field, value, source)),
         }
@@ -127,15 +159,24 @@ impl IngressService {
 }
 
 impl IngressRule {
-    pub fn from_raw(raw: RawIngressRule) -> Result<Self> {
+    pub fn from_raw(raw: RawIngressRule, rule_index: usize, total_rules: usize) -> Result<Self> {
         let service = match raw.service {
             Some(service) => IngressService::parse("service", &service)?,
             None => return Err(ConfigError::invariant("ingress rule is missing service")),
         };
 
+        validate_hostname(
+            raw.hostname.as_deref(),
+            raw.path.as_deref(),
+            rule_index,
+            total_rules,
+        )?;
+        let punycode_hostname = normalized_punycode_hostname(raw.hostname.as_deref())?;
+
         Ok(Self {
             matcher: IngressMatch {
                 hostname: raw.hostname,
+                punycode_hostname,
                 path: raw.path,
             },
             service,
@@ -148,9 +189,69 @@ impl IngressRule {
     }
 }
 
+pub fn default_no_ingress_rule() -> IngressRule {
+    IngressRule {
+        matcher: IngressMatch::default(),
+        service: IngressService::HttpStatus(503),
+        origin_request: OriginRequestConfig::default(),
+    }
+}
+
+fn validate_hostname(
+    hostname: Option<&str>,
+    path: Option<&str>,
+    rule_index: usize,
+    total_rules: usize,
+) -> Result<()> {
+    let hostname = hostname.unwrap_or_default();
+    let path = path.unwrap_or_default();
+
+    if hostname.contains(':') {
+        return Err(ConfigError::IngressHostnameContainsPort);
+    }
+    if hostname.rfind('*').is_some_and(|index| index > 0) {
+        return Err(ConfigError::IngressBadWildcard);
+    }
+
+    let is_catch_all = (hostname.is_empty() || hostname == "*") && path.is_empty();
+    let is_last_rule = rule_index + 1 == total_rules;
+    if is_last_rule && !is_catch_all {
+        return Err(ConfigError::IngressLastRuleNotCatchAll);
+    }
+    if !is_last_rule && is_catch_all {
+        return Err(ConfigError::IngressCatchAllNotLast {
+            index: rule_index + 1,
+            hostname: hostname.to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+fn normalized_punycode_hostname(hostname: Option<&str>) -> Result<Option<String>> {
+    let Some(hostname) = hostname else {
+        return Ok(None);
+    };
+    if hostname.is_empty() || hostname == "*" || hostname.contains('*') {
+        return Ok(None);
+    }
+
+    let url = Url::parse(&format!("https://{hostname}"))
+        .map_err(|source| ConfigError::invalid_url("hostname", hostname, source))?;
+    let Some(punycode) = url.host_str() else {
+        return Ok(None);
+    };
+    if punycode == hostname {
+        Ok(None)
+    } else {
+        Ok(Some(punycode.to_owned()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{IngressRule, IngressService, RawIngressRule};
+    use super::{IngressRule, IngressService, RawIngressRule, default_no_ingress_rule};
+    use crate::error::ConfigError;
 
     fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
         match result {
@@ -171,11 +272,54 @@ mod tests {
 
     #[test]
     fn raw_rule_without_hostname_or_path_is_catch_all() {
-        let rule = ok(IngressRule::from_raw(RawIngressRule {
-            service: Some("https://localhost:8080".to_owned()),
-            ..RawIngressRule::default()
-        }));
+        let rule = ok(IngressRule::from_raw(
+            RawIngressRule {
+                service: Some("https://localhost:8080".to_owned()),
+                ..RawIngressRule::default()
+            },
+            0,
+            1,
+        ));
 
         assert!(rule.is_catch_all());
+    }
+
+    #[test]
+    fn wildcard_not_at_start_is_rejected() {
+        let error = IngressRule::from_raw(
+            RawIngressRule {
+                hostname: Some("test.*.example.com".to_owned()),
+                service: Some("https://localhost:8080".to_owned()),
+                ..RawIngressRule::default()
+            },
+            0,
+            1,
+        )
+        .expect_err("wildcard should be rejected");
+
+        assert!(matches!(error, ConfigError::IngressBadWildcard));
+    }
+
+    #[test]
+    fn no_ingress_default_rule_is_http_503() {
+        assert_eq!(default_no_ingress_rule().service, IngressService::HttpStatus(503));
+    }
+
+    #[test]
+    fn unicode_hostname_captures_punycode() {
+        let rule = ok(IngressRule::from_raw(
+            RawIngressRule {
+                hostname: Some("môô.cloudflare.com".to_owned()),
+                service: Some("https://localhost:8080".to_owned()),
+                ..RawIngressRule::default()
+            },
+            0,
+            2,
+        ));
+
+        assert_eq!(
+            rule.matcher.punycode_hostname.as_deref(),
+            Some("xn--m-xgaa.cloudflare.com")
+        );
     }
 }

--- a/crates/cloudflared-config/src/lib.rs
+++ b/crates/cloudflared-config/src/lib.rs
@@ -14,6 +14,9 @@
 //! Externally visible first-slice behavior is still incomplete. This crate is a
 //! synchronous domain skeleton, not a parity-complete implementation.
 
+use std::path::Path;
+
+pub mod artifact;
 pub mod credentials;
 pub mod discovery;
 pub mod error;
@@ -25,8 +28,9 @@ pub use crate::credentials::{
     CredentialSurface, OriginCertLocator, OriginCertToken, TunnelCredentialsFile, TunnelReference,
 };
 pub use crate::discovery::{
-    ConfigSource, DiscoveryCandidate, DiscoveryDefaults, DiscoveryOrigin, DiscoveryPlan, DiscoveryRequest,
-    default_nix_log_directory, default_nix_primary_config_path, default_nix_search_directories,
+    ConfigSource, DiscoveryAction, DiscoveryCandidate, DiscoveryDefaults, DiscoveryOrigin, DiscoveryOutcome,
+    DiscoveryPlan, DiscoveryRequest, default_nix_log_directory, default_nix_primary_config_path,
+    default_nix_search_directories,
 };
 pub use crate::error::{ConfigError, Result};
 pub use crate::ingress::{
@@ -40,6 +44,19 @@ pub fn parse_raw_config(source_name: &str, contents: &str) -> Result<RawConfig> 
     RawConfig::from_yaml_str(source_name, contents)
 }
 
+pub fn load_raw_config(path: &Path) -> Result<RawConfig> {
+    RawConfig::from_yaml_path(path)
+}
+
 pub fn normalize_config(source: ConfigSource, raw: RawConfig) -> Result<NormalizedConfig> {
     NormalizedConfig::from_raw(source, raw)
+}
+
+pub fn load_normalized_config(path: &Path, source: ConfigSource) -> Result<NormalizedConfig> {
+    let raw = load_raw_config(path)?;
+    normalize_config(source, raw)
+}
+
+pub fn discover_config(request: &DiscoveryRequest) -> Result<DiscoveryOutcome> {
+    request.find_or_create_config_path()
 }

--- a/crates/cloudflared-config/src/normalized.rs
+++ b/crates/cloudflared-config/src/normalized.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -7,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::credentials::{CredentialSurface, TunnelReference};
 use crate::discovery::ConfigSource;
 use crate::error::Result;
-use crate::ingress::IngressRule;
+use crate::ingress::{IngressRule, default_no_ingress_rule};
 use crate::raw_config::{RawConfig, WarpRoutingConfig};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -37,11 +35,16 @@ impl NormalizedConfig {
         };
         let tunnel = raw.tunnel.map(TunnelReference::from_raw);
 
-        let ingress = raw
-            .ingress
-            .into_iter()
-            .map(IngressRule::from_raw)
-            .collect::<Result<Vec<_>>>()?;
+        let ingress = if raw.ingress.is_empty() {
+            vec![default_no_ingress_rule()]
+        } else {
+            let total_rules = raw.ingress.len();
+            raw.ingress
+                .into_iter()
+                .enumerate()
+                .map(|(rule_index, rule)| IngressRule::from_raw(rule, rule_index, total_rules))
+                .collect::<Result<Vec<_>>>()?
+        };
 
         Ok(Self {
             source,
@@ -60,6 +63,7 @@ impl NormalizedConfig {
 mod tests {
     use crate::credentials::TunnelReference;
     use crate::discovery::ConfigSource;
+    use crate::ingress::IngressService;
     use crate::normalized::{NormalizationWarning, NormalizedConfig};
     use crate::raw_config::RawConfig;
 
@@ -93,6 +97,29 @@ mod tests {
                 raw: "config-file-test".to_owned(),
                 uuid: None,
             })
+        );
+    }
+
+    #[test]
+    fn normalization_creates_default_503_ingress_when_missing() {
+        let raw = ok(RawConfig::from_yaml_str(
+            "fixture.yaml",
+            "tunnel: config-file-test\noriginRequest:\n  connectTimeout: 30s\n",
+        ));
+        let normalized = ok(NormalizedConfig::from_raw(
+            ConfigSource::DiscoveredPath("/tmp/config.yml".into()),
+            raw,
+        ));
+
+        assert_eq!(normalized.ingress.len(), 1);
+        assert_eq!(normalized.ingress[0].service, IngressService::HttpStatus(503));
+        assert_eq!(
+            normalized
+                .origin_request
+                .connect_timeout
+                .as_ref()
+                .map(|value| value.0.as_str()),
+            Some("30s")
         );
     }
 }

--- a/crates/cloudflared-config/src/raw_config.rs
+++ b/crates/cloudflared-config/src/raw_config.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/cloudflared-config/tests/README.md
+++ b/crates/cloudflared-config/tests/README.md
@@ -13,8 +13,9 @@ subsystems start.
 Current state:
 
 - Phase 1A fixture taxonomy and harness scaffolding exist
+- Phase 1B.2 can now emit Rust actual artifacts for config discovery/loading fixtures
 - Go truth capture is not checked in yet
-- no subsystem behavior is implemented yet
+- config discovery and config loading behavior is only partially implemented
 - Rust-versus-Go parity is not complete yet
 
 Phase 1A outputs in this directory:
@@ -23,12 +24,15 @@ Phase 1A outputs in this directory:
 - a checked-in golden artifact contract for future Go truth and Rust actuals
 - Rust-side helper scaffolding and ignored parity test entrypoints
 - an external runner entrypoint at `tools/first_slice_parity.py`
+- a Rust actual emission path for targeted Phase 1B.2 fixture categories
 
 Current execution model:
 
 - `python3 tools/first_slice_parity.py inventory` shows the accepted fixture set
 - `python3 tools/first_slice_parity.py check-go-truth` fails until Go truth JSON
  is captured under `tests/fixtures/first-slice/golden/go-truth/`
+- `python3 tools/first_slice_parity.py emit-rust-actual` writes readable JSON
+ artifacts for the Phase 1B.2 config discovery/loading fixtures
 - `cargo test -p cloudflared-config` validates the fixture inventory and keeps
  ignored parity tests visible without claiming passing parity
 

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
@@ -1,10 +1,17 @@
 # Rust Actual Outputs
 
-This directory is intentionally empty in Phase 1A.
+This directory is reserved for canonical JSON emitted by the Rust-side first
+slice harness path.
 
-Phase 1B work in `crates/cloudflared-config/` will eventually emit canonical
-JSON reports here, either as checked-in review artifacts or temporary compare
-outputs depending on the owning test flow.
+Current state in Phase 1B.2:
 
-Phase 1A reserves the path and format only. It does not claim any Rust-side
-parity output exists yet.
+- config discovery and config loading fixtures can now emit Rust actual reports
+- the files are generated via `python3 tools/first_slice_parity.py emit-rust-actual`
+- the output remains incomplete for first-slice categories that are still out of
+ scope for this phase
+
+The directory should remain reviewable and stable:
+
+- one JSON file per emitted fixture id
+- envelope shape must follow `golden/schema/README.md`
+- no file here should imply Go parity unless the corresponding Go truth exists

--- a/crates/cloudflared-config/tests/parity_harness_inventory.rs
+++ b/crates/cloudflared-config/tests/parity_harness_inventory.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 #![allow(unused_crate_dependencies)]
 
 use cloudflared_config as _;

--- a/crates/cloudflared-config/tests/phase_1a_parity_scaffold.rs
+++ b/crates/cloudflared-config/tests/phase_1a_parity_scaffold.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 #![allow(unused_crate_dependencies)]
 
 use cloudflared_config as _;

--- a/crates/cloudflared-config/tests/phase_1b2_config_loading.rs
+++ b/crates/cloudflared-config/tests/phase_1b2_config_loading.rs
@@ -1,0 +1,120 @@
+#![allow(unused_crate_dependencies)]
+
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use cloudflared_config::{
+    ConfigError, ConfigSource, DiscoveryDefaults, DiscoveryRequest, IngressService, discover_config,
+    load_normalized_config,
+};
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn temp_dir(name: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("cloudflared-config-{name}-{unique}"));
+    fs::create_dir_all(&path).expect("temp directory should be created");
+    path
+}
+
+#[test]
+fn discovery_prefers_first_existing_candidate() {
+    let root = temp_dir("fixture-discovery");
+    let first = root.join("home/.cloudflared/config.yml");
+    let second = root.join("home/.cloudflare-warp/config.yaml");
+    fs::create_dir_all(first.parent().expect("first parent should exist"))
+        .expect("first parent should be created");
+    fs::create_dir_all(second.parent().expect("second parent should exist"))
+        .expect("second parent should be created");
+    fs::write(&first, "logDirectory: /var/log/cloudflared\n").expect("first config should be written");
+    fs::write(&second, "logDirectory: /var/log/cloudflared\n").expect("second config should be written");
+
+    let request = DiscoveryRequest {
+        explicit_config: None,
+        defaults: DiscoveryDefaults {
+            config_filenames: vec!["config.yml".to_owned(), "config.yaml".to_owned()],
+            search_directories: vec![root.join("home/.cloudflared"), root.join("home/.cloudflare-warp")],
+            primary_config_path: root.join("usr/local/etc/cloudflared/config.yml"),
+            primary_log_directory: root.join("var/log/cloudflared"),
+        },
+    };
+
+    let outcome = discover_config(&request).expect("discovery should succeed");
+    assert_eq!(outcome.path, first);
+
+    fs::remove_dir_all(root).expect("temp directory should be removable");
+}
+
+#[test]
+fn yaml_loading_normalizes_unicode_fixture() {
+    let fixture = support::fixtures_root().join("yaml-config/valid/unicode_ingress.yaml");
+    let normalized = load_normalized_config(
+        &fixture,
+        ConfigSource::DiscoveredPath("yaml-config/valid/unicode_ingress.yaml".into()),
+    )
+    .expect("fixture should normalize");
+
+    assert_eq!(normalized.ingress.len(), 2);
+    assert_eq!(
+        normalized.ingress[0].matcher.hostname.as_deref(),
+        Some("môô.cloudflare.com")
+    );
+    assert_eq!(
+        normalized.ingress[0].matcher.punycode_hostname.as_deref(),
+        Some("xn--m-xgaa.cloudflare.com")
+    );
+}
+
+#[test]
+fn invalid_yaml_fixture_maps_to_error_category() {
+    let fixture = support::fixtures_root().join("invalid-input/ingress/missing_catch_all.yaml");
+    let error = load_normalized_config(
+        &fixture,
+        ConfigSource::DiscoveredPath("invalid-input/ingress/missing_catch_all.yaml".into()),
+    )
+    .expect_err("fixture should fail validation");
+
+    assert!(matches!(error, ConfigError::IngressLastRuleNotCatchAll));
+    assert_eq!(error.category(), "ingress-last-rule-not-catch-all");
+}
+
+#[test]
+fn no_ingress_fixture_emits_default_503_contract() {
+    let fixture = support::fixtures_root().join("yaml-config/edge/no_ingress_minimal.yaml");
+    let normalized = load_normalized_config(
+        &fixture,
+        ConfigSource::DiscoveredPath("yaml-config/edge/no_ingress_minimal.yaml".into()),
+    )
+    .expect("fixture should normalize");
+
+    assert_eq!(normalized.ingress.len(), 1);
+    assert_eq!(normalized.ingress[0].service, IngressService::HttpStatus(503));
+}
+
+#[test]
+fn harness_can_emit_targeted_rust_actual_artifact() {
+    let output_dir = temp_dir("rust-actual");
+    let output = Command::new("python3")
+        .arg(support::tool_path())
+        .arg("emit-rust-actual")
+        .arg("--output-dir")
+        .arg(&output_dir)
+        .arg("--fixture-id")
+        .arg("config-basic-named-tunnel")
+        .output()
+        .expect("python3 should be available to run the first-slice parity harness");
+
+    assert!(
+        output.status.success(),
+        "expected rust actual emission to succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output_dir.join("config-basic-named-tunnel.json").exists());
+
+    fs::remove_dir_all(output_dir).expect("temp directory should be removable");
+}

--- a/crates/cloudflared-config/tests/support/mod.rs
+++ b/crates/cloudflared-config/tests/support/mod.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 use std::fs;
 use std::path::PathBuf;
 

--- a/tools/first_slice_parity.py
+++ b/tools/first_slice_parity.py
@@ -17,6 +17,12 @@ FIXTURE_ROOT = (
 INDEX_PATH = FIXTURE_ROOT / "fixture-index.toml"
 GO_TRUTH_DIR = FIXTURE_ROOT / "golden" / "go-truth"
 RUST_ACTUAL_DIR = FIXTURE_ROOT / "golden" / "rust-actual"
+SUPPORTED_RUST_ACTUAL_CATEGORIES = {
+    "config-discovery",
+    "yaml-config",
+    "invalid-input",
+    "ordering-defaulting",
+}
 
 
 @dataclass(frozen=True)
@@ -87,6 +93,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Limit comparison to one or more fixture IDs.",
     )
     compare.set_defaults(func=cmd_compare)
+
+    emit_rust_actual = subparsers.add_parser(
+        "emit-rust-actual",
+        help="Generate Rust-side actual artifacts for the targeted Phase 1B.2 fixtures.",
+    )
+    emit_rust_actual.add_argument(
+        "--fixture-id",
+        action="append",
+        default=[],
+        help="Limit emission to one or more fixture IDs.",
+    )
+    emit_rust_actual.add_argument(
+        "--output-dir",
+        default=str(RUST_ACTUAL_DIR),
+        help="Directory where Rust actual JSON files should be written.",
+    )
+    emit_rust_actual.set_defaults(func=cmd_emit_rust_actual)
 
     return parser
 
@@ -208,6 +231,72 @@ def cmd_compare(args: argparse.Namespace, fixtures: list[Fixture]) -> int:
     return 0
 
 
+def cmd_emit_rust_actual(args: argparse.Namespace, fixtures: list[Fixture]) -> int:
+    selected = select_fixtures(fixtures, args.fixture_id)
+    targeted = [
+        fixture
+        for fixture in selected
+        if fixture.category in SUPPORTED_RUST_ACTUAL_CATEGORIES
+    ]
+    skipped = [
+        fixture
+        for fixture in selected
+        if fixture.category not in SUPPORTED_RUST_ACTUAL_CATEGORIES
+    ]
+
+    if not targeted:
+        print("no Phase 1B.2-targeted fixtures were selected", file=sys.stderr)
+        return 1
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    plan = {
+        "fixture_root": str(FIXTURE_ROOT),
+        "output_dir": str(output_dir),
+        "fixtures": [build_emission_fixture(fixture) for fixture in targeted],
+    }
+
+    import subprocess
+
+    completed = subprocess.run(
+        [
+            "cargo",
+            "run",
+            "-q",
+            "-p",
+            "cloudflared-config",
+            "--example",
+            "first_slice_emit",
+        ],
+        cwd=REPO_ROOT,
+        input=json.dumps(plan),
+        text=True,
+        capture_output=True,
+    )
+
+    if skipped:
+        for fixture in skipped:
+            print(
+                f"skipping unsupported Phase 1B.2 category for {fixture.fixture_id}: {fixture.category}",
+                file=sys.stderr,
+            )
+
+    if completed.returncode != 0:
+        if completed.stderr:
+            print(completed.stderr, file=sys.stderr, end="")
+        if completed.stdout:
+            print(completed.stdout, file=sys.stderr, end="")
+        return completed.returncode
+
+    print(
+        f"emitted {len(targeted)} Rust actual artifacts into {display_repo_relative(output_dir)}"
+    )
+    for fixture in targeted:
+        print(f"- {fixture.fixture_id}")
+    return 0
+
+
 def select_fixtures(fixtures: list[Fixture], fixture_ids: list[str]) -> list[Fixture]:
     if not fixture_ids:
         return fixtures
@@ -228,6 +317,41 @@ def comparison_status(fixture: Fixture) -> str:
     if not go_truth_exists:
         return "blocked-missing-go-truth"
     return "waiting-for-rust-actual"
+
+
+def build_emission_fixture(fixture: Fixture) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "fixture_id": fixture.fixture_id,
+        "category": fixture.category,
+        "comparison": fixture.comparison,
+        "input": fixture.input_path.relative_to(FIXTURE_ROOT).as_posix(),
+        "source_refs": list(fixture.go_truth),
+    }
+    if fixture.category == "config-discovery":
+        payload["discovery_case"] = load_discovery_case(fixture.fixture_id)
+    return payload
+
+
+def load_discovery_case(fixture_id: str) -> dict[str, object]:
+    cases_path = FIXTURE_ROOT / "config-discovery" / "cases.toml"
+    with cases_path.open("rb") as handle:
+        raw = tomllib.load(handle)
+
+    for case in raw.get("case", []):
+        if case.get("id") == fixture_id:
+            return {
+                "explicit_config": bool(case.get("explicit_config", False)),
+                "present": list(case.get("present", [])),
+            }
+
+    raise SystemExit(f"missing config discovery case for fixture {fixture_id}")
+
+
+def display_repo_relative(path: Path) -> str:
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this PR does

This PR makes the config-loading path real for the current first-slice fixtures.

It adds actual config discovery, YAML loading, raw-to-normalized conversion, and Rust actual artifact emission for the targeted fixture set.

## Included in this PR

- real config discovery behavior
- YAML file loading into `RawConfig`
- raw-to-normalized conversion for the current config-loading path
- Rust actual artifact emission for targeted fixture categories
- narrow tests and small status/doc updates

## Scope

This stays within the accepted first slice, focused on the config-loading path.

## Not included

This PR does not cover:
- transport or proxying
- supervisor/runtime work
- metrics or management APIs
- full credentials behavior
- full ingress parity
- CLI-origin parity
- Go-vs-Rust parity completion

## Why now

Phase 1A #1 set up the harness and fixture structure.
Phase 1B.1 #2 gave `cloudflared-config` a real home.

This PR is the next step: making the config-loading path executable for the current fixtures without widening into broader runtime work.

## Current status after this PR

What exists after this:
- Phase 1A harness groundwork
- Phase 1B.1 config crate skeleton
- real config discovery/loading behavior for targeted fixtures
- Rust actual artifact emission for targeted config cases

What still comes next:
- broader credentials handling
- broader ingress behavior
- captured Go truth
- real parity comparison