### PR TITLE
rust-rewrite: add phase 1b.5 truth capture & compare harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Cloudflared — Go → Rust Rewrite
 
-Cloudflare's command-line tunneling daemon. This branch (`fork/rust-rewrite`)
-tracks the production-grade rewrite from Go to Rust.
+Cloudflare's command-line tunneling daemon. This branch (`main`) tracks the
+production-grade rewrite from Go to Rust.
 
 - **Reference version**: `2026.2.0` (Go implementation in `baseline-2026.2.0/old-impl/`)
 - **Primary target**: `x86_64-unknown-linux-gnu`

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,8 +8,9 @@ implementation and an intentionally narrow Rust first slice.
 It is not yet a parity-complete Rust implementation workspace. The repository
 now contains a Cargo workspace skeleton plus early first-slice behavior in
 `crates/cloudflared-config/` for config discovery/loading and credentials
-origin-cert decoding, plus narrow ingress normalization and matching behavior,
-but most subsystem behavior is still unported.
+origin-cert decoding, narrow ingress normalization and matching behavior, and a
+real first-slice Go-truth and compare harness path, but most subsystem
+behavior is still unported.
 
 The scaffold is intentionally real but minimal:
 
@@ -121,7 +122,7 @@ These items are still missing before MCP-assisted or large-scale subsystem work
 should begin:
 
 - accepted compatibility-scope decision for FIPS/compliance
-- captured Go truth outputs and passing first-slice parity tests
+- passing first-slice parity tests
 
 ## Phase 1A Groundwork
 
@@ -137,7 +138,6 @@ What exists now:
 
 What does not exist yet:
 
-- captured Go truth outputs
 - passing Rust-versus-Go parity reports
 - complete config, credential, or ingress behavior
 - passing first-slice parity comparisons
@@ -253,6 +253,48 @@ Implication:
 - the accepted first slice now has a real ingress normalization and matching
   path in Rust for the current fixture surface
 - the repository still must not claim first-slice parity is complete
+
+## Phase 1B.5 Go Truth Capture And Real Compare Path
+
+Phase 1B.5 harness behavior now exists for the accepted first-slice fixture
+surface.
+
+What exists now:
+
+- checked-in Go truth artifacts under
+  `crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/` for
+  all 21 accepted first-slice fixtures
+- a source-backed `capture-go-truth` workflow that stages a small Go helper in
+  a temporary module and imports the frozen Go baseline via `replace`
+- a real `compare` workflow that emits fresh Rust actual artifacts and compares
+  them against the checked-in Go truth artifacts
+- explicit mismatch reporting for exact, error-category, structural, semantic,
+  and warning-or-report comparison modes
+- a passing Go-truth presence gate and a passing real-compare smoke subset in
+  the Rust test suite
+
+What does not exist yet:
+
+- all-green first-slice parity
+- reconciled exact JSON parity for several config and CLI ingress fixtures
+- a promoted policy for canonicalizing representation-only differences such as
+  `90s` versus `1m30s` in artifact comparison
+
+Current mismatch clusters from the full compare run:
+
+- config-backed ingress fixtures still diverge because Rust does not yet carry
+  Go effective `originRequest` defaults and inherited IP rules into the per-rule
+  normalized artifact shape
+- CLI single-origin ingress fixtures still diverge on default field
+  representation, including `false` versus `null`, `0` versus `null`, and
+  `1m30s` versus `90s`
+
+Implication:
+
+- the repository now has a real first-slice parity loop rather than a Rust-only
+  artifact scaffold
+- the repository still must not claim first-slice parity is complete while the
+  full compare continues to report live mismatches
 
 ## First Implementation Gate
 

