### PR TITLE
rust-rewrite: add phase 1b.3 origin cert path

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,17 +2,17 @@
 
 ## Classification
 
-This repository is currently a rewrite planning and scaffolding repository with
-a frozen Go reference implementation.
+This repository is currently a rewrite workspace with a frozen Go reference
+implementation and an intentionally narrow Rust first slice.
 
-It is not yet a Rust implementation workspace in the substantive sense. The
-repository now contains a Cargo workspace skeleton plus a first-slice domain
-skeleton in `crates/cloudflared-config/`, but no subsystem behavior has been
-ported yet.
+It is not yet a parity-complete Rust implementation workspace. The repository
+now contains a Cargo workspace skeleton plus early first-slice behavior in
+`crates/cloudflared-config/` for config discovery/loading and credentials
+origin-cert decoding, but most subsystem behavior is still unported.
 
 The scaffold is intentionally real but minimal:
 
-- the workspace builds as a Rust scaffold
+- the workspace builds as a Rust scaffold with partial first-slice behavior
 - the runnable binary exists
 - policy and governance documents define the rewrite boundary
 - manifests should reflect only code that exists today, not speculative future
@@ -137,8 +137,8 @@ What exists now:
 What does not exist yet:
 
 - captured Go truth outputs
-- Rust-emitted parity reports
-- implemented config, credential, or ingress behavior
+- passing Rust-versus-Go parity reports
+- complete config, credential, or ingress behavior
 - passing first-slice parity comparisons
 
 Implication:
@@ -196,6 +196,34 @@ Implication:
 - the accepted first slice now has a real config-loading path in Rust
 - the repository still must not claim first-slice parity is complete
 
+## Phase 1B.3 Credentials And Origin-Cert Path
+
+Phase 1B.3 behavior now exists for the targeted credentials/origin-cert
+fixtures.
+
+What exists now:
+
+- source-backed PEM scanning for origin certificates
+- tolerance for legacy `PRIVATE KEY` and `CERTIFICATE` blocks during scanning
+- rejection for unknown PEM block types and multiple token blocks
+- origin-cert JSON token extraction with endpoint lowercasing
+- account-id refresh validation through the `OriginCertUser` read path
+- Rust actual artifact emission for the targeted `credentials-origin-cert`
+  fixtures
+
+What does not exist yet:
+
+- Go truth outputs for comparison
+- default origin-cert search-path resolution behavior
+- tunnel credential file artifact fixtures
+- full ingress normalization artifact coverage
+- full first-slice parity comparisons
+
+Implication:
+
+- the accepted first slice now has a real credentials/origin-cert path in Rust
+- the repository still must not claim first-slice parity is complete
+
 ## First Implementation Gate
 
 No large-scale subsystem implementation should begin until all of the following
@@ -235,9 +263,10 @@ Scope boundary for the first slice:
 
 Current scaffold implication:
 
-- no subsystem implementation code is present yet
-- the crate layout already reserves the correct boundaries for this first slice
-- manifests should stay sparse until this slice starts landing
+- narrow first-slice implementation code is now present
+- the crate layout still reserves the correct boundaries for the remainder of
+  this first slice
+- manifests should stay sparse while the remaining slice behavior lands
 
 ## Done Means
 

--- a/crates/cloudflared-config/examples/first_slice_emit.rs
+++ b/crates/cloudflared-config/examples/first_slice_emit.rs
@@ -6,11 +6,12 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cloudflared_config::artifact::{
-    DiscoveryCase, DiscoveryReportPayload, EmissionPlan, FixtureSpec, discovery_envelope, error_envelope,
-    normalized_config_envelope,
+    DiscoveryCase, DiscoveryReportPayload, EmissionPlan, FixtureSpec, credential_envelope,
+    discovery_envelope, error_envelope, normalized_config_envelope,
 };
 use cloudflared_config::{
-    ConfigSource, DiscoveryDefaults, DiscoveryRequest, discover_config, load_normalized_config,
+    ConfigSource, DiscoveryDefaults, DiscoveryRequest, OriginCertToken, discover_config,
+    load_normalized_config,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,7 +24,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "yaml-config" | "ordering-defaulting" | "invalid-input" => {
                 emit_config_fixture(&plan.fixture_root, fixture)?
             }
-            other => return Err(format!("unsupported fixture category for Phase 1B.2: {other}").into()),
+            "credentials-origin-cert" => emit_origin_cert_fixture(&plan, fixture)?,
+            other => {
+                return Err(format!("unsupported fixture category for current first slice: {other}").into());
+            }
         };
 
         let output_path = plan.output_dir.join(format!("{}.json", fixture.fixture_id));
