### PR TITLE
rust-rewrite: add phase 1b.4 ingress path

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -8,7 +8,8 @@ implementation and an intentionally narrow Rust first slice.
 It is not yet a parity-complete Rust implementation workspace. The repository
 now contains a Cargo workspace skeleton plus early first-slice behavior in
 `crates/cloudflared-config/` for config discovery/loading and credentials
-origin-cert decoding, but most subsystem behavior is still unported.
+origin-cert decoding, plus narrow ingress normalization and matching behavior,
+but most subsystem behavior is still unported.
 
 The scaffold is intentionally real but minimal:
 
@@ -222,6 +223,35 @@ What does not exist yet:
 Implication:
 
 - the accepted first slice now has a real credentials/origin-cert path in Rust
+- the repository still must not claim first-slice parity is complete
+
+## Phase 1B.4 Ingress Normalization And Matching Path
+
+Phase 1B.4 behavior now exists for the targeted ingress normalization,
+ordering/defaulting, and CLI single-origin fixtures.
+
+What exists now:
+
+- semantic ingress service normalization for the current fixture surface
+- deterministic user-rule matching with host:port stripping and catch-all fallback
+- punycode-aware hostname matching for the current IDN ingress fixture surface
+- preserved no-ingress default 503 contract through normalized config output
+- narrow CLI single-origin synthesis for `--hello-world`, `--bastion`, `--url`,
+  and `--unix-socket`
+- Rust actual artifact emission for targeted ingress-related fixture categories
+
+What does not exist yet:
+
+- Go truth outputs for comparison
+- internal ingress-rule matching and negative rule-index behavior
+- full regex-path semantics for general ingress matching
+- full tunnel credential JSON artifact coverage
+- full first-slice parity comparisons
+
+Implication:
+
+- the accepted first slice now has a real ingress normalization and matching
+  path in Rust for the current fixture surface
 - the repository still must not claim first-slice parity is complete
 
 ## First Implementation Gate