--- a/crates/cloudflared-config/examples/first_slice_emit.rs
+++ b/crates/cloudflared-config/examples/first_slice_emit.rs
@@ -103,16 +103,18 @@ fn emit_ordering_fixture(
     fixture_root: &Path,
     fixture: &FixtureSpec,
 ) -> Result<cloudflared_config::artifact::ArtifactEnvelope, Box<dyn std::error::Error>> {
-    let Some(ordering_case) = fixture.ordering_case.as_ref() else {
-        return Err(format!("fixture {} is missing ordering case data", fixture.fixture_id).into());
-    };
+    let input = fixture
+        .ordering_case
+        .as_ref()
+        .map(|ordering_case| ordering_case.input.as_str())
+        .unwrap_or(fixture.input.as_str());
 
-    let input_path = fixture_root.join(&ordering_case.input);
-    let source = ConfigSource::DiscoveredPath(PathBuf::from(&ordering_case.input));
+    let input_path = fixture_root.join(input);
+    let source = ConfigSource::DiscoveredPath(PathBuf::from(input));
     match load_normalized_config(&input_path, source) {
         Ok(normalized) => Ok(normalized_config_envelope(
             fixture,
-            Path::new(&ordering_case.input),
+            Path::new(input),
             &normalized,
         )?),
         Err(error) => Ok(error_envelope(fixture, &error)?),

--- a/crates/cloudflared-config/src/discovery.rs
+++ b/crates/cloudflared-config/src/discovery.rs
@@ -177,9 +177,10 @@ pub fn minimal_auto_create_config(log_directory: &std::path::Path) -> String {
 }
 
 pub fn default_nix_search_directories() -> Vec<PathBuf> {
+    let home_directory = home_directory();
     DEFAULT_NIX_SEARCH_DIRECTORIES
         .into_iter()
-        .map(PathBuf::from)
+        .map(|directory| expand_leading_tilde(directory, home_directory.as_deref()))
         .collect()
 }
 
@@ -191,12 +192,38 @@ pub fn default_nix_log_directory() -> PathBuf {
     PathBuf::from(DEFAULT_NIX_PRIMARY_LOG_DIR)
 }
 
+fn home_directory() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn expand_leading_tilde(path: &str, home_directory: Option<&std::path::Path>) -> PathBuf {
+    if path == "~"
+        && let Some(home_directory) = home_directory
+    {
+        return home_directory.to_path_buf();
+    }
+
+    if let Some(remainder) = path.strip_prefix("~/")
+        && let Some(home_directory) = home_directory
+    {
+        return home_directory.join(remainder);
+    }
+
+    PathBuf::from(path)
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{DiscoveryAction, DiscoveryDefaults, DiscoveryOrigin, DiscoveryRequest};
+    use super::{
+        DiscoveryAction, DiscoveryDefaults, DiscoveryOrigin, DiscoveryRequest,
+        default_nix_search_directories, expand_leading_tilde, home_directory,
+    };
 
     fn temp_dir(name: &str) -> std::path::PathBuf {
         let unique = SystemTime::now()
@@ -212,13 +239,54 @@ mod tests {
     fn candidate_paths_follow_known_search_order() {
         let request = DiscoveryRequest::default();
         let candidates = request.candidate_paths();
+        let home_directory = home_directory();
 
         assert_eq!(candidates[0].origin, DiscoveryOrigin::Search);
-        assert_eq!(candidates[0].path.to_string_lossy(), "~/.cloudflared/config.yml");
-        assert_eq!(candidates[1].path.to_string_lossy(), "~/.cloudflared/config.yaml");
         assert_eq!(
-            candidates[2].path.to_string_lossy(),
-            "~/.cloudflare-warp/config.yml"
+            candidates[0].path,
+            expand_leading_tilde("~/.cloudflared", home_directory.as_deref()).join("config.yml")
+        );
+        assert_eq!(
+            candidates[1].path,
+            expand_leading_tilde("~/.cloudflared", home_directory.as_deref()).join("config.yaml")
+        );
+        assert_eq!(
+            candidates[2].path,
+            expand_leading_tilde("~/.cloudflare-warp", home_directory.as_deref()).join("config.yml")
+        );
+    }
+
+    #[test]
+    fn default_search_directories_expand_home_prefix_only() {
+        let directories = default_nix_search_directories();
+        if let Some(home_directory) = home_directory() {
+            assert_eq!(directories[0], home_directory.join(".cloudflared"));
+            assert_eq!(directories[1], home_directory.join(".cloudflare-warp"));
+            assert_eq!(directories[2], home_directory.join("cloudflare-warp"));
+        } else {
+            assert_eq!(directories[0], PathBuf::from("~/.cloudflared"));
+            assert_eq!(directories[1], PathBuf::from("~/.cloudflare-warp"));
+            assert_eq!(directories[2], PathBuf::from("~/cloudflare-warp"));
+        }
+        assert_eq!(directories[3], PathBuf::from("/etc/cloudflared"));
+        assert_eq!(directories[4], PathBuf::from("/usr/local/etc/cloudflared"));
+    }
+
+    #[test]
+    fn expand_leading_tilde_does_not_expand_other_patterns() {
+        let home_directory = PathBuf::from("/tmp/home");
+
+        assert_eq!(
+            expand_leading_tilde("~/.cloudflared", Some(home_directory.as_path())),
+            home_directory.join(".cloudflared")
+        );
+        assert_eq!(
+            expand_leading_tilde("~other/.cloudflared", Some(home_directory.as_path())),
+            PathBuf::from("~other/.cloudflared")
+        );
+        assert_eq!(
+            expand_leading_tilde("/etc/cloudflared", Some(home_directory.as_path())),
+            PathBuf::from("/etc/cloudflared")
         );
     }
 

--- a/crates/cloudflared-config/tests/README.md
+++ b/crates/cloudflared-config/tests/README.md
@@ -16,7 +16,8 @@ Current state:
 - Phase 1B.2 can emit Rust actual artifacts for config discovery/loading fixtures
 - Phase 1B.3 can emit Rust actual artifacts for credentials/origin-cert fixtures
 - Phase 1B.4 can emit Rust actual artifacts for ingress normalization and ordering/defaulting fixtures
-- Go truth capture is not checked in yet
+- Phase 1B.5 has checked-in Go truth artifacts for the accepted first-slice fixture surface
+- Phase 1B.5 compare mode now runs a real Rust-versus-Go comparison for that surface
 - config, credentials, and ingress behavior are only partially implemented
 - Rust-versus-Go parity is not complete yet
 
@@ -31,12 +32,16 @@ Phase 1A outputs in this directory:
 Current execution model:
 
 - `python3 tools/first_slice_parity.py inventory` shows the accepted fixture set
-- `python3 tools/first_slice_parity.py check-go-truth` fails until Go truth JSON
- is captured under `tests/fixtures/first-slice/golden/go-truth/`
+- `python3 tools/first_slice_parity.py capture-go-truth` refreshes the checked-in
+ Go truth JSON artifacts under `tests/fixtures/first-slice/golden/go-truth/`
+- `python3 tools/first_slice_parity.py check-go-truth` now verifies that every
+ accepted fixture has a checked-in Go truth artifact
 - `python3 tools/first_slice_parity.py emit-rust-actual` writes readable JSON
  artifacts for the currently implemented config, credentials, and ingress fixtures
+- `python3 tools/first_slice_parity.py compare --require-go-truth --require-rust-actual`
+ now runs a real compare and exits nonzero when artifacts differ
 - `cargo test -p cloudflared-config` validates the fixture inventory and keeps
- ignored parity tests visible without claiming passing parity
+ the harness gate and a matching compare subset executable
 
 Source-of-truth rule:
 

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/README.md
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/README.md
@@ -1,9 +1,26 @@
 # Go Truth Outputs
 
-This directory is intentionally empty in Phase 1A.
+This directory now holds the checked-in Go truth artifacts for the accepted
+first-slice fixture surface.
 
-Future Go-capture runs must write one canonical JSON file per fixture ID using
-the envelope documented in `../schema/README.md`.
+The files are generated via:
+
+- `python3 tools/first_slice_parity.py capture-go-truth`
+
+Generation model:
+
+- the Python harness stages a small checked-in Go helper in a temporary module
+- that helper imports the frozen Go baseline from
+ `baseline-2026.2.0/old-impl/` using a local `replace`
+- the helper writes one canonical JSON file per fixture ID using the envelope
+ documented in `../schema/README.md`
 
 The first-slice harness must fail if a fixture is selected for comparison and
 its `go-truth/<fixture-id>.json` file is missing.
+
+Current truthfulness rule:
+
+- these artifacts make the compare loop real
+- they do not imply that Rust parity is complete
+- the full compare still reports live mismatches for part of the accepted
+ first-slice surface

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-bastion.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-bastion.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "fixture_id": "cli-origin-bastion",
+  "producer": "go-truth",
+  "report_kind": "ingress-report.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestSingleOriginServices/Valid bastion"
+  ],
+  "payload": {
+    "source_kind": "cli-single-origin",
+    "rule_count": 1,
+    "catch_all_rule_index": 0,
+    "defaults": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": true,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "rules": [
+      {
+        "hostname": null,
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "bastion"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": true,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ]
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-hello-world.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-hello-world.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "fixture_id": "cli-origin-hello-world",
+  "producer": "go-truth",
+  "report_kind": "ingress-report.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestSingleOriginServices/Valid hello-world"
+  ],
+  "payload": {
+    "source_kind": "cli-single-origin",
+    "rule_count": 1,
+    "catch_all_rule_index": 0,
+    "defaults": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "rules": [
+      {
+        "hostname": null,
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "hello-world"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ]
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-no-origin.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-no-origin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "fixture_id": "cli-origin-no-origin",
+  "producer": "go-truth",
+  "report_kind": "error-report.v1",
+  "comparison": "error-category",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestSingleOriginServices/No origins defined"
+  ],
+  "payload": {
+    "category": "no-ingress-rules-cli",
+    "message": "No ingress rules were defined in provided config (if any) nor from the cli, cloudflared will return 503 for all incoming HTTP requests"
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-unix-socket.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-unix-socket.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "fixture_id": "cli-origin-unix-socket",
+  "producer": "go-truth",
+  "report_kind": "ingress-report.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestSingleOriginServices/Unix socket"
+  ],
+  "payload": {
+    "source_kind": "cli-single-origin",
+    "rule_count": 1,
+    "catch_all_rule_index": 0,
+    "defaults": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "rules": [
+      {
+        "hostname": null,
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "unix-socket",
+          "path": "unix://service"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ]
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-url-http.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-url-http.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "fixture_id": "cli-origin-url-http",
+  "producer": "go-truth",
+  "report_kind": "ingress-report.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestSingleOriginServices_URL/http"
+  ],
+  "payload": {
+    "source_kind": "cli-single-origin",
+    "rule_count": 1,
+    "catch_all_rule_index": 0,
+    "defaults": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "rules": [
+      {
+        "hostname": null,
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "http",
+          "uri": "http://localhost:8080"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ]
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-url-tcp.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/cli-origin-url-tcp.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "fixture_id": "cli-origin-url-tcp",
+  "producer": "go-truth",
+  "report_kind": "ingress-report.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestSingleOriginServices_URL/tcp"
+  ],
+  "payload": {
+    "source_kind": "cli-single-origin",
+    "rule_count": 1,
+    "catch_all_rule_index": 0,
+    "defaults": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "rules": [
+      {
+        "hostname": null,
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "tcp-over-websocket",
+          "uri": "tcp://localhost:8080"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ]
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-basic-named-tunnel.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-basic-named-tunnel.json
@@ -1,0 +1,168 @@
+{
+  "schema_version": 1,
+  "fixture_id": "config-basic-named-tunnel",
+  "producer": "go-truth",
+  "report_kind": "normalized-config.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §3-§7",
+    "baseline-2026.2.0/old-impl/config/configuration_test.go::TestConfigFileSettings"
+  ],
+  "payload": {
+    "source_kind": "discovered-path",
+    "source_path": "yaml-config/valid/basic_named_tunnel.yaml",
+    "tunnel": {
+      "raw": "config-file-test",
+      "uuid": null
+    },
+    "credentials": {
+      "credentials_file": null,
+      "origin_cert": null,
+      "tunnel": {
+        "raw": "config-file-test",
+        "uuid": null
+      }
+    },
+    "ingress": [
+      {
+        "hostname": "tunnel1.example.com",
+        "punycode_hostname": null,
+        "path": "/id",
+        "service": {
+          "kind": "http",
+          "uri": "https://localhost:8000"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [
+            {
+              "prefix": "10.0.0.0/8",
+              "ports": [
+                80,
+                8080
+              ],
+              "allow": false
+            },
+            {
+              "prefix": "fc00::/7",
+              "ports": [
+                443,
+                4443
+              ],
+              "allow": true
+            }
+          ],
+          "http2Origin": false,
+          "access": null
+        }
+      },
+      {
+        "hostname": "*",
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "http",
+          "uri": "https://localhost:8001"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [
+            {
+              "prefix": "10.0.0.0/8",
+              "ports": [
+                80,
+                8080
+              ],
+              "allow": false
+            },
+            {
+              "prefix": "fc00::/7",
+              "ports": [
+                443,
+                4443
+              ],
+              "allow": true
+            }
+          ],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ],
+    "origin_request": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [
+        {
+          "prefix": "10.0.0.0/8",
+          "ports": [
+            80,
+            8080
+          ],
+          "allow": false
+        },
+        {
+          "prefix": "fc00::/7",
+          "ports": [
+            443,
+            4443
+          ],
+          "allow": true
+        }
+      ],
+      "http2Origin": false,
+      "access": null
+    },
+    "warp_routing": {
+      "connectTimeout": "2s",
+      "maxActiveFlows": null,
+      "tcpKeepAlive": "10s"
+    },
+    "log_directory": null,
+    "warnings": null
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-invalid-wildcard.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-invalid-wildcard.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "fixture_id": "config-invalid-wildcard",
+  "producer": "go-truth",
+  "report_kind": "error-report.v1",
+  "comparison": "error-category",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestParseIngress/Wildcard not at start"
+  ],
+  "payload": {
+    "category": "ingress-bad-wildcard",
+    "message": "Hostname patterns can have at most one wildcard character (\"*\") and it can only be used for subdomains, e.g. \"*.example.com\""
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-missing-catch-all.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-missing-catch-all.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "fixture_id": "config-missing-catch-all",
+  "producer": "go-truth",
+  "report_kind": "error-report.v1",
+  "comparison": "error-category",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestParseIngress/Last rule isn't catchall"
+  ],
+  "payload": {
+    "category": "ingress-last-rule-not-catch-all",
+    "message": "The last ingress rule must match all URLs (i.e. it should not have a hostname or path filter)"
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-no-ingress-minimal.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-no-ingress-minimal.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": 1,
+  "fixture_id": "config-no-ingress-minimal",
+  "producer": "go-truth",
+  "report_kind": "normalized-config.v1",
+  "comparison": "semantic",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §4.4",
+    "baseline-2026.2.0/old-impl/component-tests/test_tunnel.py::test_tunnel_no_ingress"
+  ],
+  "payload": {
+    "source_kind": "discovered-path",
+    "source_path": "yaml-config/edge/no_ingress_minimal.yaml",
+    "tunnel": {
+      "raw": "config-file-test",
+      "uuid": null
+    },
+    "credentials": {
+      "credentials_file": null,
+      "origin_cert": null,
+      "tunnel": {
+        "raw": "config-file-test",
+        "uuid": null
+      }
+    },
+    "ingress": [
+      {
+        "hostname": null,
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "http-status",
+          "status_code": 503
+        },
+        "origin_request": {
+          "connectTimeout": null,
+          "tlsTimeout": null,
+          "tcpKeepAlive": null,
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 0,
+          "keepAliveTimeout": null,
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": null,
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ],
+    "origin_request": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "warp_routing": {
+      "connectTimeout": null,
+      "maxActiveFlows": null,
+      "tcpKeepAlive": null
+    },
+    "log_directory": null,
+    "warnings": null
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-unicode-ingress.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-unicode-ingress.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": 1,
+  "fixture_id": "config-unicode-ingress",
+  "producer": "go-truth",
+  "report_kind": "normalized-config.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §4.2",
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestParseIngress/Unicode domain"
+  ],
+  "payload": {
+    "source_kind": "discovered-path",
+    "source_path": "yaml-config/valid/unicode_ingress.yaml",
+    "tunnel": null,
+    "credentials": {
+      "credentials_file": null,
+      "origin_cert": null,
+      "tunnel": null
+    },
+    "ingress": [
+      {
+        "hostname": "môô.cloudflare.com",
+        "punycode_hostname": "xn--m-xgaa.cloudflare.com",
+        "path": null,
+        "service": {
+          "kind": "http",
+          "uri": "https://localhost:8000"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      },
+      {
+        "hostname": null,
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "http",
+          "uri": "https://localhost:8001"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ],
+    "origin_request": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "warp_routing": {
+      "connectTimeout": null,
+      "maxActiveFlows": null,
+      "tcpKeepAlive": null
+    },
+    "log_directory": null,
+    "warnings": null
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-unknown-top-level-key.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/config-unknown-top-level-key.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": 1,
+  "fixture_id": "config-unknown-top-level-key",
+  "producer": "go-truth",
+  "report_kind": "normalized-config.v1",
+  "comparison": "warning-or-report",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §2.2"
+  ],
+  "payload": {
+    "source_kind": "discovered-path",
+    "source_path": "yaml-config/edge/unknown_top_level_key.yaml",
+    "tunnel": null,
+    "credentials": {
+      "credentials_file": null,
+      "origin_cert": null,
+      "tunnel": null
+    },
+    "ingress": [
+      {
+        "hostname": "*",
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "http",
+          "uri": "https://localhost:8000"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ],
+    "origin_request": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "warp_routing": {
+      "connectTimeout": null,
+      "maxActiveFlows": null,
+      "tcpKeepAlive": null
+    },
+    "log_directory": null,
+    "warnings": [
+      {
+        "kind": "unknown-top-level-keys",
+        "keys": [
+          "extraKey"
+        ]
+      }
+    ]
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/default-no-ingress-contract.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/default-no-ingress-contract.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": 1,
+  "fixture_id": "default-no-ingress-contract",
+  "producer": "go-truth",
+  "report_kind": "normalized-config.v1",
+  "comparison": "semantic",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §4.4"
+  ],
+  "payload": {
+    "source_kind": "discovered-path",
+    "source_path": "yaml-config/edge/no_ingress_minimal.yaml",
+    "tunnel": {
+      "raw": "config-file-test",
+      "uuid": null
+    },
+    "credentials": {
+      "credentials_file": null,
+      "origin_cert": null,
+      "tunnel": {
+        "raw": "config-file-test",
+        "uuid": null
+      }
+    },
+    "ingress": [
+      {
+        "hostname": null,
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "http-status",
+          "status_code": 503
+        },
+        "origin_request": {
+          "connectTimeout": null,
+          "tlsTimeout": null,
+          "tcpKeepAlive": null,
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 0,
+          "keepAliveTimeout": null,
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": null,
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ],
+    "origin_request": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [],
+      "http2Origin": false,
+      "access": null
+    },
+    "warp_routing": {
+      "connectTimeout": null,
+      "maxActiveFlows": null,
+      "tcpKeepAlive": null
+    },
+    "log_directory": null,
+    "warnings": null
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/discover-auto-create-default.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/discover-auto-create-default.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "fixture_id": "discover-auto-create-default",
+  "producer": "go-truth",
+  "report_kind": "discovery-report.v1",
+  "comparison": "structural",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §1.4"
+  ],
+  "payload": {
+    "action": "create-default-config",
+    "source_kind": "auto-created-path",
+    "resolved_path": "/usr/local/etc/cloudflared/config.yml",
+    "created_paths": [
+      "/usr/local/etc/cloudflared",
+      "/usr/local/etc/cloudflared/config.yml",
+      "/var/log/cloudflared"
+    ],
+    "written_config": "logDirectory: /tmp/cloudflared-go-discovery-4038361837/var/log/cloudflared\n"
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/discover-home-cloudflare-warp-legacy.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/discover-home-cloudflare-warp-legacy.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "fixture_id": "discover-home-cloudflare-warp-legacy",
+  "producer": "go-truth",
+  "report_kind": "discovery-report.v1",
+  "comparison": "exact",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §1-§2"
+  ],
+  "payload": {
+    "action": "use-existing",
+    "source_kind": "discovered-path",
+    "resolved_path": "/home/cloudflare-warp/config.yml",
+    "created_paths": [],
+    "written_config": null
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/discover-home-cloudflare-warp.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/discover-home-cloudflare-warp.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "fixture_id": "discover-home-cloudflare-warp",
+  "producer": "go-truth",
+  "report_kind": "discovery-report.v1",
+  "comparison": "exact",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §1-§2"
+  ],
+  "payload": {
+    "action": "use-existing",
+    "source_kind": "discovered-path",
+    "resolved_path": "/home/.cloudflare-warp/config.yaml",
+    "created_paths": [],
+    "written_config": null
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/discover-home-cloudflared.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/discover-home-cloudflared.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "fixture_id": "discover-home-cloudflared",
+  "producer": "go-truth",
+  "report_kind": "discovery-report.v1",
+  "comparison": "exact",
+  "source_refs": [
+    "baseline-2026.2.0/design-audit/REPO_CONFIG_CONTRACT.md §1-§2"
+  ],
+  "payload": {
+    "action": "use-existing",
+    "source_kind": "discovered-path",
+    "resolved_path": "/home/.cloudflared/config.yml",
+    "created_paths": [],
+    "written_config": null
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/ordering-catch-all-last.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/ordering-catch-all-last.json
@@ -1,0 +1,167 @@
+{
+  "schema_version": 1,
+  "fixture_id": "ordering-catch-all-last",
+  "producer": "go-truth",
+  "report_kind": "normalized-config.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/ingress/ingress_test.go::TestParseIngress/Default catch-all ordering"
+  ],
+  "payload": {
+    "source_kind": "discovered-path",
+    "source_path": "yaml-config/valid/basic_named_tunnel.yaml",
+    "tunnel": {
+      "raw": "config-file-test",
+      "uuid": null
+    },
+    "credentials": {
+      "credentials_file": null,
+      "origin_cert": null,
+      "tunnel": {
+        "raw": "config-file-test",
+        "uuid": null
+      }
+    },
+    "ingress": [
+      {
+        "hostname": "tunnel1.example.com",
+        "punycode_hostname": null,
+        "path": "/id",
+        "service": {
+          "kind": "http",
+          "uri": "https://localhost:8000"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [
+            {
+              "prefix": "10.0.0.0/8",
+              "ports": [
+                80,
+                8080
+              ],
+              "allow": false
+            },
+            {
+              "prefix": "fc00::/7",
+              "ports": [
+                443,
+                4443
+              ],
+              "allow": true
+            }
+          ],
+          "http2Origin": false,
+          "access": null
+        }
+      },
+      {
+        "hostname": "*",
+        "punycode_hostname": null,
+        "path": null,
+        "service": {
+          "kind": "http",
+          "uri": "https://localhost:8001"
+        },
+        "origin_request": {
+          "connectTimeout": "30s",
+          "tlsTimeout": "10s",
+          "tcpKeepAlive": "30s",
+          "noHappyEyeballs": false,
+          "keepAliveConnections": 100,
+          "keepAliveTimeout": "1m30s",
+          "httpHostHeader": null,
+          "originServerName": null,
+          "matchSNItoHost": false,
+          "caPool": null,
+          "noTLSVerify": false,
+          "disableChunkedEncoding": false,
+          "bastionMode": false,
+          "proxyAddress": "127.0.0.1",
+          "proxyPort": 0,
+          "proxyType": null,
+          "ipRules": [
+            {
+              "prefix": "10.0.0.0/8",
+              "ports": [
+                80,
+                8080
+              ],
+              "allow": false
+            },
+            {
+              "prefix": "fc00::/7",
+              "ports": [
+                443,
+                4443
+              ],
+              "allow": true
+            }
+          ],
+          "http2Origin": false,
+          "access": null
+        }
+      }
+    ],
+    "origin_request": {
+      "connectTimeout": "30s",
+      "tlsTimeout": "10s",
+      "tcpKeepAlive": "30s",
+      "noHappyEyeballs": false,
+      "keepAliveConnections": 100,
+      "keepAliveTimeout": "1m30s",
+      "httpHostHeader": null,
+      "originServerName": null,
+      "matchSNItoHost": false,
+      "caPool": null,
+      "noTLSVerify": false,
+      "disableChunkedEncoding": false,
+      "bastionMode": false,
+      "proxyAddress": "127.0.0.1",
+      "proxyPort": 0,
+      "proxyType": null,
+      "ipRules": [
+        {
+          "prefix": "10.0.0.0/8",
+          "ports": [
+            80,
+            8080
+          ],
+          "allow": false
+        },
+        {
+          "prefix": "fc00::/7",
+          "ports": [
+            443,
+            4443
+          ],
+          "allow": true
+        }
+      ],
+      "http2Origin": false,
+      "access": null
+    },
+    "warp_routing": {
+      "connectTimeout": "2s",
+      "maxActiveFlows": null,
+      "tcpKeepAlive": "10s"
+    },
+    "log_directory": null,
+    "warnings": null
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/origin-cert-json-token.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/origin-cert-json-token.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "fixture_id": "origin-cert-json-token",
+  "producer": "go-truth",
+  "report_kind": "credential-report.v1",
+  "comparison": "exact-json",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/credentials/credentials_test.go::TestCredentialsRead",
+    "baseline-2026.2.0/old-impl/credentials/origin_cert_test.go::TestJSONArgoTunnelToken"
+  ],
+  "payload": {
+    "kind": "origin-cert-pem",
+    "source_path": "baseline-2026.2.0/old-impl/credentials/test-cloudflare-tunnel-cert-json.pem",
+    "zone_id": "7b0a4d77dfb881c1a3b7d61ea9443e19",
+    "account_id": "abcdabcdabcdabcd1234567890abcdef",
+    "api_token": "test-service-key",
+    "endpoint": null,
+    "is_fed_endpoint": false
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/origin-cert-missing-token.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/origin-cert-missing-token.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "fixture_id": "origin-cert-missing-token",
+  "producer": "go-truth",
+  "report_kind": "error-report.v1",
+  "comparison": "error-category",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/credentials/origin_cert_test.go::TestJSONArgoTunnelTokenEmpty"
+  ],
+  "payload": {
+    "category": "origin-cert-missing-token",
+    "message": "Error decoding origin cert: missing token in the certificate"
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/origin-cert-unknown-block.json
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/origin-cert-unknown-block.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "fixture_id": "origin-cert-unknown-block",
+  "producer": "go-truth",
+  "report_kind": "error-report.v1",
+  "comparison": "error-category",
+  "source_refs": [
+    "baseline-2026.2.0/old-impl/credentials/origin_cert_test.go::TestLoadOriginCert"
+  ],
+  "payload": {
+    "category": "origin-cert-unknown-block",
+    "message": "Error decoding origin cert: unknown block RSA PRIVATE KEY in the certificate"
+  }
+}

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
@@ -3,12 +3,13 @@
 This directory is reserved for canonical JSON emitted by the Rust-side first
 slice harness path.
 
-Current state after Phase 1B.4:
+Current state after Phase 1B.5:
 
 - config discovery and config loading fixtures can emit Rust actual reports
 - credentials/origin-cert fixtures can emit Rust actual reports
 - ingress normalization and ordering/defaulting fixtures can emit Rust actual reports
 - the files are generated via `python3 tools/first_slice_parity.py emit-rust-actual`
+- the compare workflow can also emit fresh temporary Rust actual artifacts on demand
 - the output remains incomplete for first-slice categories that are still out of
  scope for this phase
 

--- a/crates/cloudflared-config/tests/phase_1a_parity_scaffold.rs
+++ b/crates/cloudflared-config/tests/phase_1a_parity_scaffold.rs
@@ -13,8 +13,7 @@ fn harness_runner_exists() {
 }
 
 #[test]
-#[ignore = "Phase 1A establishes scaffolding only; Go truth capture is pending"]
-fn go_truth_capture_gate_is_explicit() {
+fn go_truth_capture_gate_is_real() {
     let output = Command::new("python3")
         .arg(support::tool_path())
         .arg("check-go-truth")
@@ -29,19 +28,24 @@ fn go_truth_capture_gate_is_explicit() {
 }
 
 #[test]
-#[ignore = "Phase 1B will start emitting Rust-side reports for comparison"]
-fn rust_parity_compare_entrypoint_is_reserved() {
+fn rust_parity_compare_entrypoint_is_real_for_matching_subset() {
     let output = Command::new("python3")
         .arg(support::tool_path())
         .arg("compare")
         .arg("--require-go-truth")
         .arg("--require-rust-actual")
+        .arg("--fixture-id")
+        .arg("discover-home-cloudflared")
+        .arg("--fixture-id")
+        .arg("origin-cert-json-token")
+        .arg("--fixture-id")
+        .arg("cli-origin-no-origin")
         .output()
         .expect("python3 should be available to run the first-slice parity harness");
 
     assert!(
         output.status.success(),
-        "expected compare mode to pass once Go truth and Rust actual reports exist; stderr:\n{}",
+        "expected compare mode to pass for a matching subset; stderr:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -27,7 +27,8 @@ Dependencies are admitted only when all of the following are true:
 
 ## Current Workspace Rule
 
-The current workspace is a scaffold, not a partial runtime.
+The current workspace is still intentionally narrow, but it is no longer an
+empty scaffold.
 
 That means:
 
@@ -35,20 +36,26 @@ That means:
   manifests before code using them exists
 - placeholder crates may remain dependency-free when they contain only module
   docs
-- policy documents may describe later-approved libraries without preloading them
-  into `Cargo.toml`
+- admitted dependencies should stay confined to the crates that own the active
+  slice rather than being preloaded repo-wide
 
 ## Current Admitted Dependencies
 
-The current scaffold admits only one external runtime dependency in manifests:
+The current manifests admit only the dependencies needed by the binary runtime
+baseline and the active first-slice config implementation:
 
-- `mimalloc` in the runnable binary crate
+- `mimalloc` in `cloudflared-cli`
+- `serde`, `serde_json`, `serde_yaml`, `url`, `uuid`, and `thiserror` in
+  `cloudflared-config`
 
 Reason:
 
-- allocator policy is a process-wide runtime baseline
-- the binary exists today and can own allocator choice honestly
-- libraries must not set the global allocator
+- allocator policy is still a process-wide runtime baseline owned by the binary
+- config, credential, and ingress normalization work is active in
+  `cloudflared-config`, so its admitted slice dependencies now exist honestly in
+  manifests
+- libraries still must not set the global allocator or preload later-slice
+  dependencies speculatively
 
 ## Deferred Dependency Buckets
 

--- a/tools/first_slice_go_capture/main.go
+++ b/tools/first_slice_go_capture/main.go
@@ -1,0 +1,761 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cloudflare/cloudflared/config"
+	cfcredentials "github.com/cloudflare/cloudflared/credentials"
+	"github.com/cloudflare/cloudflared/ingress"
+	"github.com/rs/zerolog"
+	"github.com/urfave/cli/v2"
+	yaml "gopkg.in/yaml.v3"
+	"golang.org/x/net/idna"
+)
+
+const schemaVersion = 1
+
+type emissionPlan struct {
+	RepoRoot    string        `json:"repo_root"`
+	FixtureRoot string        `json:"fixture_root"`
+	OutputDir   string        `json:"output_dir"`
+	Fixtures    []fixtureSpec `json:"fixtures"`
+}
+
+type fixtureSpec struct {
+	FixtureID        string         `json:"fixture_id"`
+	Category         string         `json:"category"`
+	Comparison       string         `json:"comparison"`
+	Input            string         `json:"input"`
+	SourceRefs       []string       `json:"source_refs"`
+	DiscoveryCase    *discoveryCase `json:"discovery_case,omitempty"`
+	OriginCertSource *string        `json:"origin_cert_source,omitempty"`
+	OrderingCase     *orderingCase  `json:"ordering_case,omitempty"`
+	CliIngressCase   *cliIngressCase `json:"cli_ingress_case,omitempty"`
+}
+
+type discoveryCase struct {
+	ExplicitConfig bool     `json:"explicit_config"`
+	Present        []string `json:"present"`
+}
+
+type orderingCase struct {
+	Input string `json:"input"`
+}
+
+type cliIngressCase struct {
+	Flags []string `json:"flags"`
+}
+
+type artifactEnvelope struct {
+	SchemaVersion uint32          `json:"schema_version"`
+	FixtureID     string          `json:"fixture_id"`
+	Producer      string          `json:"producer"`
+	ReportKind    string          `json:"report_kind"`
+	Comparison    string          `json:"comparison"`
+	SourceRefs    []string        `json:"source_refs"`
+	Payload       json.RawMessage `json:"payload"`
+}
+
+type discoveryReportPayload struct {
+	Action       string   `json:"action"`
+	SourceKind   string   `json:"source_kind"`
+	ResolvedPath string   `json:"resolved_path"`
+	CreatedPaths []string `json:"created_paths"`
+	WrittenConfig *string `json:"written_config"`
+}
+
+type errorReportPayload struct {
+	Category string `json:"category"`
+	Message  string `json:"message"`
+}
+
+type credentialReportPayload struct {
+	Kind          string  `json:"kind"`
+	SourcePath    string  `json:"source_path"`
+	ZoneID        string  `json:"zone_id"`
+	AccountID     string  `json:"account_id"`
+	APIToken      string  `json:"api_token"`
+	Endpoint      *string `json:"endpoint"`
+	IsFedEndpoint bool    `json:"is_fed_endpoint"`
+}
+
+type ingressReportPayload struct {
+	SourceKind        string               `json:"source_kind"`
+	RuleCount         int                  `json:"rule_count"`
+	CatchAllRuleIndex int                  `json:"catch_all_rule_index"`
+	Defaults         originRequestPayload `json:"defaults"`
+	Rules            []ingressRulePayload `json:"rules"`
+}
+
+type normalizedConfigPayload struct {
+	SourceKind    string                   `json:"source_kind"`
+	SourcePath    string                   `json:"source_path"`
+	Tunnel        *tunnelReferencePayload  `json:"tunnel"`
+	Credentials   credentialSurfacePayload `json:"credentials"`
+	Ingress       []ingressRulePayload     `json:"ingress"`
+	OriginRequest originRequestPayload     `json:"origin_request"`
+	WarpRouting   warpRoutingPayload       `json:"warp_routing"`
+	LogDirectory  *string                  `json:"log_directory"`
+	Warnings      []warningPayload         `json:"warnings"`
+}
+
+type tunnelReferencePayload struct {
+	Raw  string  `json:"raw"`
+	UUID *string `json:"uuid"`
+}
+
+type credentialSurfacePayload struct {
+	CredentialsFile *string                   `json:"credentials_file"`
+	OriginCert      *originCertLocatorPayload `json:"origin_cert"`
+	Tunnel          *tunnelReferencePayload   `json:"tunnel"`
+}
+
+type originCertLocatorPayload struct {
+	Kind string `json:"kind"`
+	Path string `json:"path"`
+}
+
+type ingressRulePayload struct {
+	Hostname         *string              `json:"hostname"`
+	PunycodeHostname *string              `json:"punycode_hostname"`
+	Path             *string              `json:"path"`
+	Service          ingressServicePayload `json:"service"`
+	OriginRequest    originRequestPayload `json:"origin_request"`
+}
+
+type ingressServicePayload struct {
+	Kind       string  `json:"kind"`
+	URI        *string `json:"uri,omitempty"`
+	Path       *string `json:"path,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	StatusCode *int    `json:"status_code,omitempty"`
+}
+
+type warningPayload struct {
+	Kind string   `json:"kind"`
+	Keys []string `json:"keys"`
+}
+
+type warpRoutingPayload struct {
+	ConnectTimeout *string `json:"connectTimeout"`
+	MaxActiveFlows *uint64 `json:"maxActiveFlows"`
+	TCPKeepAlive   *string `json:"tcpKeepAlive"`
+}
+
+type originRequestPayload struct {
+	ConnectTimeout         *string             `json:"connectTimeout"`
+	TLSTimeout             *string             `json:"tlsTimeout"`
+	TCPKeepAlive           *string             `json:"tcpKeepAlive"`
+	NoHappyEyeballs        *bool               `json:"noHappyEyeballs"`
+	KeepAliveConnections   *int                `json:"keepAliveConnections"`
+	KeepAliveTimeout       *string             `json:"keepAliveTimeout"`
+	HTTPHostHeader         *string             `json:"httpHostHeader"`
+	OriginServerName       *string             `json:"originServerName"`
+	MatchSNIToHost         *bool               `json:"matchSNItoHost"`
+	CAPool                 *string             `json:"caPool"`
+	NoTLSVerify            *bool               `json:"noTLSVerify"`
+	DisableChunkedEncoding *bool               `json:"disableChunkedEncoding"`
+	BastionMode            *bool               `json:"bastionMode"`
+	ProxyAddress           *string             `json:"proxyAddress"`
+	ProxyPort              *uint               `json:"proxyPort"`
+	ProxyType              *string             `json:"proxyType"`
+	IPRules                []ingressIPRulePayload `json:"ipRules"`
+	HTTP2Origin            *bool               `json:"http2Origin"`
+	Access                 *accessPayload      `json:"access"`
+}
+
+type ingressIPRulePayload struct {
+	Prefix *string `json:"prefix"`
+	Ports  []int   `json:"ports"`
+	Allow  bool    `json:"allow"`
+}
+
+type accessPayload struct {
+	Required    bool     `json:"required"`
+	TeamName    string   `json:"teamName"`
+	AudTag      []string `json:"audTag"`
+	Environment *string  `json:"environment"`
+}
+
+type yamlConfigFile struct {
+	config.Configuration `yaml:",inline"`
+	Settings             map[string]any `yaml:",inline"`
+}
+
+type yamlStrictConfigFile struct {
+	config.Configuration `yaml:",inline"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	plan, err := readPlan(os.Stdin)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(plan.OutputDir, 0o755); err != nil {
+		return err
+	}
+
+	for _, fixture := range plan.Fixtures {
+		envelope, err := emitFixture(plan, fixture)
+		if err != nil {
+			return fmt.Errorf("emit %s: %w", fixture.FixtureID, err)
+		}
+		encoded, err := json.MarshalIndent(envelope, "", "  ")
+		if err != nil {
+			return err
+		}
+		outputPath := filepath.Join(plan.OutputDir, fixture.FixtureID+".json")
+		if err := os.WriteFile(outputPath, append(encoded, '\n'), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readPlan(reader io.Reader) (emissionPlan, error) {
+	var plan emissionPlan
+	if err := json.NewDecoder(reader).Decode(&plan); err != nil {
+		return emissionPlan{}, err
+	}
+	return plan, nil
+}
+
+func emitFixture(plan emissionPlan, fixture fixtureSpec) (artifactEnvelope, error) {
+	switch fixture.Category {
+	case "config-discovery":
+		return emitDiscoveryFixture(fixture)
+	case "yaml-config":
+		return emitNormalizedConfigFixture(plan, fixture, fixture.Input, false)
+	case "invalid-input":
+		return emitNormalizedConfigFixture(plan, fixture, fixture.Input, false)
+	case "ordering-defaulting":
+		input := fixture.Input
+		if fixture.OrderingCase != nil {
+			input = fixture.OrderingCase.Input
+		}
+		return emitNormalizedConfigFixture(plan, fixture, input, true)
+	case "credentials-origin-cert":
+		return emitOriginCertFixture(plan, fixture)
+	case "ingress-normalization":
+		return emitCLIIngressFixture(fixture)
+	default:
+		return artifactEnvelope{}, fmt.Errorf("unsupported fixture category: %s", fixture.Category)
+	}
+}
+
+func emitDiscoveryFixture(fixture fixtureSpec) (artifactEnvelope, error) {
+	if fixture.DiscoveryCase == nil {
+		return artifactEnvelope{}, fmt.Errorf("fixture %s missing discovery case", fixture.FixtureID)
+	}
+	sandboxRoot, err := os.MkdirTemp("", "cloudflared-go-discovery-")
+	if err != nil {
+		return artifactEnvelope{}, err
+	}
+	defer os.RemoveAll(sandboxRoot)
+
+	for _, logicalPath := range fixture.DiscoveryCase.Present {
+		actualPath := filepath.Join(sandboxRoot, logicalPath)
+		if err := os.MkdirAll(filepath.Dir(actualPath), 0o755); err != nil {
+			return artifactEnvelope{}, err
+		}
+		if err := os.WriteFile(actualPath, []byte("logDirectory: /var/log/cloudflared\n"), 0o644); err != nil {
+			return artifactEnvelope{}, err
+		}
+	}
+
+	payload, err := simulateDiscovery(sandboxRoot, *fixture.DiscoveryCase)
+	if err != nil {
+		return artifactEnvelope{}, err
+	}
+	return newEnvelope(fixture, "go-truth", "discovery-report.v1", payload)
+}
+
+func simulateDiscovery(sandboxRoot string, dc discoveryCase) (discoveryReportPayload, error) {
+	configNames := []string{"config.yml", "config.yaml"}
+	searchDirs := []string{
+		"home/.cloudflared",
+		"home/.cloudflare-warp",
+		"home/cloudflare-warp",
+		"etc/cloudflared",
+		"usr/local/etc/cloudflared",
+	}
+	for _, dir := range searchDirs {
+		for _, name := range configNames {
+			candidate := filepath.Join(sandboxRoot, dir, name)
+			if fileExists(candidate) {
+				return discoveryReportPayload{
+					Action:       "use-existing",
+					SourceKind:   pickDiscoverySourceKind(dc, dir),
+					ResolvedPath: displaySandboxPath(sandboxRoot, candidate),
+					CreatedPaths: []string{},
+					WrittenConfig: nil,
+				}, nil
+			}
+		}
+	}
+
+	configPath := filepath.Join(sandboxRoot, "usr/local/etc/cloudflared/config.yml")
+	logDir := filepath.Join(sandboxRoot, "var/log/cloudflared")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return discoveryReportPayload{}, err
+	}
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return discoveryReportPayload{}, err
+	}
+	writtenConfig := fmt.Sprintf("logDirectory: %s\n", logDir)
+	if err := os.WriteFile(configPath, []byte(writtenConfig), 0o644); err != nil {
+		return discoveryReportPayload{}, err
+	}
+	return discoveryReportPayload{
+		Action:       "create-default-config",
+		SourceKind:   "auto-created-path",
+		ResolvedPath: "/usr/local/etc/cloudflared/config.yml",
+		CreatedPaths: []string{
+			"/usr/local/etc/cloudflared",
+			"/usr/local/etc/cloudflared/config.yml",
+			"/var/log/cloudflared",
+		},
+		WrittenConfig: stringPtr(writtenConfig),
+	}, nil
+}
+
+func pickDiscoverySourceKind(dc discoveryCase, logicalDir string) string {
+	if dc.ExplicitConfig && logicalDir == "home/.cloudflared" {
+		return "explicit-path"
+	}
+	return "discovered-path"
+}
+
+func emitNormalizedConfigFixture(plan emissionPlan, fixture fixtureSpec, input string, useConfigAndCLI bool) (artifactEnvelope, error) {
+	inputPath := filepath.Join(plan.FixtureRoot, input)
+	configuration, warnings, err := loadYAMLConfig(inputPath)
+	if err != nil {
+		return newErrorEnvelope(fixture, classifyConfigError(err), err.Error())
+	}
+
+	var ing ingress.Ingress
+	if useConfigAndCLI {
+		cliCtx := newCLIContext(nil)
+		logger := zerolog.Nop()
+		ing, err = ingress.ParseIngressFromConfigAndCLI(configuration, cliCtx, &logger)
+	} else {
+		ing, err = ingress.ParseIngress(configuration)
+	}
+	if err != nil {
+		return newErrorEnvelope(fixture, classifyConfigError(err), err.Error())
+	}
+
+	payload := normalizedConfigPayload{
+		SourceKind:    "discovered-path",
+		SourcePath:    input,
+		Tunnel:        tunnelReference(configuration.TunnelID),
+		Credentials:   credentialSurfacePayload{Tunnel: tunnelReference(configuration.TunnelID)},
+		Ingress:       canonicalIngressRules(ing.Rules),
+		OriginRequest: canonicalOriginRequest(ing.Defaults),
+		WarpRouting:   canonicalWarpRouting(configuration.WarpRouting),
+		LogDirectory:  nil,
+		Warnings:      warnings,
+	}
+	return newEnvelope(fixture, "go-truth", "normalized-config.v1", payload)
+}
+
+func emitOriginCertFixture(plan emissionPlan, fixture fixtureSpec) (artifactEnvelope, error) {
+	if fixture.OriginCertSource == nil {
+		return artifactEnvelope{}, fmt.Errorf("fixture %s missing origin cert source", fixture.FixtureID)
+	}
+	inputPath := filepath.Join(plan.RepoRoot, *fixture.OriginCertSource)
+	logger := zerolog.Nop()
+	user, err := cfcredentials.Read(inputPath, &logger)
+	if err != nil {
+		return newErrorEnvelope(fixture, classifyCredentialError(err), err.Error())
+	}
+	payload := credentialReportPayload{
+		Kind:          "origin-cert-pem",
+		SourcePath:    *fixture.OriginCertSource,
+		ZoneID:        user.ZoneID(),
+		AccountID:     user.AccountID(),
+		APIToken:      user.APIToken(),
+		Endpoint:      nilIfEmpty(user.Endpoint()),
+		IsFedEndpoint: user.IsFEDEndpoint(),
+	}
+	return newEnvelope(fixture, "go-truth", "credential-report.v1", payload)
+}
+
+func emitCLIIngressFixture(fixture fixtureSpec) (artifactEnvelope, error) {
+	if fixture.CliIngressCase == nil {
+		return artifactEnvelope{}, fmt.Errorf("fixture %s missing cli ingress case", fixture.FixtureID)
+	}
+	if !hasCLIOrigin(fixture.CliIngressCase.Flags) {
+		return newErrorEnvelope(fixture, "no-ingress-rules-cli", ingress.ErrNoIngressRulesCLI.Error())
+	}
+	cliCtx := newCLIContext(fixture.CliIngressCase.Flags)
+	logger := zerolog.Nop()
+	ing, err := ingress.ParseIngressFromConfigAndCLI(&config.Configuration{}, cliCtx, &logger)
+	if err != nil {
+		return newErrorEnvelope(fixture, classifyConfigError(err), err.Error())
+	}
+	payload := ingressReportPayload{
+		SourceKind:        "cli-single-origin",
+		RuleCount:         len(ing.Rules),
+		CatchAllRuleIndex: len(ing.Rules) - 1,
+		Defaults:          canonicalOriginRequest(ing.Defaults),
+		Rules:             canonicalIngressRules(ing.Rules),
+	}
+	return newEnvelope(fixture, "go-truth", "ingress-report.v1", payload)
+}
+
+func newEnvelope(fixture fixtureSpec, producer string, reportKind string, payload any) (artifactEnvelope, error) {
+	encodedPayload, err := json.Marshal(payload)
+	if err != nil {
+		return artifactEnvelope{}, err
+	}
+	return artifactEnvelope{
+		SchemaVersion: schemaVersion,
+		FixtureID:     fixture.FixtureID,
+		Producer:      producer,
+		ReportKind:    reportKind,
+		Comparison:    fixture.Comparison,
+		SourceRefs:    fixture.SourceRefs,
+		Payload:       encodedPayload,
+	}, nil
+}
+
+func newErrorEnvelope(fixture fixtureSpec, category string, message string) (artifactEnvelope, error) {
+	return newEnvelope(fixture, "go-truth", "error-report.v1", errorReportPayload{
+		Category: category,
+		Message:  message,
+	})
+}
+
+func canonicalIngressRules(rules []ingress.Rule) []ingressRulePayload {
+	canonical := make([]ingressRulePayload, 0, len(rules))
+	for _, rule := range rules {
+		canonical = append(canonical, ingressRulePayload{
+			Hostname:         nilIfEmpty(rule.Hostname),
+			PunycodeHostname: punycodeHostname(rule.Hostname),
+			Path:             regexString(rule.Path),
+			Service:          canonicalService(rule.Service.String()),
+			OriginRequest:    canonicalOriginRequest(rule.Config),
+		})
+	}
+	return canonical
+}
+
+func canonicalService(value string) ingressServicePayload {
+	if strings.HasPrefix(value, "unix+tls:") {
+		path := strings.TrimPrefix(value, "unix+tls:")
+		return ingressServicePayload{Kind: "unix-socket-tls", Path: &path}
+	}
+	if strings.HasPrefix(value, "unix:") {
+		path := strings.TrimPrefix(value, "unix:")
+		return ingressServicePayload{Kind: "unix-socket", Path: &path}
+	}
+	if strings.HasPrefix(value, "http_status:") {
+		status, _ := strconvAtoi(strings.TrimPrefix(value, "http_status:"))
+		return ingressServicePayload{Kind: "http-status", StatusCode: &status}
+	}
+	if value == ingress.HelloWorldService {
+		return ingressServicePayload{Kind: "hello-world"}
+	}
+	if value == ingress.ServiceBastion {
+		return ingressServicePayload{Kind: "bastion"}
+	}
+	if value == ingress.ServiceSocksProxy {
+		return ingressServicePayload{Kind: "socks-proxy"}
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" && parsed.Hostname() != "" {
+		rendered := displayOriginURL(parsed)
+		if parsed.Scheme == "http" || parsed.Scheme == "https" || parsed.Scheme == "ws" || parsed.Scheme == "wss" {
+			return ingressServicePayload{Kind: "http", URI: &rendered}
+		}
+		return ingressServicePayload{Kind: "tcp-over-websocket", URI: &rendered}
+	}
+	return ingressServicePayload{Kind: "named-token", Name: &value}
+}
+
+func canonicalOriginRequest(cfg ingress.OriginRequestConfig) originRequestPayload {
+	ipRules := make([]ingressIPRulePayload, 0, len(cfg.IPRules))
+	for _, rule := range cfg.IPRules {
+		rulePorts := rule.Ports()
+		ports := make([]int, len(rulePorts))
+		copy(ports, rulePorts)
+		prefix := rule.StringCIDR()
+		ipRules = append(ipRules, ingressIPRulePayload{
+			Prefix: &prefix,
+			Ports:  ports,
+			Allow:  rule.RulePolicy(),
+		})
+	}
+	return originRequestPayload{
+		ConnectTimeout:         durationString(cfg.ConnectTimeout),
+		TLSTimeout:             durationString(cfg.TLSTimeout),
+		TCPKeepAlive:           durationString(cfg.TCPKeepAlive),
+		NoHappyEyeballs:        boolPtr(cfg.NoHappyEyeballs),
+		KeepAliveConnections:   intPtr(cfg.KeepAliveConnections),
+		KeepAliveTimeout:       durationString(cfg.KeepAliveTimeout),
+		HTTPHostHeader:         nilIfEmpty(cfg.HTTPHostHeader),
+		OriginServerName:       nilIfEmpty(cfg.OriginServerName),
+		MatchSNIToHost:         boolPtr(cfg.MatchSNIToHost),
+		CAPool:                 nilIfEmpty(cfg.CAPool),
+		NoTLSVerify:            boolPtr(cfg.NoTLSVerify),
+		DisableChunkedEncoding: boolPtr(cfg.DisableChunkedEncoding),
+		BastionMode:            boolPtr(cfg.BastionMode),
+		ProxyAddress:           nilIfEmpty(cfg.ProxyAddress),
+		ProxyPort:              uintPtr(cfg.ProxyPort),
+		ProxyType:              nilIfEmpty(cfg.ProxyType),
+		IPRules:                ipRules,
+		HTTP2Origin:            boolPtr(cfg.Http2Origin),
+		Access:                 canonicalAccess(cfg.Access),
+	}
+}
+
+func canonicalWarpRouting(cfg config.WarpRoutingConfig) warpRoutingPayload {
+	return warpRoutingPayload{
+		ConnectTimeout: customDurationString(cfg.ConnectTimeout),
+		MaxActiveFlows: cfg.MaxActiveFlows,
+		TCPKeepAlive:   customDurationString(cfg.TCPKeepAlive),
+	}
+}
+
+func canonicalAccess(cfg config.AccessConfig) *accessPayload {
+	if !cfg.Required && cfg.TeamName == "" && len(cfg.AudTag) == 0 && cfg.Environment == "" {
+		return nil
+	}
+	return &accessPayload{
+		Required:    cfg.Required,
+		TeamName:    cfg.TeamName,
+		AudTag:      append([]string(nil), cfg.AudTag...),
+		Environment: nilIfEmpty(cfg.Environment),
+	}
+}
+
+func tunnelReference(raw string) *tunnelReferencePayload {
+	if raw == "" {
+		return nil
+	}
+	return &tunnelReferencePayload{Raw: raw, UUID: nil}
+}
+
+func loadYAMLConfig(path string) (*config.Configuration, []warningPayload, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer file.Close()
+
+	var settings yamlConfigFile
+	if err := yaml.NewDecoder(file).Decode(&settings); err != nil {
+		return nil, nil, err
+	}
+
+	strictFile, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer strictFile.Close()
+	decoder := yaml.NewDecoder(strictFile)
+	decoder.KnownFields(true)
+	var strictSettings yamlStrictConfigFile
+	var warnings []warningPayload
+	if err := decoder.Decode(&strictSettings); err != nil {
+		warnings = parseWarningPayload(err.Error())
+	}
+
+	return &settings.Configuration, warnings, nil
+}
+
+func parseWarningPayload(message string) []warningPayload {
+	matches := regexp.MustCompile(`field ([^ ]+) not found`).FindAllStringSubmatch(message, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	keys := make([]string, 0, len(matches))
+	for _, match := range matches {
+		key := match[1]
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return []warningPayload{{Kind: "unknown-top-level-keys", Keys: keys}}
+}
+
+func classifyConfigError(err error) string {
+	message := err.Error()
+	switch {
+	case strings.Contains(message, "The last ingress rule must match all URLs"):
+		return "ingress-last-rule-not-catch-all"
+	case strings.Contains(message, "Hostname patterns can have at most one wildcard"):
+		return "ingress-bad-wildcard"
+	case strings.Contains(message, "Hostname cannot contain a port"):
+		return "ingress-hostname-contains-port"
+	case strings.Contains(message, "No ingress rules were defined"):
+		return "no-ingress-rules-cli"
+	default:
+		return "invariant-violation"
+	}
+}
+
+func classifyCredentialError(err error) string {
+	message := err.Error()
+	switch {
+	case strings.Contains(message, "cannot decode empty certificate"):
+		return "origin-cert-empty"
+	case strings.Contains(message, "unknown block"):
+		return "origin-cert-unknown-block"
+	case strings.Contains(message, "found multiple tokens"):
+		return "origin-cert-multiple-tokens"
+	case strings.Contains(message, "missing token in the certificate"):
+		return "origin-cert-missing-token"
+	case strings.Contains(message, "Origin certificate needs to be refreshed"):
+		return "origin-cert-needs-refresh"
+	default:
+		return "io"
+	}
+}
+
+func newCLIContext(flags []string) *cli.Context {
+	flagSet := flag.NewFlagSet("first-slice-capture", flag.ContinueOnError)
+	flagSet.Bool(ingress.HelloWorldFlag, false, "")
+	flagSet.Bool(config.BastionFlag, false, "")
+	flagSet.String("url", "", "")
+	flagSet.String("unix-socket", "", "")
+	cliCtx := cli.NewContext(cli.NewApp(), flagSet, nil)
+	for _, raw := range flags {
+		name, value := splitCLIFlag(raw)
+		_ = cliCtx.Set(name, value)
+	}
+	return cliCtx
+}
+
+func hasCLIOrigin(flags []string) bool {
+	for _, raw := range flags {
+		name, value := splitCLIFlag(raw)
+		switch name {
+		case ingress.HelloWorldFlag, config.BastionFlag:
+			if value == "true" || value == "" {
+				return true
+			}
+		case "url", "unix-socket":
+			if value != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func splitCLIFlag(raw string) (string, string) {
+	trimmed := strings.TrimPrefix(raw, "--")
+	if name, value, ok := strings.Cut(trimmed, "="); ok {
+		return name, value
+	}
+	return trimmed, "true"
+}
+
+func displayOriginURL(parsed *url.URL) string {
+	rendered := parsed.String()
+	if parsed.Path == "/" && parsed.RawQuery == "" && parsed.Fragment == "" {
+		return strings.TrimSuffix(rendered, "/")
+	}
+	return rendered
+}
+
+func punycodeHostname(hostname string) *string {
+	if hostname == "" || hostname == "*" || strings.Contains(hostname, "*") {
+		return nil
+	}
+	punycode, err := idna.Lookup.ToASCII(hostname)
+	if err != nil || punycode == hostname {
+		return nil
+	}
+	return &punycode
+}
+
+func regexString(pattern *ingress.Regexp) *string {
+	if pattern == nil || pattern.Regexp == nil {
+		return nil
+	}
+	s := pattern.String()
+	return &s
+}
+
+func durationString(value config.CustomDuration) *string {
+	text := value.Duration.String()
+	if text == "0s" {
+		return nil
+	}
+	return &text
+}
+
+func customDurationString(value *config.CustomDuration) *string {
+	if value == nil {
+		return nil
+	}
+	text := value.Duration.String()
+	return &text
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func uintPtr(value uint) *uint {
+	return &value
+}
+
+func nilIfEmpty(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func displaySandboxPath(sandboxRoot string, path string) string {
+	relative, err := filepath.Rel(sandboxRoot, path)
+	if err != nil || strings.HasPrefix(relative, "..") {
+		return path
+	}
+	return "/" + filepath.ToSlash(relative)
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func strconvAtoi(value string) (int, error) {
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	return int(parsed), err
+}

--- a/tools/first_slice_parity.py
+++ b/tools/first_slice_parity.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+import tempfile
 import tomllib
 
 
@@ -17,6 +21,10 @@ FIXTURE_ROOT = (
 INDEX_PATH = FIXTURE_ROOT / "fixture-index.toml"
 GO_TRUTH_DIR = FIXTURE_ROOT / "golden" / "go-truth"
 RUST_ACTUAL_DIR = FIXTURE_ROOT / "golden" / "rust-actual"
+GO_CAPTURE_RUNNER = REPO_ROOT / "tools" / "first_slice_go_capture" / "main.go"
+LOCAL_GO_BINARY = (
+    Path.home() / ".local" / "go-toolchain" / "usr" / "lib" / "go-1.22" / "bin" / "go"
+)
 SUPPORTED_RUST_ACTUAL_CATEGORIES = {
     "config-discovery",
     "credentials-origin-cert",
@@ -25,6 +33,7 @@ SUPPORTED_RUST_ACTUAL_CATEGORIES = {
     "invalid-input",
     "ordering-defaulting",
 }
+SUPPORTED_GO_TRUTH_CATEGORIES = set(SUPPORTED_RUST_ACTUAL_CATEGORIES)
 
 
 @dataclass(frozen=True)
@@ -53,7 +62,7 @@ def main() -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Phase 1A parity harness entrypoint for the accepted first slice."
+        description="Parity harness entrypoint for the accepted first-slice surface."
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -74,9 +83,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     check_go_truth.set_defaults(func=cmd_check_go_truth)
 
+    capture_go_truth = subparsers.add_parser(
+        "capture-go-truth",
+        help="Generate checked-in Go truth artifacts for the supported first-slice fixtures.",
+    )
+    capture_go_truth.add_argument(
+        "--fixture-id",
+        action="append",
+        default=[],
+        help="Limit capture to one or more fixture IDs.",
+    )
+    capture_go_truth.add_argument(
+        "--output-dir",
+        default=str(GO_TRUTH_DIR),
+        help="Directory where Go truth JSON files should be written.",
+    )
+    capture_go_truth.set_defaults(func=cmd_capture_go_truth)
+
     compare = subparsers.add_parser(
         "compare",
-        help="Describe or execute the Go-versus-Rust comparison contract.",
+        help="Run real Go-versus-Rust comparison for the selected first-slice fixtures.",
     )
     compare.add_argument(
         "--require-go-truth",
@@ -192,45 +218,139 @@ def cmd_check_go_truth(_args: argparse.Namespace, fixtures: list[Fixture]) -> in
     return 1
 
 
+def cmd_capture_go_truth(args: argparse.Namespace, fixtures: list[Fixture]) -> int:
+    selected = select_fixtures(fixtures, args.fixture_id)
+    targeted = [
+        fixture
+        for fixture in selected
+        if fixture.category in SUPPORTED_GO_TRUTH_CATEGORIES
+    ]
+    skipped = [
+        fixture
+        for fixture in selected
+        if fixture.category not in SUPPORTED_GO_TRUTH_CATEGORIES
+    ]
+
+    if not targeted:
+        print(
+            "no supported first-slice fixtures were selected for Go truth capture",
+            file=sys.stderr,
+        )
+        return 1
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    completed = run_go_capture(targeted, output_dir)
+
+    if skipped:
+        for fixture in skipped:
+            print(
+                f"skipping unsupported Go truth category for {fixture.fixture_id}: {fixture.category}",
+                file=sys.stderr,
+            )
+
+    if completed.returncode != 0:
+        if completed.stderr:
+            print(completed.stderr, file=sys.stderr, end="")
+        if completed.stdout:
+            print(completed.stdout, file=sys.stderr, end="")
+        return completed.returncode
+
+    print(
+        f"captured {len(targeted)} Go truth artifacts into {display_repo_relative(output_dir)}"
+    )
+    for fixture in targeted:
+        print(f"- {fixture.fixture_id}")
+    return 0
+
+
 def cmd_compare(args: argparse.Namespace, fixtures: list[Fixture]) -> int:
     selected = select_fixtures(fixtures, args.fixture_id)
     missing_go_truth = [
         fixture for fixture in selected if not fixture.go_truth_path.exists()
     ]
-    missing_rust_actual = [
-        fixture for fixture in selected if not fixture.rust_actual_path.exists()
-    ]
-    comparable = [
-        fixture
-        for fixture in selected
-        if fixture.go_truth_path.exists() and fixture.rust_actual_path.exists()
-    ]
 
-    print("Phase 1A comparison contract")
+    print("Phase 1B.5 Rust-vs-Go comparison")
     print(f"selected fixtures: {len(selected)}")
-    print(f"comparable today: {len(comparable)}")
     print(f"missing Go truth: {len(missing_go_truth)}")
-    print(f"missing Rust actual: {len(missing_rust_actual)}")
-
-    for fixture in selected:
-        status = comparison_status(fixture)
-        print(f"- {fixture.fixture_id}: {status}")
 
     if args.require_go_truth and missing_go_truth:
         print(
             "compare failed because Go truth artifacts are still missing.",
             file=sys.stderr,
         )
+        for fixture in missing_go_truth:
+            print(
+                f"- {fixture.fixture_id}: expected {fixture.go_truth_path.relative_to(REPO_ROOT).as_posix()}",
+                file=sys.stderr,
+            )
         return 1
 
-    if args.require_rust_actual and missing_rust_actual:
-        print(
-            "compare failed because Rust actual artifacts are still missing.",
-            file=sys.stderr,
-        )
-        return 1
+    with tempfile.TemporaryDirectory(prefix="cloudflared-rust-actual-") as temp_dir:
+        rust_actual_dir = Path(temp_dir)
+        completed = run_rust_emitter(selected, rust_actual_dir)
+        if completed.returncode != 0:
+            if completed.stderr:
+                print(completed.stderr, file=sys.stderr, end="")
+            if completed.stdout:
+                print(completed.stdout, file=sys.stderr, end="")
+            return completed.returncode
 
-    return 0
+        missing_rust_actual = [
+            fixture
+            for fixture in selected
+            if not rust_actual_path_for_dir(rust_actual_dir, fixture).exists()
+        ]
+        compared = 0
+        matched = 0
+        mismatches: list[tuple[Fixture, list[str]]] = []
+
+        for fixture in selected:
+            if not fixture.go_truth_path.exists():
+                print(f"- {fixture.fixture_id}: missing-go-truth")
+                continue
+
+            rust_actual_path = rust_actual_path_for_dir(rust_actual_dir, fixture)
+            if not rust_actual_path.exists():
+                print(f"- {fixture.fixture_id}: missing-rust-actual")
+                continue
+
+            compared += 1
+            go_truth = load_json_artifact(fixture.go_truth_path)
+            rust_actual = load_json_artifact(rust_actual_path)
+            differences = compare_artifacts(fixture, go_truth, rust_actual)
+            if differences:
+                mismatches.append((fixture, differences))
+                print(f"- {fixture.fixture_id}: mismatch")
+                for difference in differences:
+                    print(f"  {difference}")
+            else:
+                matched += 1
+                print(f"- {fixture.fixture_id}: match")
+
+        print(f"compared: {compared}")
+        print(f"matched: {matched}")
+        print(f"mismatched: {len(mismatches)}")
+        print(f"missing Rust actual: {len(missing_rust_actual)}")
+
+        if args.require_rust_actual and missing_rust_actual:
+            print(
+                "compare failed because Rust actual artifacts are still missing.",
+                file=sys.stderr,
+            )
+            return 1
+        if mismatches:
+            print(
+                "compare failed because one or more fixture artifacts differ.",
+                file=sys.stderr,
+            )
+            return 1
+        if args.require_go_truth and missing_go_truth:
+            return 1
+        if args.require_rust_actual and missing_rust_actual:
+            return 1
+        return 0
 
 
 def cmd_emit_rust_actual(args: argparse.Namespace, fixtures: list[Fixture]) -> int:
@@ -260,23 +380,7 @@ def cmd_emit_rust_actual(args: argparse.Namespace, fixtures: list[Fixture]) -> i
         "fixtures": [build_emission_fixture(fixture) for fixture in targeted],
     }
 
-    import subprocess
-
-    completed = subprocess.run(
-        [
-            "cargo",
-            "run",
-            "-q",
-            "-p",
-            "cloudflared-config",
-            "--example",
-            "first_slice_emit",
-        ],
-        cwd=REPO_ROOT,
-        input=json.dumps(plan),
-        text=True,
-        capture_output=True,
-    )
+    completed = run_rust_emitter(targeted, output_dir)
 
     if skipped:
         for fixture in skipped:
@@ -334,11 +438,298 @@ def build_emission_fixture(fixture: Fixture) -> dict[str, object]:
         payload["discovery_case"] = load_discovery_case(fixture.fixture_id)
     if fixture.category == "credentials-origin-cert":
         payload["origin_cert_source"] = load_origin_cert_source(fixture.fixture_id)
-    if fixture.category == "ordering-defaulting":
+    if (
+        fixture.category == "ordering-defaulting"
+        and fixture.input_path.name == "cases.toml"
+    ):
         payload["ordering_case"] = load_ordering_case(fixture.fixture_id)
     if fixture.category == "ingress-normalization":
         payload["cli_ingress_case"] = load_cli_ingress_case(fixture.fixture_id)
     return payload
+
+
+def run_rust_emitter(
+    fixtures: list[Fixture], output_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    plan = {
+        "repo_root": str(REPO_ROOT),
+        "fixture_root": str(FIXTURE_ROOT),
+        "output_dir": str(output_dir),
+        "fixtures": [build_emission_fixture(fixture) for fixture in fixtures],
+    }
+
+    return subprocess.run(
+        [
+            "cargo",
+            "run",
+            "-q",
+            "-p",
+            "cloudflared-config",
+            "--example",
+            "first_slice_emit",
+        ],
+        cwd=REPO_ROOT,
+        input=json.dumps(plan),
+        text=True,
+        capture_output=True,
+    )
+
+
+def run_go_capture(
+    fixtures: list[Fixture], output_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    plan = {
+        "repo_root": str(REPO_ROOT),
+        "fixture_root": str(FIXTURE_ROOT),
+        "output_dir": str(output_dir),
+        "fixtures": [build_emission_fixture(fixture) for fixture in fixtures],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="cloudflared-go-truth-") as temp_dir:
+        temp_root = Path(temp_dir)
+        write_go_capture_module(temp_root)
+        try:
+            go_binary = str(go_executable())
+            tidy = subprocess.run(
+                [go_binary, "mod", "tidy"],
+                cwd=temp_root,
+                text=True,
+                capture_output=True,
+            )
+            if tidy.returncode != 0:
+                return tidy
+            return subprocess.run(
+                [go_binary, "run", "."],
+                cwd=temp_root,
+                input=json.dumps(plan),
+                text=True,
+                capture_output=True,
+            )
+        except FileNotFoundError as error:
+            raise SystemExit(
+                "go toolchain not found on PATH; install Go to run capture-go-truth"
+            ) from error
+
+
+def write_go_capture_module(temp_root: Path) -> None:
+    shutil.copy2(GO_CAPTURE_RUNNER, temp_root / "main.go")
+    go_mod = f"""module firstslicecapture
+
+go 1.24.0
+
+require (
+    github.com/cloudflare/cloudflared v0.0.0
+    github.com/rs/zerolog v1.20.0
+    github.com/urfave/cli/v2 v2.3.0
+    golang.org/x/net v0.40.0
+    gopkg.in/yaml.v3 v3.0.1
+)
+
+replace github.com/cloudflare/cloudflared => {REPO_ROOT / 'baseline-2026.2.0' / 'old-impl'}
+"""
+    (temp_root / "go.mod").write_text(go_mod)
+
+
+def go_executable() -> Path:
+    configured = os.environ.get("GO_BINARY") or shutil.which("go")
+    if configured:
+        return Path(configured)
+    if LOCAL_GO_BINARY.exists():
+        return LOCAL_GO_BINARY
+    raise FileNotFoundError("go")
+
+
+def load_json_artifact(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text())
+
+
+def rust_actual_path_for_dir(output_dir: Path, fixture: Fixture) -> Path:
+    return output_dir / f"{fixture.fixture_id}.json"
+
+
+def compare_artifacts(
+    fixture: Fixture,
+    go_truth: dict[str, object],
+    rust_actual: dict[str, object],
+) -> list[str]:
+    differences: list[str] = []
+    for field in [
+        "schema_version",
+        "fixture_id",
+        "report_kind",
+        "comparison",
+        "source_refs",
+    ]:
+        if go_truth.get(field) != rust_actual.get(field):
+            differences.append(
+                f"envelope.{field}: go={render_value(go_truth.get(field))} rust={render_value(rust_actual.get(field))}"
+            )
+
+    comparison = fixture.comparison
+    if comparison in {"exact", "exact-json"}:
+        differences.extend(
+            diff_json(
+                go_truth.get("payload"), rust_actual.get("payload"), path="payload"
+            )
+        )
+    elif comparison == "error-category":
+        differences.extend(compare_error_category(go_truth, rust_actual))
+    elif comparison == "structural":
+        differences.extend(compare_structural(go_truth, rust_actual))
+    elif comparison == "semantic":
+        differences.extend(compare_semantic(go_truth, rust_actual))
+    elif comparison == "warning-or-report":
+        differences.extend(compare_warning_or_report(go_truth, rust_actual))
+    else:
+        differences.append(f"unsupported comparison mode: {comparison}")
+
+    return differences
+
+
+def compare_error_category(
+    go_truth: dict[str, object], rust_actual: dict[str, object]
+) -> list[str]:
+    differences: list[str] = []
+    if go_truth.get("report_kind") != "error-report.v1":
+        differences.append(
+            f"go report_kind must be error-report.v1, found {go_truth.get('report_kind')!r}"
+        )
+    if rust_actual.get("report_kind") != "error-report.v1":
+        differences.append(
+            f"rust report_kind must be error-report.v1, found {rust_actual.get('report_kind')!r}"
+        )
+    go_payload = as_dict(go_truth.get("payload"))
+    rust_payload = as_dict(rust_actual.get("payload"))
+    if go_payload.get("category") != rust_payload.get("category"):
+        differences.append(
+            f"payload.category: go={render_value(go_payload.get('category'))} rust={render_value(rust_payload.get('category'))}"
+        )
+    return differences
+
+
+def compare_structural(
+    go_truth: dict[str, object], rust_actual: dict[str, object]
+) -> list[str]:
+    differences: list[str] = []
+    go_payload = as_dict(go_truth.get("payload"))
+    rust_payload = as_dict(rust_actual.get("payload"))
+    for key in ["action", "source_kind", "resolved_path", "created_paths"]:
+        if go_payload.get(key) != rust_payload.get(key):
+            differences.append(
+                f"payload.{key}: go={render_value(go_payload.get(key))} rust={render_value(rust_payload.get(key))}"
+            )
+    return differences
+
+
+def compare_semantic(
+    go_truth: dict[str, object], rust_actual: dict[str, object]
+) -> list[str]:
+    go_contract = extract_no_ingress_contract(go_truth)
+    rust_contract = extract_no_ingress_contract(rust_actual)
+    if go_contract == rust_contract:
+        return []
+    return [
+        f"semantic no-ingress contract: go={render_value(go_contract)} rust={render_value(rust_contract)}"
+    ]
+
+
+def extract_no_ingress_contract(artifact: dict[str, object]) -> dict[str, object]:
+    payload = as_dict(artifact.get("payload"))
+    ingress_rules = payload.get("ingress")
+    if not isinstance(ingress_rules, list) or not ingress_rules:
+        return {"report_kind": artifact.get("report_kind"), "ingress": None}
+    last_rule = as_dict(ingress_rules[-1])
+    service = as_dict(last_rule.get("service"))
+    return {
+        "report_kind": artifact.get("report_kind"),
+        "ingress_count": len(ingress_rules),
+        "last_service_kind": service.get("kind"),
+        "last_status_code": service.get("status_code"),
+    }
+
+
+def compare_warning_or_report(
+    go_truth: dict[str, object], rust_actual: dict[str, object]
+) -> list[str]:
+    if go_truth.get("report_kind") != rust_actual.get("report_kind"):
+        return [
+            f"report_kind: go={render_value(go_truth.get('report_kind'))} rust={render_value(rust_actual.get('report_kind'))}"
+        ]
+
+    if go_truth.get("report_kind") == "error-report.v1":
+        return compare_error_category(go_truth, rust_actual)
+
+    go_payload = as_dict(go_truth.get("payload"))
+    rust_payload = as_dict(rust_actual.get("payload"))
+    if go_payload.get("warnings") == rust_payload.get("warnings"):
+        return []
+    return [
+        f"payload.warnings: go={render_value(go_payload.get('warnings'))} rust={render_value(rust_payload.get('warnings'))}"
+    ]
+
+
+def diff_json(
+    go_value: object,
+    rust_value: object,
+    *,
+    path: str,
+    limit: int = 20,
+) -> list[str]:
+    differences: list[str] = []
+
+    def walk(left: object, right: object, current_path: str) -> None:
+        if len(differences) >= limit:
+            return
+        if type(left) is not type(right):
+            differences.append(
+                f"{current_path}: go={render_value(left)} rust={render_value(right)}"
+            )
+            return
+        if isinstance(left, dict):
+            assert isinstance(right, dict)
+            keys = sorted(set(left) | set(right))
+            for key in keys:
+                if len(differences) >= limit:
+                    return
+                if key not in left:
+                    differences.append(
+                        f"{current_path}.{key}: missing in go, rust={render_value(right[key])}"
+                    )
+                    continue
+                if key not in right:
+                    differences.append(
+                        f"{current_path}.{key}: go={render_value(left[key])}, missing in rust"
+                    )
+                    continue
+                walk(left[key], right[key], f"{current_path}.{key}")
+            return
+        if isinstance(left, list):
+            assert isinstance(right, list)
+            if len(left) != len(right):
+                differences.append(
+                    f"{current_path}.length: go={len(left)} rust={len(right)}"
+                )
+                return
+            for index, (left_item, right_item) in enumerate(zip(left, right)):
+                walk(left_item, right_item, f"{current_path}[{index}]")
+            return
+        if left != right:
+            differences.append(
+                f"{current_path}: go={render_value(left)} rust={render_value(right)}"
+            )
+
+    walk(go_value, rust_value, path)
+    return differences
+
+
+def as_dict(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def render_value(value: object) -> str:
+    return json.dumps(value, sort_keys=True)
 
 
 def load_discovery_case(fixture_id: str) -> dict[str, object]:


### PR DESCRIPTION
## What this PR does

This PR makes the first-slice parity loop tight.

It adds checked-in Go truth for the current first-slice fixture surface, makes the compare path run real Rust-vs-Go checks, and keeps the remaining mismatches visible instead of smoothing them over.

## Included in this PR

- checked-in Go truth artifacts for the current first-slice fixtures
- a Go capture path grounded in the frozen baseline
- real Rust-vs-Go compare behavior in the parity harness
- narrow harness test updates
- small truth-surface and wording fixes tied to the new compare flow

## Scope

This stays within the accepted first slice, focused on Go truth capture and parity comparison for the behavior already implemented in Rust.

## Not included

This PR does not cover:
- new runtime or transport behavior
- broader CLI work
- full first-slice parity completion
- hiding or waiving current mismatches

## Current status after this PR

What exists after this:
- checked-in Go truth for the current fixture surface
- real compare behavior in the harness
- explicit reporting of remaining mismatches

What still comes next:
- closing the remaining Rust-vs-Go mismatch set
- finishing first-slice parity