@@ -72,6 +76,25 @@ fn emit_config_fixture(
             Path::new(&fixture.input),
             &normalized,
         )?),
+        Err(error) => Ok(error_envelope(fixture, &error)?),
+    }
+}
+
+fn emit_origin_cert_fixture(
+    plan: &EmissionPlan,
+    fixture: &FixtureSpec,
+) -> Result<cloudflared_config::artifact::ArtifactEnvelope, Box<dyn std::error::Error>> {
+    let Some(source_path) = fixture.origin_cert_source.as_ref() else {
+        return Err(format!(
+            "fixture {} is missing origin cert source data",
+            fixture.fixture_id
+        )
+        .into());
+    };
+
+    let input_path = plan.repo_root.join(source_path);
+    match OriginCertToken::from_pem_path(&input_path) {
+        Ok(token) => Ok(credential_envelope(fixture, source_path, &token)?),
         Err(error) => Ok(error_envelope(fixture, &error)?),
     }
 }

--- a/crates/cloudflared-config/src/artifact.rs
+++ b/crates/cloudflared-config/src/artifact.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::credentials::{CredentialSurface, OriginCertLocator, TunnelReference};
+use crate::credentials::{CredentialSurface, OriginCertLocator, OriginCertToken, TunnelReference};
 use crate::discovery::{ConfigSource, DiscoveryAction, DiscoveryOutcome};
 use crate::error::ConfigError;
 use crate::ingress::{IngressRule, IngressService, OriginRequestConfig};
@@ -14,6 +14,7 @@ pub const SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct EmissionPlan {
+    pub repo_root: PathBuf,
     pub fixture_root: PathBuf,
     pub output_dir: PathBuf,
     pub fixtures: Vec<FixtureSpec>,
@@ -28,6 +29,8 @@ pub struct FixtureSpec {
     pub source_refs: Vec<String>,
     #[serde(default)]
     pub discovery_case: Option<DiscoveryCase>,
+    #[serde(default)]
+    pub origin_cert_source: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -60,6 +63,17 @@ pub struct DiscoveryReportPayload {
 pub struct ErrorReportPayload {
     pub category: &'static str,
     pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CredentialReportPayload {
+    pub kind: &'static str,
+    pub source_path: String,
+    pub zone_id: String,
+    pub account_id: String,
+    pub api_token: String,
+    pub endpoint: Option<String>,
+    pub is_fed_endpoint: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -168,6 +182,22 @@ pub fn error_envelope(
             category: error.category(),
             message: error.to_string(),
         })?,
+    })
+}
+
+pub fn credential_envelope(
+    fixture: &FixtureSpec,
+    source_path: &str,
+    token: &OriginCertToken,
+) -> Result<ArtifactEnvelope, serde_json::Error> {
+    Ok(ArtifactEnvelope {
+        schema_version: SCHEMA_VERSION,
+        fixture_id: fixture.fixture_id.clone(),
+        producer: "rust-actual",
+        report_kind: "credential-report.v1",
+        comparison: fixture.comparison.clone(),
+        source_refs: fixture.source_refs.clone(),
+        payload: serde_json::to_value(CredentialReportPayload::from_origin_cert(source_path, token))?,
     })
 }
 
@@ -339,6 +369,20 @@ impl WarningPayload {
                 kind: "unknown-top-level-keys",
                 keys: keys.clone(),
             },
+        }
+    }
+}
+
+impl CredentialReportPayload {
+    fn from_origin_cert(source_path: &str, token: &OriginCertToken) -> Self {
+        Self {
+            kind: "origin-cert-pem",
+            source_path: source_path.to_owned(),
+            zone_id: token.zone_id.clone(),
+            account_id: token.account_id.clone(),
+            api_token: token.api_token.clone(),
+            endpoint: token.endpoint.clone(),
+            is_fed_endpoint: token.is_fed_endpoint(),
         }
     }
 }