--- a/crates/cloudflared-config/examples/first_slice_emit.rs
+++ b/crates/cloudflared-config/examples/first_slice_emit.rs
@@ -7,11 +7,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use cloudflared_config::artifact::{
     DiscoveryCase, DiscoveryReportPayload, EmissionPlan, FixtureSpec, credential_envelope,
-    discovery_envelope, error_envelope, normalized_config_envelope,
+    discovery_envelope, error_envelope, ingress_envelope, normalized_config_envelope,
 };
 use cloudflared_config::{
-    ConfigSource, DiscoveryDefaults, DiscoveryRequest, OriginCertToken, discover_config,
-    load_normalized_config,
+    ConfigSource, DiscoveryDefaults, DiscoveryRequest, NormalizedIngress, OriginCertToken, discover_config,
+    load_normalized_config, parse_cli_ingress,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -21,10 +21,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for fixture in &plan.fixtures {
         let envelope = match fixture.category.as_str() {
             "config-discovery" => emit_discovery_fixture(fixture)?,
-            "yaml-config" | "ordering-defaulting" | "invalid-input" => {
-                emit_config_fixture(&plan.fixture_root, fixture)?
-            }
+            "yaml-config" | "invalid-input" => emit_config_fixture(&plan.fixture_root, fixture)?,
+            "ordering-defaulting" => emit_ordering_fixture(&plan.fixture_root, fixture)?,
             "credentials-origin-cert" => emit_origin_cert_fixture(&plan, fixture)?,
+            "ingress-normalization" => emit_cli_ingress_fixture(fixture)?,
             other => {
                 return Err(format!("unsupported fixture category for current first slice: {other}").into());
             }
@@ -97,6 +97,46 @@ fn emit_origin_cert_fixture(
         Ok(token) => Ok(credential_envelope(fixture, source_path, &token)?),
         Err(error) => Ok(error_envelope(fixture, &error)?),
     }
+}
+
+fn emit_ordering_fixture(
+    fixture_root: &Path,
+    fixture: &FixtureSpec,
+) -> Result<cloudflared_config::artifact::ArtifactEnvelope, Box<dyn std::error::Error>> {
+    let Some(ordering_case) = fixture.ordering_case.as_ref() else {
+        return Err(format!("fixture {} is missing ordering case data", fixture.fixture_id).into());
+    };
+
+    let input_path = fixture_root.join(&ordering_case.input);
+    let source = ConfigSource::DiscoveredPath(PathBuf::from(&ordering_case.input));
+    match load_normalized_config(&input_path, source) {
+        Ok(normalized) => Ok(normalized_config_envelope(
+            fixture,
+            Path::new(&ordering_case.input),
+            &normalized,
+        )?),
+        Err(error) => Ok(error_envelope(fixture, &error)?),
+    }
+}
+
+fn emit_cli_ingress_fixture(
+    fixture: &FixtureSpec,
+) -> Result<cloudflared_config::artifact::ArtifactEnvelope, Box<dyn std::error::Error>> {
+    let Some(cli_case) = fixture.cli_ingress_case.as_ref() else {
+        return Err(format!("fixture {} is missing cli ingress case data", fixture.fixture_id).into());
+    };
+
+    match parse_cli_ingress(&cli_case.flags) {
+        Ok(normalized) => emit_cli_ingress_envelope(fixture, &normalized),
+        Err(error) => Ok(error_envelope(fixture, &error)?),
+    }
+}
+
+fn emit_cli_ingress_envelope(
+    fixture: &FixtureSpec,
+    normalized: &NormalizedIngress,
+) -> Result<cloudflared_config::artifact::ArtifactEnvelope, Box<dyn std::error::Error>> {
+    Ok(ingress_envelope(fixture, "cli-single-origin", normalized)?)
 }
 
 fn build_discovery_sandbox(case: &DiscoveryCase) -> Result<PathBuf, Box<dyn std::error::Error>> {

--- a/crates/cloudflared-config/src/artifact.rs
+++ b/crates/cloudflared-config/src/artifact.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::credentials::{CredentialSurface, OriginCertLocator, OriginCertToken, TunnelReference};
 use crate::discovery::{ConfigSource, DiscoveryAction, DiscoveryOutcome};
 use crate::error::ConfigError;
-use crate::ingress::{IngressRule, IngressService, OriginRequestConfig};
+use crate::ingress::{IngressRule, IngressService, NormalizedIngress, OriginRequestConfig};
 use crate::normalized::{NormalizationWarning, NormalizedConfig};
 use crate::raw_config::WarpRoutingConfig;
 
@@ -31,12 +31,26 @@ pub struct FixtureSpec {
     pub discovery_case: Option<DiscoveryCase>,
     #[serde(default)]
     pub origin_cert_source: Option<String>,
+    #[serde(default)]
+    pub ordering_case: Option<OrderingCase>,
+    #[serde(default)]
+    pub cli_ingress_case: Option<CliIngressCase>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct DiscoveryCase {
     pub explicit_config: bool,
     pub present: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OrderingCase {
+    pub input: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CliIngressCase {
+    pub flags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -74,6 +88,15 @@ pub struct CredentialReportPayload {
     pub api_token: String,
     pub endpoint: Option<String>,
     pub is_fed_endpoint: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IngressReportPayload {
+    pub source_kind: &'static str,
+    pub rule_count: usize,
+    pub catch_all_rule_index: usize,
+    pub defaults: OriginRequestConfig,
+    pub rules: Vec<IngressRulePayload>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -201,6 +224,22 @@ pub fn credential_envelope(
     })
 }
 
+pub fn ingress_envelope(
+    fixture: &FixtureSpec,
+    source_kind: &'static str,
+    normalized: &NormalizedIngress,
+) -> Result<ArtifactEnvelope, serde_json::Error> {
+    Ok(ArtifactEnvelope {
+        schema_version: SCHEMA_VERSION,
+        fixture_id: fixture.fixture_id.clone(),
+        producer: "rust-actual",
+        report_kind: "ingress-report.v1",
+        comparison: fixture.comparison.clone(),
+        source_refs: fixture.source_refs.clone(),
+        payload: serde_json::to_value(IngressReportPayload::from_ingress(source_kind, normalized))?,
+    })
+}
+
 impl DiscoveryReportPayload {
     pub fn from_outcome(outcome: &DiscoveryOutcome, sandbox_root: &Path) -> Self {
         Self {
@@ -316,9 +355,16 @@ impl IngressRulePayload {
 impl IngressServicePayload {
     fn from_service(service: &IngressService) -> Self {
         match service {
-            IngressService::Uri(uri) => Self {
-                kind: "uri",
-                uri: Some(uri.to_string()),
+            IngressService::Http(uri) => Self {
+                kind: "http",
+                uri: Some(display_origin_url(uri)),
+                path: None,
+                name: None,
+                status_code: None,
+            },
+            IngressService::TcpOverWebsocket(uri) => Self {
+                kind: "tcp-over-websocket",
+                uri: Some(display_origin_url(uri)),
                 path: None,
                 name: None,
                 status_code: None,
@@ -346,6 +392,20 @@ impl IngressServicePayload {
             },
             IngressService::HelloWorld => Self {
                 kind: "hello-world",
+                uri: None,
+                path: None,
+                name: None,
+                status_code: None,
+            },
+            IngressService::Bastion => Self {
+                kind: "bastion",
+                uri: None,
+                path: None,
+                name: None,
+                status_code: None,
+            },
+            IngressService::SocksProxy => Self {
+                kind: "socks-proxy",
                 uri: None,
                 path: None,
                 name: None,
@@ -387,10 +447,35 @@ impl CredentialReportPayload {
     }
 }
 
+impl IngressReportPayload {
+    fn from_ingress(source_kind: &'static str, normalized: &NormalizedIngress) -> Self {
+        Self {
+            source_kind,
+            rule_count: normalized.rules.len(),
+            catch_all_rule_index: normalized.rules.len().saturating_sub(1),
+            defaults: normalized.defaults.clone(),
+            rules: normalized
+                .rules
+                .iter()
+                .map(IngressRulePayload::from_rule)
+                .collect(),
+        }
+    }
+}
+
 fn display_path(path: &Path, sandbox_root: &Path) -> String {
     if let Ok(relative) = path.strip_prefix(sandbox_root) {
         format!("/{}", relative.display())
     } else {
         path.display().to_string()
+    }
+}
+
+fn display_origin_url(url: &url::Url) -> String {
+    let rendered = url.to_string();
+    if url.path() == "/" && url.query().is_none() && url.fragment().is_none() {
+        rendered.trim_end_matches('/').to_owned()
+    } else {
+        rendered
     }
 }

--- a/crates/cloudflared-config/src/error.rs
+++ b/crates/cloudflared-config/src/error.rs
@@ -85,6 +85,12 @@ pub enum ConfigError {
     )]
     OriginCertNeedsRefresh { path: PathBuf },
 
+    #[error(
+        "No ingress rules were defined in provided config (if any) nor from the cli, cloudflared will \
+         return 503 for all incoming HTTP requests"
+    )]
+    NoIngressRulesCli,
+
     #[error("the last ingress rule must match all URLs")]
     IngressLastRuleNotCatchAll,
 
@@ -213,6 +219,7 @@ impl ConfigError {
             Self::OriginCertMultipleTokens => "origin-cert-multiple-tokens",
             Self::OriginCertMissingToken => "origin-cert-missing-token",
             Self::OriginCertNeedsRefresh { .. } => "origin-cert-needs-refresh",
+            Self::NoIngressRulesCli => "no-ingress-rules-cli",
             Self::IngressLastRuleNotCatchAll => "ingress-last-rule-not-catch-all",
             Self::IngressBadWildcard => "ingress-bad-wildcard",
             Self::IngressHostnameContainsPort => "ingress-hostname-contains-port",

--- a/crates/cloudflared-config/src/ingress.rs
+++ b/crates/cloudflared-config/src/ingress.rs
@@ -5,6 +5,17 @@ use url::Url;
 
 use crate::error::{ConfigError, Result};
 
+pub const NO_INGRESS_RULES_CLI_MESSAGE: &str = "No ingress rules were defined in provided config (if any) \
+                                                nor from the cli, cloudflared will return 503 for all \
+                                                incoming HTTP requests";
+
+const DEFAULT_HTTP_CONNECT_TIMEOUT: &str = "30s";
+const DEFAULT_TLS_TIMEOUT: &str = "10s";
+const DEFAULT_TCP_KEEP_ALIVE: &str = "30s";
+const DEFAULT_KEEP_ALIVE_TIMEOUT: &str = "90s";
+const DEFAULT_PROXY_ADDRESS: &str = "127.0.0.1";
+const DEFAULT_KEEP_ALIVE_CONNECTIONS: u32 = 100;
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct DurationSpec(pub String);
@@ -87,11 +98,14 @@ pub struct RawIngressRule {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum IngressService {
-    Uri(Url),
+    Http(Url),
+    TcpOverWebsocket(Url),
     UnixSocket(PathBuf),
     UnixSocketTls(PathBuf),
     HttpStatus(u16),
     HelloWorld,
+    Bastion,
+    SocksProxy,
     NamedToken(String),
 }
 
@@ -107,6 +121,20 @@ pub struct IngressRule {
     pub matcher: IngressMatch,
     pub service: IngressService,
     pub origin_request: OriginRequestConfig,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct CliIngressRequest {
+    pub hello_world: bool,
+    pub bastion: bool,
+    pub url: Option<String>,
+    pub unix_socket: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NormalizedIngress {
+    pub rules: Vec<IngressRule>,
+    pub defaults: OriginRequestConfig,
 }
 
 impl IngressService {
@@ -135,25 +163,41 @@ impl IngressService {
         if value == "hello_world" {
             return Ok(Self::HelloWorld);
         }
+        if value == "bastion" {
+            return Ok(Self::Bastion);
+        }
+        if value == "socks-proxy" {
+            return Ok(Self::SocksProxy);
+        }
 
-        match Url::parse(value) {
-            Ok(url) => {
-                if url.scheme().is_empty() || url.host_str().is_none() {
-                    return Err(ConfigError::invalid_ingress_service(
-                        value,
-                        "address must include a scheme and hostname",
-                    ));
-                }
-                if !url.path().is_empty() && url.path() != "/" {
-                    return Err(ConfigError::invalid_ingress_service(
-                        value,
-                        "origin service addresses must not include a path",
-                    ));
-                }
-                Ok(Self::Uri(url))
+        let mut url = Url::parse(value).map_err(|source| match source {
+            url::ParseError::RelativeUrlWithoutBase => {
+                ConfigError::invalid_ingress_service(value, "address must include a scheme and hostname")
             }
-            Err(url::ParseError::RelativeUrlWithoutBase) => Ok(Self::NamedToken(value.to_owned())),
-            Err(source) => Err(ConfigError::invalid_url(field, value, source)),
+            other => ConfigError::invalid_url(field, value, other),
+        })?;
+
+        if url.scheme().is_empty() || url.host_str().is_none() {
+            return Err(ConfigError::invalid_ingress_service(
+                value,
+                "address must include a scheme and hostname",
+            ));
+        }
+
+        if !url.path().is_empty() && url.path() != "/" {
+            return Err(ConfigError::invalid_ingress_service(
+                value,
+                "origin service addresses must not include a path",
+            ));
+        }
+        if url.path() == "/" {
+            url.set_path("");
+        }
+
+        if is_http_scheme(url.scheme()) {
+            Ok(Self::Http(url))
+        } else {
+            Ok(Self::TcpOverWebsocket(url))
         }
     }
 }
@@ -187,6 +231,69 @@ impl IngressRule {
     pub fn is_catch_all(&self) -> bool {
         self.matcher.hostname.is_none() && self.matcher.path.is_none()
     }
+
+    pub fn matches(&self, hostname: &str, path: &str) -> bool {
+        let hostname = strip_port(hostname);
+        let host_match = match self.matcher.hostname.as_deref() {
+            None | Some("") | Some("*") => true,
+            Some(rule_host) => match_host(rule_host, hostname),
+        };
+        let punycode_match = self
+            .matcher
+            .punycode_hostname
+            .as_deref()
+            .is_some_and(|rule_host| match_host(rule_host, hostname));
+        let path_match = self
+            .matcher
+            .path
+            .as_deref()
+            .is_none_or(|pattern| match_path(pattern, path));
+
+        (host_match || punycode_match) && path_match
+    }
+}
+
+impl CliIngressRequest {
+    pub fn from_flags(flags: &[String]) -> Self {
+        let mut request = Self::default();
+
+        for flag in flags {
+            if let Some(value) = flag.strip_prefix("--hello-world=") {
+                request.hello_world = value == "true";
+            } else if flag == "--hello-world" {
+                request.hello_world = true;
+            } else if let Some(value) = flag.strip_prefix("--bastion=") {
+                request.bastion = value == "true";
+            } else if flag == "--bastion" {
+                request.bastion = true;
+            } else if let Some(value) = flag.strip_prefix("--url=") {
+                request.url = Some(value.to_owned());
+            } else if let Some(value) = flag.strip_prefix("--unix-socket=") {
+                request.unix_socket = Some(value.to_owned());
+            }
+        }
+
+        request
+    }
+}
+
+impl NormalizedIngress {
+    pub fn from_cli_request(request: &CliIngressRequest) -> Result<Self> {
+        let defaults = default_single_origin_origin_request(request);
+        let service = parse_single_origin_service(request)?;
+        Ok(Self {
+            rules: vec![IngressRule {
+                matcher: IngressMatch::default(),
+                service,
+                origin_request: defaults.clone(),
+            }],
+            defaults,
+        })
+    }
+
+    pub fn find_matching_rule(&self, hostname: &str, path: &str) -> Option<usize> {
+        find_matching_rule(&self.rules, hostname, path)
+    }
 }
 
 pub fn default_no_ingress_rule() -> IngressRule {
@@ -194,6 +301,90 @@ pub fn default_no_ingress_rule() -> IngressRule {
         matcher: IngressMatch::default(),
         service: IngressService::HttpStatus(503),
         origin_request: OriginRequestConfig::default(),
+    }
+}
+
+pub fn find_matching_rule(rules: &[IngressRule], hostname: &str, path: &str) -> Option<usize> {
+    if rules.is_empty() {
+        return None;
+    }
+
+    for (index, rule) in rules.iter().enumerate() {
+        if rule.matches(hostname, path) {
+            return Some(index);
+        }
+    }
+
+    Some(rules.len() - 1)
+}
+
+pub fn parse_cli_ingress(flags: &[String]) -> Result<NormalizedIngress> {
+    let request = CliIngressRequest::from_flags(flags);
+    NormalizedIngress::from_cli_request(&request)
+}
+
+fn parse_single_origin_service(request: &CliIngressRequest) -> Result<IngressService> {
+    if request.hello_world {
+        return Ok(IngressService::HelloWorld);
+    }
+    if request.bastion {
+        return Ok(IngressService::Bastion);
+    }
+    if let Some(url) = request.url.as_deref() {
+        return parse_cli_origin_url(url);
+    }
+    if let Some(unix_socket) = request.unix_socket.as_deref() {
+        return Ok(IngressService::UnixSocket(PathBuf::from(unix_socket)));
+    }
+
+    Err(ConfigError::NoIngressRulesCli)
+}
+
+fn parse_cli_origin_url(value: &str) -> Result<IngressService> {
+    let mut url = Url::parse(value).map_err(|source| ConfigError::invalid_url("url", value, source))?;
+    if url.scheme().is_empty() || url.host_str().is_none() {
+        return Err(ConfigError::invalid_ingress_service(
+            value,
+            "address must include a scheme and hostname",
+        ));
+    }
+    if !url.path().is_empty() && url.path() != "/" {
+        url.set_path("");
+        url.set_query(None);
+        url.set_fragment(None);
+    }
+    if url.path() == "/" {
+        url.set_path("");
+    }
+
+    if is_http_scheme(url.scheme()) {
+        Ok(IngressService::Http(url))
+    } else {
+        Ok(IngressService::TcpOverWebsocket(url))
+    }
+}
+
+fn default_single_origin_origin_request(request: &CliIngressRequest) -> OriginRequestConfig {
+    OriginRequestConfig {
+        connect_timeout: Some(DurationSpec(DEFAULT_HTTP_CONNECT_TIMEOUT.to_owned())),
+        tls_timeout: Some(DurationSpec(DEFAULT_TLS_TIMEOUT.to_owned())),
+        tcp_keep_alive: Some(DurationSpec(DEFAULT_TCP_KEEP_ALIVE.to_owned())),
+        no_happy_eyeballs: Some(false),
+        keep_alive_connections: Some(DEFAULT_KEEP_ALIVE_CONNECTIONS),
+        keep_alive_timeout: Some(DurationSpec(DEFAULT_KEEP_ALIVE_TIMEOUT.to_owned())),
+        http_host_header: None,
+        origin_server_name: None,
+        match_sni_to_host: Some(false),
+        ca_pool: None,
+        no_tls_verify: Some(false),
+        disable_chunked_encoding: Some(false),
+        bastion_mode: request.bastion.then_some(true),
+        proxy_address: Some(DEFAULT_PROXY_ADDRESS.to_owned()),
+        proxy_port: None,
+        proxy_type: None,
+        ip_rules: Vec::new(),
+        http2_origin: Some(false),
+        access: None,
     }
 }
 
@@ -248,9 +439,50 @@ fn normalized_punycode_hostname(hostname: Option<&str>) -> Result<Option<String>
     }
 }
 
+fn is_http_scheme(scheme: &str) -> bool {
+    matches!(scheme, "http" | "https" | "ws" | "wss")
+}
+
+fn match_host(rule_host: &str, req_host: &str) -> bool {
+    if rule_host == req_host {
+        return true;
+    }
+
+    if let Some(suffix) = rule_host.strip_prefix("*.") {
+        let suffix = format!(".{suffix}");
+        return req_host.ends_with(&suffix);
+    }
+
+    false
+}
+
+fn match_path(pattern: &str, path: &str) -> bool {
+    path.contains(pattern)
+}
+
+fn strip_port(hostname: &str) -> &str {
+    if hostname.starts_with('[') {
+        return hostname;
+    }
+
+    if let Some((host, port)) = hostname.rsplit_once(':')
+        && !host.contains(':')
+        && !host.is_empty()
+        && !port.is_empty()
+        && port.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return host;
+    }
+
+    hostname
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{IngressRule, IngressService, RawIngressRule, default_no_ingress_rule};
+    use super::{
+        CliIngressRequest, IngressRule, IngressService, NormalizedIngress, RawIngressRule,
+        default_no_ingress_rule, find_matching_rule, parse_cli_ingress,
+    };
     use crate::error::ConfigError;
 
     fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
@@ -261,12 +493,22 @@ mod tests {
     }
 
     #[test]
-    fn service_parser_recognizes_url_services() {
+    fn service_parser_recognizes_http_services() {
         let service = ok(IngressService::parse("service", "https://localhost:8080"));
 
         match service {
-            IngressService::Uri(url) => assert_eq!(url.scheme(), "https"),
-            other => panic!("expected URI service, found {other:?}"),
+            IngressService::Http(url) => assert_eq!(url.scheme(), "https"),
+            other => panic!("expected HTTP service, found {other:?}"),
+        }
+    }
+
+    #[test]
+    fn service_parser_recognizes_tcp_over_websocket_services() {
+        let service = ok(IngressService::parse("service", "tcp://localhost:8080"));
+
+        match service {
+            IngressService::TcpOverWebsocket(url) => assert_eq!(url.scheme(), "tcp"),
+            other => panic!("expected TCP-over-websocket service, found {other:?}"),
         }
     }
 
@@ -321,5 +563,126 @@ mod tests {
             rule.matcher.punycode_hostname.as_deref(),
             Some("xn--m-xgaa.cloudflare.com")
         );
+    }
+
+    #[test]
+    fn matching_prefers_first_matching_rule_and_strips_port() {
+        let rules = vec![
+            ok(IngressRule::from_raw(
+                RawIngressRule {
+                    hostname: Some("tunnel-a.example.com".to_owned()),
+                    service: Some("https://localhost:8080".to_owned()),
+                    ..RawIngressRule::default()
+                },
+                0,
+                3,
+            )),
+            ok(IngressRule::from_raw(
+                RawIngressRule {
+                    hostname: Some("tunnel-b.example.com".to_owned()),
+                    path: Some("/health".to_owned()),
+                    service: Some("https://localhost:8081".to_owned()),
+                    ..RawIngressRule::default()
+                },
+                1,
+                3,
+            )),
+            ok(IngressRule::from_raw(
+                RawIngressRule {
+                    service: Some("http_status:404".to_owned()),
+                    ..RawIngressRule::default()
+                },
+                2,
+                3,
+            )),
+        ];
+
+        assert_eq!(
+            find_matching_rule(&rules, "tunnel-a.example.com:443", "/"),
+            Some(0)
+        );
+        assert_eq!(
+            find_matching_rule(&rules, "tunnel-b.example.com", "/health"),
+            Some(1)
+        );
+        assert_eq!(
+            find_matching_rule(&rules, "tunnel-b.example.com", "/index.html"),
+            Some(2)
+        );
+        assert_eq!(find_matching_rule(&rules, "unknown.example.com", "/"), Some(2));
+    }
+
+    #[test]
+    fn unicode_rule_matches_punycode_hostname() {
+        let rules = vec![
+            ok(IngressRule::from_raw(
+                RawIngressRule {
+                    hostname: Some("môô.cloudflare.com".to_owned()),
+                    service: Some("https://localhost:8080".to_owned()),
+                    ..RawIngressRule::default()
+                },
+                0,
+                2,
+            )),
+            ok(IngressRule::from_raw(
+                RawIngressRule {
+                    service: Some("http_status:404".to_owned()),
+                    ..RawIngressRule::default()
+                },
+                1,
+                2,
+            )),
+        ];
+
+        assert_eq!(
+            find_matching_rule(&rules, "xn--m-xgaa.cloudflare.com", "/"),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn cli_request_parses_flags() {
+        let request = CliIngressRequest::from_flags(&[
+            "--url=http://localhost:8080".to_owned(),
+            "--hello-world=false".to_owned(),
+        ]);
+
+        assert_eq!(request.url.as_deref(), Some("http://localhost:8080"));
+        assert!(!request.hello_world);
+    }
+
+    #[test]
+    fn cli_ingress_hello_world_normalizes() {
+        let ingress = ok(parse_cli_ingress(&["--hello-world=true".to_owned()]));
+
+        assert_eq!(ingress.rules.len(), 1);
+        assert_eq!(ingress.rules[0].service, IngressService::HelloWorld);
+        assert_eq!(
+            ingress
+                .defaults
+                .connect_timeout
+                .as_ref()
+                .map(|value| value.0.as_str()),
+            Some("30s")
+        );
+    }
+
+    #[test]
+    fn cli_ingress_bastion_sets_bastion_mode() {
+        let ingress = ok(NormalizedIngress::from_cli_request(&CliIngressRequest {
+            bastion: true,
+            ..CliIngressRequest::default()
+        }));
+
+        assert_eq!(ingress.rules[0].service, IngressService::Bastion);
+        assert_eq!(ingress.defaults.bastion_mode, Some(true));
+    }
+
+    #[test]
+    fn cli_ingress_without_origin_is_an_error() {
+        let error = parse_cli_ingress(&[]).expect_err("missing origin should fail");
+
+        assert!(matches!(error, ConfigError::NoIngressRulesCli));
+        assert_eq!(error.category(), "no-ingress-rules-cli");
     }
 }

--- a/crates/cloudflared-config/src/lib.rs
+++ b/crates/cloudflared-config/src/lib.rs
@@ -35,8 +35,9 @@ pub use crate::discovery::{
 };
 pub use crate::error::{ConfigError, Result};
 pub use crate::ingress::{
-    AccessConfig, DurationSpec, IngressIpRule, IngressMatch, IngressRule, IngressService,
-    OriginRequestConfig, RawIngressRule,
+    AccessConfig, CliIngressRequest, DurationSpec, IngressIpRule, IngressMatch, IngressRule, IngressService,
+    NO_INGRESS_RULES_CLI_MESSAGE, NormalizedIngress, OriginRequestConfig, RawIngressRule, find_matching_rule,
+    parse_cli_ingress,
 };
 pub use crate::normalized::{NormalizationWarning, NormalizedConfig};
 pub use crate::raw_config::{RawConfig, WarpRoutingConfig};

--- a/crates/cloudflared-config/tests/README.md
+++ b/crates/cloudflared-config/tests/README.md
@@ -15,8 +15,9 @@ Current state:
 - Phase 1A fixture taxonomy and harness scaffolding exist
 - Phase 1B.2 can emit Rust actual artifacts for config discovery/loading fixtures
 - Phase 1B.3 can emit Rust actual artifacts for credentials/origin-cert fixtures
+- Phase 1B.4 can emit Rust actual artifacts for ingress normalization and ordering/defaulting fixtures
 - Go truth capture is not checked in yet
-- config and credentials behavior is only partially implemented
+- config, credentials, and ingress behavior are only partially implemented
 - Rust-versus-Go parity is not complete yet
 
 Phase 1A outputs in this directory:
@@ -25,7 +26,7 @@ Phase 1A outputs in this directory:
 - a checked-in golden artifact contract for future Go truth and Rust actuals
 - Rust-side helper scaffolding and ignored parity test entrypoints
 - an external runner entrypoint at `tools/first_slice_parity.py`
-- a Rust actual emission path for targeted Phase 1B.2 and Phase 1B.3 fixture categories
+- a Rust actual emission path for the currently implemented first-slice fixture categories
 
 Current execution model:
 
@@ -33,7 +34,7 @@ Current execution model:
 - `python3 tools/first_slice_parity.py check-go-truth` fails until Go truth JSON
  is captured under `tests/fixtures/first-slice/golden/go-truth/`
 - `python3 tools/first_slice_parity.py emit-rust-actual` writes readable JSON
- artifacts for the currently implemented config and credentials fixtures
+ artifacts for the currently implemented config, credentials, and ingress fixtures
 - `cargo test -p cloudflared-config` validates the fixture inventory and keeps
  ignored parity tests visible without claiming passing parity
 

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
@@ -3,10 +3,11 @@
 This directory is reserved for canonical JSON emitted by the Rust-side first
 slice harness path.
 
-Current state after Phase 1B.3:
+Current state after Phase 1B.4:
 
 - config discovery and config loading fixtures can emit Rust actual reports
 - credentials/origin-cert fixtures can emit Rust actual reports
+- ingress normalization and ordering/defaulting fixtures can emit Rust actual reports
 - the files are generated via `python3 tools/first_slice_parity.py emit-rust-actual`
 - the output remains incomplete for first-slice categories that are still out of
  scope for this phase

--- a/crates/cloudflared-config/tests/phase_1b4_ingress.rs
+++ b/crates/cloudflared-config/tests/phase_1b4_ingress.rs
@@ -1,0 +1,139 @@
+#![allow(unused_crate_dependencies)]
+
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use cloudflared_config::{
+    ConfigError, ConfigSource, IngressService, find_matching_rule, load_normalized_config, parse_cli_ingress,
+};
+
+#[path = "support/mod.rs"]
+mod support;
+
+fn temp_dir(name: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("cloudflared-config-{name}-{unique}"));
+    fs::create_dir_all(&path).expect("temp directory should be created");
+    path
+}
+
+#[test]
+fn basic_named_tunnel_fixture_matches_first_rule_then_catch_all() {
+    let fixture = support::fixtures_root().join("yaml-config/valid/basic_named_tunnel.yaml");
+    let normalized = load_normalized_config(
+        &fixture,
+        ConfigSource::DiscoveredPath("yaml-config/valid/basic_named_tunnel.yaml".into()),
+    )
+    .expect("fixture should normalize");
+
+    assert_eq!(
+        find_matching_rule(&normalized.ingress, "tunnel1.example.com", "/id"),
+        Some(0)
+    );
+    assert_eq!(
+        find_matching_rule(&normalized.ingress, "tunnel1.example.com:443", "/other"),
+        Some(1)
+    );
+    assert_eq!(
+        find_matching_rule(&normalized.ingress, "unknown.example.com", "/id"),
+        Some(1)
+    );
+}
+
+#[test]
+fn unicode_ingress_fixture_matches_punycode_hostname() {
+    let fixture = support::fixtures_root().join("yaml-config/valid/unicode_ingress.yaml");
+    let normalized = load_normalized_config(
+        &fixture,
+        ConfigSource::DiscoveredPath("yaml-config/valid/unicode_ingress.yaml".into()),
+    )
+    .expect("fixture should normalize");
+
+    assert_eq!(
+        find_matching_rule(&normalized.ingress, "xn--m-xgaa.cloudflare.com", "/"),
+        Some(0)
+    );
+}
+
+#[test]
+fn cli_origin_url_http_normalizes_to_http_service() {
+    let ingress =
+        parse_cli_ingress(&["--url=http://localhost:8080".to_owned()]).expect("cli origin should normalize");
+
+    assert_eq!(ingress.rules.len(), 1);
+    match &ingress.rules[0].service {
+        IngressService::Http(url) => {
+            assert_eq!(url.scheme(), "http");
+            assert_eq!(url.host_str(), Some("localhost"));
+            assert_eq!(url.port(), Some(8080));
+        }
+        other => panic!("expected HTTP service, found {other:?}"),
+    }
+}
+
+#[test]
+fn cli_origin_no_origin_returns_expected_error_category() {
+    let error = parse_cli_ingress(&[]).expect_err("missing CLI origin should fail");
+
+    assert!(matches!(error, ConfigError::NoIngressRulesCli));
+    assert_eq!(error.category(), "no-ingress-rules-cli");
+}
+
+#[test]
+fn harness_can_emit_ingress_related_rust_actual_artifacts() {
+    let output_dir = temp_dir("rust-actual-ingress");
+    let output = Command::new("python3")
+        .arg(support::tool_path())
+        .arg("emit-rust-actual")
+        .arg("--output-dir")
+        .arg(&output_dir)
+        .arg("--fixture-id")
+        .arg("cli-origin-hello-world")
+        .arg("--fixture-id")
+        .arg("cli-origin-no-origin")
+        .arg("--fixture-id")
+        .arg("ordering-catch-all-last")
+        .output()
+        .expect("python3 should be available to run the first-slice parity harness");
+
+    assert!(
+        output.status.success(),
+        "expected rust actual emission to succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let cli_artifact = output_dir.join("cli-origin-hello-world.json");
+    let cli_payload: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&cli_artifact).expect("CLI artifact should be readable"))
+            .expect("CLI artifact should be valid json");
+    assert_eq!(cli_payload["report_kind"], "ingress-report.v1");
+    assert_eq!(
+        cli_payload["payload"]["rules"][0]["service"]["kind"],
+        "hello-world"
+    );
+
+    let cli_error_artifact = output_dir.join("cli-origin-no-origin.json");
+    let cli_error_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&cli_error_artifact).expect("CLI error artifact should be readable"),
+    )
+    .expect("CLI error artifact should be valid json");
+    assert_eq!(cli_error_payload["report_kind"], "error-report.v1");
+    assert_eq!(cli_error_payload["payload"]["category"], "no-ingress-rules-cli");
+
+    let ordering_artifact = output_dir.join("ordering-catch-all-last.json");
+    let ordering_payload: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&ordering_artifact).expect("ordering artifact should be readable"),
+    )
+    .expect("ordering artifact should be valid json");
+    assert_eq!(ordering_payload["report_kind"], "normalized-config.v1");
+    assert_eq!(
+        ordering_payload["payload"]["ingress"][1]["service"]["kind"],
+        "http"
+    );
+
+    fs::remove_dir_all(output_dir).expect("temp directory should be removable");
+}

--- a/tools/first_slice_parity.py
+++ b/tools/first_slice_parity.py
@@ -20,6 +20,7 @@ RUST_ACTUAL_DIR = FIXTURE_ROOT / "golden" / "rust-actual"
 SUPPORTED_RUST_ACTUAL_CATEGORIES = {
     "config-discovery",
     "credentials-origin-cert",
+    "ingress-normalization",
     "yaml-config",
     "invalid-input",
     "ordering-defaulting",
@@ -333,6 +334,10 @@ def build_emission_fixture(fixture: Fixture) -> dict[str, object]:
         payload["discovery_case"] = load_discovery_case(fixture.fixture_id)
     if fixture.category == "credentials-origin-cert":
         payload["origin_cert_source"] = load_origin_cert_source(fixture.fixture_id)
+    if fixture.category == "ordering-defaulting":
+        payload["ordering_case"] = load_ordering_case(fixture.fixture_id)
+    if fixture.category == "ingress-normalization":
+        payload["cli_ingress_case"] = load_cli_ingress_case(fixture.fixture_id)
     return payload
 
 
@@ -361,6 +366,34 @@ def load_origin_cert_source(fixture_id: str) -> str:
             return str(source["path"])
 
     raise SystemExit(f"missing credentials source for fixture {fixture_id}")
+
+
+def load_ordering_case(fixture_id: str) -> dict[str, object]:
+    cases_path = FIXTURE_ROOT / "ordering-defaulting" / "cases.toml"
+    with cases_path.open("rb") as handle:
+        raw = tomllib.load(handle)
+
+    for case in raw.get("case", []):
+        if case.get("id") == fixture_id:
+            return {
+                "input": str(case["input"]),
+            }
+
+    raise SystemExit(f"missing ordering/defaulting case for fixture {fixture_id}")
+
+
+def load_cli_ingress_case(fixture_id: str) -> dict[str, object]:
+    cases_path = FIXTURE_ROOT / "ingress-normalization" / "cases.toml"
+    with cases_path.open("rb") as handle:
+        raw = tomllib.load(handle)
+
+    for case in raw.get("case", []):
+        if case.get("id") == fixture_id:
+            return {
+                "flags": list(case.get("flags", [])),
+            }
+
+    raise SystemExit(f"missing ingress-normalization case for fixture {fixture_id}")
 
 
 def display_repo_relative(path: Path) -> str:


### PR DESCRIPTION
## What this PR does

This PR makes the ingress path real for the current first-slice fixtures.

It adds ingress normalization, deterministic matching, narrow CLI single-origin synthesis, and Rust actual artifact emission for the targeted ingress-related cases.

## Included in this PR

- ingress validation and normalization for the current fixture surface
- deterministic first-match behavior with catch-all fallback
- punycode-aware hostname matching for the current IDN fixture path
- preserved no-ingress default 503 contract
- narrow CLI single-origin normalization for `--hello-world`, `--bastion`, `--url`, and `--unix-socket`
- Rust actual artifact emission for targeted ingress-related fixtures

## Scope

This stays within the accepted first slice, focused on ingress normalization and matching.

## Not included

This PR does not cover:
- transport or proxying
- runtime/supervisor work
- internal ingress-rule behavior
- full regex-path matching semantics
- Go truth capture
- full first-slice parity completion

## Why now

The earlier Phase 1B #4 steps made config loading and origin-cert handling real.

This PR closes the remaining behavior-heavy part of the first slice by making ingress normalization and targeted matching executable without widening into runtime work.

## Current status after this PR

What exists after this:
- real config-loading behavior for targeted fixtures
- real origin-cert behavior for targeted fixtures
- real ingress normalization and targeted matching behavior
- Rust actual artifact emission across those paths

What still comes next:
- Go truth capture
- broader parity comparison
- remaining first-slice gaps outside the current fixture surface