--- a/crates/cloudflared-config/src/credentials.rs
+++ b/crates/cloudflared-config/src/credentials.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use crate::error::{ConfigError, Result};
 
 pub const DEFAULT_ORIGIN_CERT_FILE: &str = "cert.pem";
+pub const FED_ENDPOINT: &str = "fed";
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TunnelReference {
@@ -88,6 +89,12 @@ pub struct OriginCertToken {
     pub endpoint: Option<String>,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OriginCertUser {
+    pub cert: OriginCertToken,
+    pub cert_path: PathBuf,
+}
+
 impl OriginCertToken {
     pub fn from_json_str(contents: &str) -> Result<Self> {
         let mut token: Self = serde_json::from_str(contents)
@@ -101,14 +108,200 @@ impl OriginCertToken {
         Self::from_json_str(&contents)
     }
 
-    pub fn from_pem_blocks(_blocks: &[u8]) -> Result<Self> {
-        Err(ConfigError::deferred("origin cert PEM decoding"))
+    pub fn from_pem_blocks(blocks: &[u8]) -> Result<Self> {
+        if blocks.is_empty() {
+            return Err(ConfigError::OriginCertEmpty);
+        }
+
+        let mut token = None;
+        for block in parse_pem_blocks(blocks) {
+            match block.block_type.as_str() {
+                "PRIVATE KEY" | "CERTIFICATE" => {}
+                "ARGO TUNNEL TOKEN" => {
+                    if token.as_ref().is_some_and(|current: &OriginCertToken| {
+                        !current.zone_id.is_empty() || !current.api_token.is_empty()
+                    }) {
+                        return Err(ConfigError::OriginCertMultipleTokens);
+                    }
+
+                    if let Ok(decoded) = Self::from_json_bytes(&block.bytes) {
+                        token = Some(decoded);
+                    }
+                }
+                other => return Err(ConfigError::origin_cert_unknown_block(other)),
+            }
+        }
+
+        let token = token.ok_or(ConfigError::OriginCertMissingToken)?;
+        if token.zone_id.is_empty() || token.api_token.is_empty() {
+            return Err(ConfigError::OriginCertMissingToken);
+        }
+
+        Ok(token)
+    }
+
+    pub fn from_pem_path(path: &Path) -> Result<Self> {
+        let contents = fs::read(path).map_err(|source| ConfigError::read(path, source))?;
+        Self::from_pem_blocks(&contents)
+    }
+
+    pub fn encode_pem(&self) -> Result<Vec<u8>> {
+        let json = serde_json::to_vec(self)
+            .map_err(|source| ConfigError::json_serialize("origin cert token", source))?;
+
+        let mut pem = String::from("-----BEGIN ARGO TUNNEL TOKEN-----\n");
+        let encoded = encode_base64(&json);
+        for chunk in encoded.as_bytes().chunks(64) {
+            pem.push_str(std::str::from_utf8(chunk).expect("base64 output should be utf-8"));
+            pem.push('\n');
+        }
+        pem.push_str("-----END ARGO TUNNEL TOKEN-----\n");
+        Ok(pem.into_bytes())
+    }
+
+    pub fn is_fed_endpoint(&self) -> bool {
+        self.endpoint.as_deref() == Some(FED_ENDPOINT)
+    }
+
+    fn from_json_bytes(contents: &[u8]) -> Result<Self> {
+        let mut token: Self = serde_json::from_slice(contents)
+            .map_err(|source| ConfigError::json_parse("origin cert token", source))?;
+        token.endpoint = token.endpoint.map(|value| value.to_ascii_lowercase());
+        Ok(token)
+    }
+}
+
+impl OriginCertUser {
+    pub fn read(path: &Path) -> Result<Self> {
+        let cert = OriginCertToken::from_pem_path(path)?;
+        if cert.account_id.is_empty() {
+            return Err(ConfigError::origin_cert_needs_refresh(path));
+        }
+
+        Ok(Self {
+            cert,
+            cert_path: path.to_path_buf(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct PemBlock {
+    block_type: String,
+    bytes: Vec<u8>,
+}
+
+fn parse_pem_blocks(blocks: &[u8]) -> Vec<PemBlock> {
+    let mut parsed = Vec::new();
+    let text = String::from_utf8_lossy(blocks);
+    let mut remaining = text.as_ref();
+
+    while let Some(begin_offset) = remaining.find("-----BEGIN ") {
+        remaining = &remaining[begin_offset + "-----BEGIN ".len()..];
+        let Some(type_end) = remaining.find("-----") else {
+            break;
+        };
+
+        let block_type = remaining[..type_end].to_owned();
+        remaining = &remaining[type_end + "-----".len()..];
+        remaining = remaining.strip_prefix("\r\n").unwrap_or(remaining);
+        remaining = remaining.strip_prefix('\n').unwrap_or(remaining);
+
+        let end_marker = format!("-----END {block_type}-----");
+        let Some(end_offset) = remaining.find(&end_marker) else {
+            break;
+        };
+
+        let body = &remaining[..end_offset];
+        parsed.push(PemBlock {
+            block_type,
+            bytes: decode_base64(body).unwrap_or_default(),
+        });
+        remaining = &remaining[end_offset + end_marker.len()..];
+    }
+
+    parsed
+}
+
+fn decode_base64(input: &str) -> Option<Vec<u8>> {
+    let filtered: Vec<u8> = input.bytes().filter(|byte| !byte.is_ascii_whitespace()).collect();
+    if filtered.is_empty() {
+        return Some(Vec::new());
+    }
+    if !filtered.len().is_multiple_of(4) {
+        return None;
+    }
+
+    let mut output = Vec::with_capacity(filtered.len() / 4 * 3);
+    for chunk in filtered.chunks(4) {
+        let mut values = [0u8; 4];
+        let mut padding = 0usize;
+
+        for (index, byte) in chunk.iter().copied().enumerate() {
+            if byte == b'=' {
+                values[index] = 0;
+                padding += 1;
+            } else {
+                values[index] = base64_value(byte)?;
+            }
+        }
+
+        output.push((values[0] << 2) | (values[1] >> 4));
+        if padding < 2 {
+            output.push((values[1] << 4) | (values[2] >> 2));
+        }
+        if padding == 0 {
+            output.push((values[2] << 6) | values[3]);
+        }
+    }
+
+    Some(output)
+}
+
+fn encode_base64(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    let mut output = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let first = chunk[0];
+        let second = *chunk.get(1).unwrap_or(&0);
+        let third = *chunk.get(2).unwrap_or(&0);
+
+        output.push(ALPHABET[(first >> 2) as usize] as char);
+        output.push(ALPHABET[(((first & 0x03) << 4) | (second >> 4)) as usize] as char);
+
+        if chunk.len() > 1 {
+            output.push(ALPHABET[(((second & 0x0f) << 2) | (third >> 6)) as usize] as char);
+        } else {
+            output.push('=');
+        }
+
+        if chunk.len() > 2 {
+            output.push(ALPHABET[(third & 0x3f) as usize] as char);
+        } else {
+            output.push('=');
+        }
+    }
+
+    output
+}
+
+fn base64_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'A'..=b'Z' => Some(byte - b'A'),
+        b'a'..=b'z' => Some(byte - b'a' + 26),
+        b'0'..=b'9' => Some(byte - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        _ => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{OriginCertToken, TunnelCredentialsFile};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{FED_ENDPOINT, OriginCertToken, OriginCertUser, TunnelCredentialsFile};
 
     fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
         match result {
@@ -134,6 +327,90 @@ mod tests {
             r#"{"zoneID":"zone","accountID":"account","apiToken":"token","endpoint":"FED"}"#,
         ));
 
-        assert_eq!(token.endpoint.as_deref(), Some("fed"));
+        assert_eq!(token.endpoint.as_deref(), Some(FED_ENDPOINT));
+    }
+
+    #[test]
+    fn origin_cert_pem_round_trips() {
+        let token = OriginCertToken {
+            zone_id: "zone".to_owned(),
+            account_id: "account".to_owned(),
+            api_token: "token".to_owned(),
+            endpoint: Some("FED".to_owned()),
+        };
+
+        let pem = ok(token.encode_pem());
+        let decoded = ok(OriginCertToken::from_pem_blocks(&pem));
+
+        assert_eq!(decoded.zone_id, "zone");
+        assert_eq!(decoded.account_id, "account");
+        assert_eq!(decoded.api_token, "token");
+        assert_eq!(decoded.endpoint.as_deref(), Some(FED_ENDPOINT));
+        assert!(decoded.is_fed_endpoint());
+    }
+
+    #[test]
+    fn origin_cert_unknown_block_is_rejected() {
+        let pem = b"-----BEGIN RSA PRIVATE KEY-----\nZm9v\n-----END RSA PRIVATE KEY-----\n";
+        let error = OriginCertToken::from_pem_blocks(pem).expect_err("unknown block should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "unknown block RSA PRIVATE KEY in the certificate"
+        );
+        assert_eq!(error.category(), "origin-cert-unknown-block");
+    }
+
+    #[test]
+    fn origin_cert_missing_token_is_rejected() {
+        let pem = concat!(
+            "-----BEGIN PRIVATE KEY-----\n",
+            "Zm9v\n",
+            "-----END PRIVATE KEY-----\n",
+            "-----BEGIN CERTIFICATE-----\n",
+            "YmFy\n",
+            "-----END CERTIFICATE-----\n"
+        );
+
+        let error = OriginCertToken::from_pem_blocks(pem.as_bytes()).expect_err("missing token should fail");
+        assert_eq!(error.to_string(), "missing token in the certificate");
+        assert_eq!(error.category(), "origin-cert-missing-token");
+    }
+
+    #[test]
+    fn origin_cert_multiple_tokens_is_rejected() {
+        let token = OriginCertToken {
+            zone_id: "zone".to_owned(),
+            account_id: "account".to_owned(),
+            api_token: "token".to_owned(),
+            endpoint: None,
+        };
+        let mut pem = ok(token.encode_pem());
+        pem.extend(ok(token.encode_pem()));
+
+        let error = OriginCertToken::from_pem_blocks(&pem).expect_err("multiple tokens should fail");
+        assert_eq!(error.to_string(), "found multiple tokens in the certificate");
+        assert_eq!(error.category(), "origin-cert-multiple-tokens");
+    }
+
+    #[test]
+    fn origin_cert_user_requires_account_id() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("cloudflared-origin-cert-{unique}.pem"));
+        let token = OriginCertToken {
+            zone_id: "zone".to_owned(),
+            account_id: String::new(),
+            api_token: "token".to_owned(),
+            endpoint: None,
+        };
+        std::fs::write(&path, ok(token.encode_pem())).expect("pem should be written");
+
+        let error = OriginCertUser::read(&path).expect_err("empty account id should fail");
+        assert_eq!(error.category(), "origin-cert-needs-refresh");
+
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/cloudflared-config/src/error.rs
+++ b/crates/cloudflared-config/src/error.rs
@@ -67,6 +67,24 @@ pub enum ConfigError {
         source: std::io::Error,
     },
 
+    #[error("cannot decode empty certificate")]
+    OriginCertEmpty,
+
+    #[error("unknown block {block_type} in the certificate")]
+    OriginCertUnknownBlock { block_type: String },
+
+    #[error("found multiple tokens in the certificate")]
+    OriginCertMultipleTokens,
+
+    #[error("missing token in the certificate")]
+    OriginCertMissingToken,
+
+    #[error(
+        "Origin certificate needs to be refreshed before creating new tunnels.\nDelete {path} and run \
+         \"cloudflared login\" to obtain a new cert."
+    )]
+    OriginCertNeedsRefresh { path: PathBuf },
+
     #[error("the last ingress rule must match all URLs")]
     IngressLastRuleNotCatchAll,
 
@@ -151,6 +169,16 @@ impl ConfigError {
         }
     }
 
+    pub fn origin_cert_unknown_block(block_type: impl Into<String>) -> Self {
+        Self::OriginCertUnknownBlock {
+            block_type: block_type.into(),
+        }
+    }
+
+    pub fn origin_cert_needs_refresh(path: impl Into<PathBuf>) -> Self {
+        Self::OriginCertNeedsRefresh { path: path.into() }
+    }
+
     pub fn invalid_ingress_service(value: impl Into<String>, reason: impl Into<String>) -> Self {
         Self::InvalidIngressService {
             value: value.into(),
@@ -180,6 +208,11 @@ impl ConfigError {
             Self::CreateDirectory { .. } => "create-directory",
             Self::CreateFile { .. } => "create-file",
             Self::WriteFile { .. } => "write-file",
+            Self::OriginCertEmpty => "origin-cert-empty",
+            Self::OriginCertUnknownBlock { .. } => "origin-cert-unknown-block",
+            Self::OriginCertMultipleTokens => "origin-cert-multiple-tokens",
+            Self::OriginCertMissingToken => "origin-cert-missing-token",
+            Self::OriginCertNeedsRefresh { .. } => "origin-cert-needs-refresh",
             Self::IngressLastRuleNotCatchAll => "ingress-last-rule-not-catch-all",
             Self::IngressBadWildcard => "ingress-bad-wildcard",
             Self::IngressHostnameContainsPort => "ingress-hostname-contains-port",

--- a/crates/cloudflared-config/src/lib.rs
+++ b/crates/cloudflared-config/src/lib.rs
@@ -25,7 +25,8 @@ pub mod normalized;
 pub mod raw_config;
 
 pub use crate::credentials::{
-    CredentialSurface, OriginCertLocator, OriginCertToken, TunnelCredentialsFile, TunnelReference,
+    CredentialSurface, FED_ENDPOINT, OriginCertLocator, OriginCertToken, OriginCertUser,
+    TunnelCredentialsFile, TunnelReference,
 };
 pub use crate::discovery::{
     ConfigSource, DiscoveryAction, DiscoveryCandidate, DiscoveryDefaults, DiscoveryOrigin, DiscoveryOutcome,

--- a/crates/cloudflared-config/tests/README.md
+++ b/crates/cloudflared-config/tests/README.md
@@ -13,9 +13,10 @@ subsystems start.
 Current state:
 
 - Phase 1A fixture taxonomy and harness scaffolding exist
-- Phase 1B.2 can now emit Rust actual artifacts for config discovery/loading fixtures
+- Phase 1B.2 can emit Rust actual artifacts for config discovery/loading fixtures
+- Phase 1B.3 can emit Rust actual artifacts for credentials/origin-cert fixtures
 - Go truth capture is not checked in yet
-- config discovery and config loading behavior is only partially implemented
+- config and credentials behavior is only partially implemented
 - Rust-versus-Go parity is not complete yet
 
 Phase 1A outputs in this directory:
@@ -24,7 +25,7 @@ Phase 1A outputs in this directory:
 - a checked-in golden artifact contract for future Go truth and Rust actuals
 - Rust-side helper scaffolding and ignored parity test entrypoints
 - an external runner entrypoint at `tools/first_slice_parity.py`
-- a Rust actual emission path for targeted Phase 1B.2 fixture categories
+- a Rust actual emission path for targeted Phase 1B.2 and Phase 1B.3 fixture categories
 
 Current execution model:
 
@@ -32,7 +33,7 @@ Current execution model:
 - `python3 tools/first_slice_parity.py check-go-truth` fails until Go truth JSON
  is captured under `tests/fixtures/first-slice/golden/go-truth/`
 - `python3 tools/first_slice_parity.py emit-rust-actual` writes readable JSON
- artifacts for the Phase 1B.2 config discovery/loading fixtures
+ artifacts for the currently implemented config and credentials fixtures
 - `cargo test -p cloudflared-config` validates the fixture inventory and keeps
  ignored parity tests visible without claiming passing parity
 

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
@@ -3,9 +3,10 @@
 This directory is reserved for canonical JSON emitted by the Rust-side first
 slice harness path.
 
-Current state in Phase 1B.2:
+Current state after Phase 1B.3:
 
-- config discovery and config loading fixtures can now emit Rust actual reports
+- config discovery and config loading fixtures can emit Rust actual reports
+- credentials/origin-cert fixtures can emit Rust actual reports
 - the files are generated via `python3 tools/first_slice_parity.py emit-rust-actual`
 - the output remains incomplete for first-slice categories that are still out of
  scope for this phase

--- a/crates/cloudflared-config/tests/phase_1b3_credentials.rs
+++ b/crates/cloudflared-config/tests/phase_1b3_credentials.rs
@@ -1,0 +1,114 @@
+#![allow(unused_crate_dependencies)]
+
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use cloudflared_config::{OriginCertToken, OriginCertUser};
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn temp_dir(name: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("cloudflared-config-{name}-{unique}"));
+    fs::create_dir_all(&path).expect("temp directory should be created");
+    path
+}
+
+fn baseline_credential_fixture(path: &str) -> std::path::PathBuf {
+    support::repo_root().join(path)
+}
+
+#[test]
+fn valid_origin_cert_fixture_decodes() {
+    let fixture = baseline_credential_fixture(
+        "baseline-2026.2.0/old-impl/credentials/test-cloudflare-tunnel-cert-json.pem",
+    );
+    let token = OriginCertToken::from_pem_path(&fixture).expect("fixture should decode");
+
+    assert_eq!(token.zone_id, "7b0a4d77dfb881c1a3b7d61ea9443e19");
+    assert_eq!(token.account_id, "abcdabcdabcdabcd1234567890abcdef");
+    assert_eq!(token.api_token, "test-service-key");
+    assert_eq!(token.endpoint, None);
+}
+
+#[test]
+fn valid_origin_cert_user_read_preserves_path() {
+    let fixture = baseline_credential_fixture(
+        "baseline-2026.2.0/old-impl/credentials/test-cloudflare-tunnel-cert-json.pem",
+    );
+    let user = OriginCertUser::read(&fixture).expect("fixture should read as user");
+
+    assert_eq!(user.cert_path, fixture);
+    assert_eq!(user.cert.account_id, "abcdabcdabcdabcd1234567890abcdef");
+}
+
+#[test]
+fn missing_token_fixture_maps_to_origin_cert_category() {
+    let fixture =
+        baseline_credential_fixture("baseline-2026.2.0/old-impl/credentials/test-cert-no-token.pem");
+    let error = OriginCertToken::from_pem_path(&fixture).expect_err("fixture should fail");
+
+    assert_eq!(error.category(), "origin-cert-missing-token");
+    assert_eq!(error.to_string(), "missing token in the certificate");
+}
+
+#[test]
+fn unknown_block_fixture_maps_to_origin_cert_category() {
+    let fixture =
+        baseline_credential_fixture("baseline-2026.2.0/old-impl/credentials/test-cert-unknown-block.pem");
+    let error = OriginCertToken::from_pem_path(&fixture).expect_err("fixture should fail");
+
+    assert_eq!(error.category(), "origin-cert-unknown-block");
+    assert_eq!(
+        error.to_string(),
+        "unknown block RSA PRIVATE KEY in the certificate"
+    );
+}
+
+#[test]
+fn harness_can_emit_origin_cert_reports() {
+    let output_dir = temp_dir("rust-actual-origin-cert");
+    let output = Command::new("python3")
+        .arg(support::tool_path())
+        .arg("emit-rust-actual")
+        .arg("--output-dir")
+        .arg(&output_dir)
+        .arg("--fixture-id")
+        .arg("origin-cert-json-token")
+        .arg("--fixture-id")
+        .arg("origin-cert-missing-token")
+        .output()
+        .expect("python3 should be available to run the first-slice parity harness");
+
+    assert!(
+        output.status.success(),
+        "expected rust actual emission to succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let success_artifact = output_dir.join("origin-cert-json-token.json");
+    let success_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&success_artifact).expect("success artifact should be readable"),
+    )
+    .expect("success artifact should be valid json");
+    assert_eq!(success_payload["report_kind"], "credential-report.v1");
+    assert_eq!(
+        success_payload["payload"]["zone_id"],
+        "7b0a4d77dfb881c1a3b7d61ea9443e19"
+    );
+
+    let error_artifact = output_dir.join("origin-cert-missing-token.json");
+    let error_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&error_artifact).expect("error artifact should be readable"),
+    )
+    .expect("error artifact should be valid json");
+    assert_eq!(error_payload["report_kind"], "error-report.v1");
+    assert_eq!(error_payload["payload"]["category"], "origin-cert-missing-token");
+
+    fs::remove_dir_all(output_dir).expect("temp directory should be removable");
+}

--- a/crates/cloudflared-config/tests/support/mod.rs
+++ b/crates/cloudflared-config/tests/support/mod.rs
@@ -14,6 +14,19 @@ pub(crate) fn fixtures_root() -> PathBuf {
 }
 
 #[allow(dead_code)]
+pub(crate) fn repo_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    for ancestor in manifest_dir.ancestors() {
+        if ancestor.join("Cargo.toml").exists() && ancestor.join("baseline-2026.2.0").exists() {
+            return ancestor.to_path_buf();
+        }
+    }
+
+    panic!("failed to locate repo root from {}", manifest_dir.display());
+}
+
+#[allow(dead_code)]
 pub(crate) fn fixture_entries() -> Vec<FixtureEntry> {
     let index_path = fixtures_root().join("fixture-index.toml");
     let contents = fs::read_to_string(&index_path)

--- a/tools/first_slice_parity.py
+++ b/tools/first_slice_parity.py
@@ -19,6 +19,7 @@ GO_TRUTH_DIR = FIXTURE_ROOT / "golden" / "go-truth"
 RUST_ACTUAL_DIR = FIXTURE_ROOT / "golden" / "rust-actual"
 SUPPORTED_RUST_ACTUAL_CATEGORIES = {
     "config-discovery",
+    "credentials-origin-cert",
     "yaml-config",
     "invalid-input",
     "ordering-defaulting",
@@ -96,7 +97,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     emit_rust_actual = subparsers.add_parser(
         "emit-rust-actual",
-        help="Generate Rust-side actual artifacts for the targeted Phase 1B.2 fixtures.",
+        help="Generate Rust-side actual artifacts for the targeted first-slice fixtures.",
     )
     emit_rust_actual.add_argument(
         "--fixture-id",
@@ -245,13 +246,14 @@ def cmd_emit_rust_actual(args: argparse.Namespace, fixtures: list[Fixture]) -> i
     ]
 
     if not targeted:
-        print("no Phase 1B.2-targeted fixtures were selected", file=sys.stderr)
+        print("no targeted first-slice fixtures were selected", file=sys.stderr)
         return 1
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     plan = {
+        "repo_root": str(REPO_ROOT),
         "fixture_root": str(FIXTURE_ROOT),
         "output_dir": str(output_dir),
         "fixtures": [build_emission_fixture(fixture) for fixture in targeted],
@@ -278,7 +280,7 @@ def cmd_emit_rust_actual(args: argparse.Namespace, fixtures: list[Fixture]) -> i
     if skipped:
         for fixture in skipped:
             print(
-                f"skipping unsupported Phase 1B.2 category for {fixture.fixture_id}: {fixture.category}",
+                f"skipping unsupported first-slice category for {fixture.fixture_id}: {fixture.category}",
                 file=sys.stderr,
             )
 
@@ -329,6 +331,8 @@ def build_emission_fixture(fixture: Fixture) -> dict[str, object]:
     }
     if fixture.category == "config-discovery":
         payload["discovery_case"] = load_discovery_case(fixture.fixture_id)
+    if fixture.category == "credentials-origin-cert":
+        payload["origin_cert_source"] = load_origin_cert_source(fixture.fixture_id)
     return payload
 
 
@@ -345,6 +349,18 @@ def load_discovery_case(fixture_id: str) -> dict[str, object]:
             }
 
     raise SystemExit(f"missing config discovery case for fixture {fixture_id}")
+
+
+def load_origin_cert_source(fixture_id: str) -> str:
+    sources_path = FIXTURE_ROOT / "credentials-origin-cert" / "sources.toml"
+    with sources_path.open("rb") as handle:
+        raw = tomllib.load(handle)
+
+    for source in raw.get("source", []):
+        if source.get("id") == fixture_id:
+            return str(source["path"])
+
+    raise SystemExit(f"missing credentials source for fixture {fixture_id}")
 
 
 def display_repo_relative(path: Path) -> str:


### PR DESCRIPTION
## What this PR does

This PR makes the origin-cert path real for the current first-slice credentials fixtures.

It adds origin-cert PEM scanning, token extraction/validation, and Rust actual artifact emission for the targeted fixture set.

## Included in this PR

- source-backed origin-cert PEM scanning
- token extraction and validation for the targeted fixtures
- narrow error handling for missing token / unknown block cases
- Rust actual artifact emission for `credentials-origin-cert`
- targeted tests and small status/doc updates

## Scope

This stays within the accepted first slice, focused only on the origin-cert credentials path.

## Not included

This PR does not cover:
- default origin-cert discovery behavior
- tunnel credential file artifact coverage
- ingress normalization or matching
- transport/runtime work
- Go-vs-Rust parity completion

## Why now

Phase 1B.2 made the config-loading path real.

This PR takes the next small step by making the origin-cert path executable for the current fixture set, without widening into broader credentials or ingress behavior.

## Current status after this PR

What exists after this:
- real config-loading behavior for targeted fixtures
- real origin-cert behavior for targeted credentials fixtures
- Rust actual artifact emission for those paths

What still comes next:
- broader credentials coverage
- ingress behavior
- Go truth capture
- real parity comparison