### PR TITLE
rust-rewrite: phase 1b.6 first-slice parity closure

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,11 +6,11 @@ This repository is currently a rewrite workspace with a frozen Go reference
 implementation and an intentionally narrow Rust first slice.
 
 It is not yet a parity-complete Rust implementation workspace. The repository
-now contains a Cargo workspace skeleton plus early first-slice behavior in
-`crates/cloudflared-config/` for config discovery/loading and credentials
-origin-cert decoding, narrow ingress normalization and matching behavior, and a
-real first-slice Go-truth and compare harness path, but most subsystem
-behavior is still unported.
+now contains a Cargo workspace skeleton plus accepted first-slice behavior in
+`crates/cloudflared-config/` for config discovery/loading, credentials
+origin-cert decoding, ingress normalization and matching, and a real
+first-slice Go-truth compare harness whose accepted fixture surface currently
+compares green, but most Phase 1 subsystem behavior is still unported.
 
 The scaffold is intentionally real but minimal:
 
@@ -122,7 +122,6 @@ These items are still missing before MCP-assisted or large-scale subsystem work
 should begin:
 
 - accepted compatibility-scope decision for FIPS/compliance
-- passing first-slice parity tests
 
 ## Phase 1A Groundwork
 
@@ -138,15 +137,13 @@ What exists now:
 
 What does not exist yet:
 
-- passing Rust-versus-Go parity reports
-- complete config, credential, or ingress behavior
-- passing first-slice parity comparisons
+- complete Phase 1 behavior outside the accepted first slice
 
 Implication:
 
 - the repo can now inventory and mechanically gate the first-slice parity
   contract
-- the repo still must not claim first-slice parity is complete
+- the repo still must not claim broader Phase 1 parity is complete
 
 ## Phase 1B.1 Domain Skeleton
 
@@ -275,26 +272,43 @@ What exists now:
 
 What does not exist yet:
 
-- all-green first-slice parity
-- reconciled exact JSON parity for several config and CLI ingress fixtures
-- a promoted policy for canonicalizing representation-only differences such as
-  `90s` versus `1m30s` in artifact comparison
-
-Current mismatch clusters from the full compare run:
-
-- config-backed ingress fixtures still diverge because Rust does not yet carry
-  Go effective `originRequest` defaults and inherited IP rules into the per-rule
-  normalized artifact shape
-- CLI single-origin ingress fixtures still diverge on default field
-  representation, including `false` versus `null`, `0` versus `null`, and
-  `1m30s` versus `90s`
+- closed first-slice Rust-versus-Go parity mismatches
 
 Implication:
 
 - the repository now has a real first-slice parity loop rather than a Rust-only
   artifact scaffold
-- the repository still must not claim first-slice parity is complete while the
-  full compare continues to report live mismatches
+- the repository still must not claim broader rewrite parity while most Phase 1
+  subsystems remain unported
+
+## Phase 1B.6 First-Slice Parity Closure
+
+Phase 1B.6 behavior now closes the known accepted first-slice Rust-versus-Go
+parity mismatches.
+
+What exists now:
+
+- config-backed normalized ingress payloads now materialize Go-effective
+  `originRequest` defaults and carry inherited IP rules into each rule payload
+- CLI single-origin ingress normalization now matches Go truth for default-field
+  representation, including `false`, `0`, and `1m30s`
+- normalized-config artifact emission now matches Go truth for `warnings: null`
+  when no warnings are present
+- the full accepted first-slice compare is green: 21 compared, 21 matched,
+  0 mismatched
+
+What does not exist yet:
+
+- internal ingress-rule matching and negative rule-index behavior
+- full regex-path semantics for general ingress matching
+- tunnel credential JSON fixture coverage
+- any Phase 1 behavior outside the accepted first slice
+
+Implication:
+
+- the accepted first slice is now parity-backed against the checked-in Go truth
+  fixture surface
+- the repository still must not claim full Phase 1 or full-rewrite completion
 
 ## First Implementation Gate
 

--- a/crates/cloudflared-config/src/artifact.rs
+++ b/crates/cloudflared-config/src/artifact.rs
@@ -109,7 +109,7 @@ pub struct NormalizedConfigPayload {
     pub origin_request: OriginRequestConfig,
     pub warp_routing: WarpRoutingConfig,
     pub log_directory: Option<String>,
-    pub warnings: Vec<WarningPayload>,
+    pub warnings: Option<Vec<WarningPayload>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -288,11 +288,17 @@ impl NormalizedConfigPayload {
                 .log_directory
                 .as_ref()
                 .map(|path| path.display().to_string()),
-            warnings: normalized
-                .warnings
-                .iter()
-                .map(WarningPayload::from_warning)
-                .collect(),
+            warnings: if normalized.warnings.is_empty() {
+                None
+            } else {
+                Some(
+                    normalized
+                        .warnings
+                        .iter()
+                        .map(WarningPayload::from_warning)
+                        .collect(),
+                )
+            },
         }
     }
 }

--- a/crates/cloudflared-config/src/ingress.rs
+++ b/crates/cloudflared-config/src/ingress.rs
@@ -12,7 +12,7 @@ pub const NO_INGRESS_RULES_CLI_MESSAGE: &str = "No ingress rules were defined in
 const DEFAULT_HTTP_CONNECT_TIMEOUT: &str = "30s";
 const DEFAULT_TLS_TIMEOUT: &str = "10s";
 const DEFAULT_TCP_KEEP_ALIVE: &str = "30s";
-const DEFAULT_KEEP_ALIVE_TIMEOUT: &str = "90s";
+const DEFAULT_KEEP_ALIVE_TIMEOUT: &str = "1m30s";
 const DEFAULT_PROXY_ADDRESS: &str = "127.0.0.1";
 const DEFAULT_KEEP_ALIVE_CONNECTIONS: u32 = 100;
 
@@ -82,6 +82,114 @@ pub struct OriginRequestConfig {
     pub http2_origin: Option<bool>,
     #[serde(default)]
     pub access: Option<AccessConfig>,
+}
+
+impl OriginRequestConfig {
+    pub fn materialized_config_defaults(raw: &Self) -> Self {
+        Self {
+            connect_timeout: raw
+                .connect_timeout
+                .clone()
+                .or_else(|| Some(DurationSpec(DEFAULT_HTTP_CONNECT_TIMEOUT.to_owned()))),
+            tls_timeout: raw
+                .tls_timeout
+                .clone()
+                .or_else(|| Some(DurationSpec(DEFAULT_TLS_TIMEOUT.to_owned()))),
+            tcp_keep_alive: raw
+                .tcp_keep_alive
+                .clone()
+                .or_else(|| Some(DurationSpec(DEFAULT_TCP_KEEP_ALIVE.to_owned()))),
+            no_happy_eyeballs: Some(raw.no_happy_eyeballs.unwrap_or(false)),
+            keep_alive_connections: Some(
+                raw.keep_alive_connections
+                    .unwrap_or(DEFAULT_KEEP_ALIVE_CONNECTIONS),
+            ),
+            keep_alive_timeout: raw
+                .keep_alive_timeout
+                .clone()
+                .or_else(|| Some(DurationSpec(DEFAULT_KEEP_ALIVE_TIMEOUT.to_owned()))),
+            http_host_header: raw.http_host_header.clone(),
+            origin_server_name: raw.origin_server_name.clone(),
+            match_sni_to_host: Some(raw.match_sni_to_host.unwrap_or(false)),
+            ca_pool: raw.ca_pool.clone(),
+            no_tls_verify: Some(raw.no_tls_verify.unwrap_or(false)),
+            disable_chunked_encoding: Some(raw.disable_chunked_encoding.unwrap_or(false)),
+            bastion_mode: Some(raw.bastion_mode.unwrap_or(false)),
+            proxy_address: raw
+                .proxy_address
+                .clone()
+                .or_else(|| Some(DEFAULT_PROXY_ADDRESS.to_owned())),
+            proxy_port: Some(raw.proxy_port.unwrap_or(0)),
+            proxy_type: raw.proxy_type.clone(),
+            ip_rules: raw.ip_rules.clone(),
+            http2_origin: Some(raw.http2_origin.unwrap_or(false)),
+            access: raw.access.clone(),
+        }
+    }
+
+    pub fn with_overrides(&self, overrides: &Self) -> Self {
+        let mut merged = self.clone();
+
+        if let Some(value) = overrides.connect_timeout.clone() {
+            merged.connect_timeout = Some(value);
+        }
+        if let Some(value) = overrides.tls_timeout.clone() {
+            merged.tls_timeout = Some(value);
+        }
+        if let Some(value) = overrides.tcp_keep_alive.clone() {
+            merged.tcp_keep_alive = Some(value);
+        }
+        if let Some(value) = overrides.no_happy_eyeballs {
+            merged.no_happy_eyeballs = Some(value);
+        }
+        if let Some(value) = overrides.keep_alive_connections {
+            merged.keep_alive_connections = Some(value);
+        }
+        if let Some(value) = overrides.keep_alive_timeout.clone() {
+            merged.keep_alive_timeout = Some(value);
+        }
+        if let Some(value) = overrides.http_host_header.clone() {
+            merged.http_host_header = Some(value);
+        }
+        if let Some(value) = overrides.origin_server_name.clone() {
+            merged.origin_server_name = Some(value);
+        }
+        if let Some(value) = overrides.match_sni_to_host {
+            merged.match_sni_to_host = Some(value);
+        }
+        if let Some(value) = overrides.ca_pool.clone() {
+            merged.ca_pool = Some(value);
+        }
+        if let Some(value) = overrides.no_tls_verify {
+            merged.no_tls_verify = Some(value);
+        }
+        if let Some(value) = overrides.disable_chunked_encoding {
+            merged.disable_chunked_encoding = Some(value);
+        }
+        if let Some(value) = overrides.bastion_mode {
+            merged.bastion_mode = Some(value);
+        }
+        if let Some(value) = overrides.proxy_address.clone() {
+            merged.proxy_address = Some(value);
+        }
+        if let Some(value) = overrides.proxy_port {
+            merged.proxy_port = Some(value);
+        }
+        if let Some(value) = overrides.proxy_type.clone() {
+            merged.proxy_type = Some(value);
+        }
+        if !overrides.ip_rules.is_empty() {
+            merged.ip_rules = overrides.ip_rules.clone();
+        }
+        if let Some(value) = overrides.http2_origin {
+            merged.http2_origin = Some(value);
+        }
+        if let Some(value) = overrides.access.clone() {
+            merged.access = Some(value);
+        }
+
+        merged
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
@@ -203,7 +311,12 @@ impl IngressService {
 }
 
 impl IngressRule {
-    pub fn from_raw(raw: RawIngressRule, rule_index: usize, total_rules: usize) -> Result<Self> {
+    pub fn from_raw(
+        raw: RawIngressRule,
+        inherited_origin_request: &OriginRequestConfig,
+        rule_index: usize,
+        total_rules: usize,
+    ) -> Result<Self> {
         let service = match raw.service {
             Some(service) => IngressService::parse("service", &service)?,
             None => return Err(ConfigError::invariant("ingress rule is missing service")),
@@ -224,7 +337,7 @@ impl IngressRule {
                 path: raw.path,
             },
             service,
-            origin_request: raw.origin_request,
+            origin_request: inherited_origin_request.with_overrides(&raw.origin_request),
         })
     }
 
@@ -378,9 +491,9 @@ fn default_single_origin_origin_request(request: &CliIngressRequest) -> OriginRe
         ca_pool: None,
         no_tls_verify: Some(false),
         disable_chunked_encoding: Some(false),
-        bastion_mode: request.bastion.then_some(true),
+        bastion_mode: Some(request.bastion),
         proxy_address: Some(DEFAULT_PROXY_ADDRESS.to_owned()),
-        proxy_port: None,
+        proxy_port: Some(0),
         proxy_type: None,
         ip_rules: Vec::new(),
         http2_origin: Some(false),
@@ -480,8 +593,8 @@ fn strip_port(hostname: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::{
-        CliIngressRequest, IngressRule, IngressService, NormalizedIngress, RawIngressRule,
-        default_no_ingress_rule, find_matching_rule, parse_cli_ingress,
+        CliIngressRequest, DurationSpec, IngressIpRule, IngressRule, IngressService, NormalizedIngress,
+        OriginRequestConfig, RawIngressRule, default_no_ingress_rule, find_matching_rule, parse_cli_ingress,
     };
     use crate::error::ConfigError;
 
@@ -519,6 +632,7 @@ mod tests {
                 service: Some("https://localhost:8080".to_owned()),
                 ..RawIngressRule::default()
             },
+            &OriginRequestConfig::default(),
             0,
             1,
         ));
@@ -534,6 +648,7 @@ mod tests {
                 service: Some("https://localhost:8080".to_owned()),
                 ..RawIngressRule::default()
             },
+            &OriginRequestConfig::default(),
             0,
             1,
         )
@@ -555,6 +670,7 @@ mod tests {
                 service: Some("https://localhost:8080".to_owned()),
                 ..RawIngressRule::default()
             },
+            &OriginRequestConfig::default(),
             0,
             2,
         ));
@@ -574,6 +690,7 @@ mod tests {
                     service: Some("https://localhost:8080".to_owned()),
                     ..RawIngressRule::default()
                 },
+                &OriginRequestConfig::default(),
                 0,
                 3,
             )),
@@ -584,6 +701,7 @@ mod tests {
                     service: Some("https://localhost:8081".to_owned()),
                     ..RawIngressRule::default()
                 },
+                &OriginRequestConfig::default(),
                 1,
                 3,
             )),
@@ -592,6 +710,7 @@ mod tests {
                     service: Some("http_status:404".to_owned()),
                     ..RawIngressRule::default()
                 },
+                &OriginRequestConfig::default(),
                 2,
                 3,
             )),
@@ -621,6 +740,7 @@ mod tests {
                     service: Some("https://localhost:8080".to_owned()),
                     ..RawIngressRule::default()
                 },
+                &OriginRequestConfig::default(),
                 0,
                 2,
             )),
@@ -629,6 +749,7 @@ mod tests {
                     service: Some("http_status:404".to_owned()),
                     ..RawIngressRule::default()
                 },
+                &OriginRequestConfig::default(),
                 1,
                 2,
             )),
@@ -676,6 +797,52 @@ mod tests {
 
         assert_eq!(ingress.rules[0].service, IngressService::Bastion);
         assert_eq!(ingress.defaults.bastion_mode, Some(true));
+    }
+
+    #[test]
+    fn cli_ingress_materializes_go_default_representation() {
+        let ingress = ok(parse_cli_ingress(&["--hello-world".to_owned()]));
+
+        assert_eq!(
+            ingress.defaults.keep_alive_timeout,
+            Some(DurationSpec("1m30s".to_owned()))
+        );
+        assert_eq!(ingress.defaults.proxy_port, Some(0));
+        assert_eq!(ingress.defaults.bastion_mode, Some(false));
+        assert_eq!(ingress.rules[0].origin_request, ingress.defaults);
+    }
+
+    #[test]
+    fn inherited_origin_request_defaults_materialize_and_merge() {
+        let inherited = OriginRequestConfig::materialized_config_defaults(&OriginRequestConfig {
+            ip_rules: vec![IngressIpRule {
+                prefix: Some("10.0.0.0/8".to_owned()),
+                ports: vec![80, 8080],
+                allow: false,
+            }],
+            ..OriginRequestConfig::default()
+        });
+        let rule = ok(IngressRule::from_raw(
+            RawIngressRule {
+                service: Some("https://localhost:8080".to_owned()),
+                ..RawIngressRule::default()
+            },
+            &inherited,
+            0,
+            1,
+        ));
+
+        assert_eq!(
+            rule.origin_request.connect_timeout,
+            Some(DurationSpec("30s".to_owned()))
+        );
+        assert_eq!(
+            rule.origin_request.keep_alive_timeout,
+            Some(DurationSpec("1m30s".to_owned()))
+        );
+        assert_eq!(rule.origin_request.proxy_port, Some(0));
+        assert_eq!(rule.origin_request.bastion_mode, Some(false));
+        assert_eq!(rule.origin_request.ip_rules, inherited.ip_rules);
     }
 
     #[test]

--- a/crates/cloudflared-config/src/normalized.rs
+++ b/crates/cloudflared-config/src/normalized.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::credentials::{CredentialSurface, TunnelReference};
 use crate::discovery::ConfigSource;
 use crate::error::Result;
-use crate::ingress::{IngressRule, default_no_ingress_rule};
+use crate::ingress::{IngressRule, OriginRequestConfig, default_no_ingress_rule};
 use crate::raw_config::{RawConfig, WarpRoutingConfig};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -34,6 +34,7 @@ impl NormalizedConfig {
             vec![NormalizationWarning::UnknownTopLevelKeys(unknown_top_level_keys)]
         };
         let tunnel = raw.tunnel.map(TunnelReference::from_raw);
+        let inherited_origin_request = OriginRequestConfig::materialized_config_defaults(&raw.origin_request);
 
         let ingress = if raw.ingress.is_empty() {
             vec![default_no_ingress_rule()]
@@ -42,7 +43,9 @@ impl NormalizedConfig {
             raw.ingress
                 .into_iter()
                 .enumerate()
-                .map(|(rule_index, rule)| IngressRule::from_raw(rule, rule_index, total_rules))
+                .map(|(rule_index, rule)| {
+                    IngressRule::from_raw(rule, &inherited_origin_request, rule_index, total_rules)
+                })
                 .collect::<Result<Vec<_>>>()?
         };
 
@@ -51,7 +54,7 @@ impl NormalizedConfig {
             tunnel: tunnel.clone(),
             credentials: CredentialSurface::configured(raw.credentials_file, raw.origin_cert, tunnel),
             ingress,
-            origin_request: raw.origin_request,
+            origin_request: inherited_origin_request,
             warp_routing: raw.warp_routing,
             log_directory: raw.log_directory,
             warnings,
@@ -121,5 +124,39 @@ mod tests {
                 .map(|value| value.0.as_str()),
             Some("30s")
         );
+        assert_eq!(
+            normalized
+                .origin_request
+                .keep_alive_timeout
+                .as_ref()
+                .map(|value| value.0.as_str()),
+            Some("1m30s")
+        );
+    }
+
+    #[test]
+    fn normalization_propagates_materialized_origin_request_to_rules() {
+        let raw = ok(RawConfig::from_yaml_str(
+            "fixture.yaml",
+            "originRequest:\n  ipRules:\n    - prefix: 10.0.0.0/8\n      ports: [80, 8080]\n      allow: false\ningress:\n  - hostname: tunnel1.example.com\n    service: https://localhost:8080\n  - service: https://localhost:8001\n",
+        ));
+        let normalized = ok(NormalizedConfig::from_raw(
+            ConfigSource::DiscoveredPath("/tmp/config.yml".into()),
+            raw,
+        ));
+
+        assert_eq!(normalized.ingress.len(), 2);
+        assert_eq!(
+            normalized.ingress[0]
+                .origin_request
+                .keep_alive_timeout
+                .as_ref()
+                .map(|value| value.0.as_str()),
+            Some("1m30s")
+        );
+        assert_eq!(normalized.ingress[0].origin_request.proxy_port, Some(0));
+        assert_eq!(normalized.ingress[0].origin_request.bastion_mode, Some(false));
+        assert_eq!(normalized.ingress[0].origin_request.ip_rules.len(), 1);
+        assert_eq!(normalized.ingress[1].origin_request.ip_rules.len(), 1);
     }
 }

--- a/crates/cloudflared-config/tests/README.md
+++ b/crates/cloudflared-config/tests/README.md
@@ -16,10 +16,10 @@ Current state:
 - Phase 1B.2 can emit Rust actual artifacts for config discovery/loading fixtures
 - Phase 1B.3 can emit Rust actual artifacts for credentials/origin-cert fixtures
 - Phase 1B.4 can emit Rust actual artifacts for ingress normalization and ordering/defaulting fixtures
-- Phase 1B.5 has checked-in Go truth artifacts for the accepted first-slice fixture surface
-- Phase 1B.5 compare mode now runs a real Rust-versus-Go comparison for that surface
-- config, credentials, and ingress behavior are only partially implemented
-- Rust-versus-Go parity is not complete yet
+- checked-in Go truth artifacts exist for the accepted first-slice fixture surface
+- Phase 1B.6 closes the accepted first-slice Rust-versus-Go mismatch set
+- Phase 1B.6 compare mode runs a real Rust-versus-Go comparison for that surface and is currently green
+- config, credentials, and ingress behavior are parity-backed only for the accepted first slice
 
 Phase 1A outputs in this directory:
 
@@ -40,8 +40,8 @@ Current execution model:
  artifacts for the currently implemented config, credentials, and ingress fixtures
 - `python3 tools/first_slice_parity.py compare --require-go-truth --require-rust-actual`
  now runs a real compare and exits nonzero when artifacts differ
-- `cargo test -p cloudflared-config` validates the fixture inventory and keeps
- the harness gate and a matching compare subset executable
+- `cargo test -p cloudflared-config` validates the fixture inventory, the Go-truth gate,
+ the narrow compare checks, and the full accepted first-slice compare closure
 
 Source-of-truth rule:
 

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/README.md
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/README.md
@@ -22,5 +22,6 @@ Current truthfulness rule:
 
 - these artifacts make the compare loop real
 - they do not imply that Rust parity is complete
-- the full compare still reports live mismatches for part of the accepted
- first-slice surface
+- the accepted first-slice compare is currently green against these artifacts
+- they still do not imply broader Phase 1 or full-rewrite parity beyond the
+ accepted fixture surface

--- a/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
+++ b/crates/cloudflared-config/tests/fixtures/first-slice/golden/rust-actual/README.md
@@ -3,15 +3,15 @@
 This directory is reserved for canonical JSON emitted by the Rust-side first
 slice harness path.
 
-Current state after Phase 1B.5:
+Current state after Phase 1B.6:
 
 - config discovery and config loading fixtures can emit Rust actual reports
 - credentials/origin-cert fixtures can emit Rust actual reports
 - ingress normalization and ordering/defaulting fixtures can emit Rust actual reports
 - the files are generated via `python3 tools/first_slice_parity.py emit-rust-actual`
 - the compare workflow can also emit fresh temporary Rust actual artifacts on demand
-- the output remains incomplete for first-slice categories that are still out of
- scope for this phase
+- the accepted first-slice compare now runs green against the checked-in Go truth
+- the output remains intentionally limited to the accepted first-slice categories
 
 The directory should remain reviewable and stable:
 

--- a/crates/cloudflared-config/tests/phase_1a_parity_scaffold.rs
+++ b/crates/cloudflared-config/tests/phase_1a_parity_scaffold.rs
@@ -49,3 +49,20 @@ fn rust_parity_compare_entrypoint_is_real_for_matching_subset() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn full_first_slice_compare_is_green() {
+    let output = Command::new("python3")
+        .arg(support::tool_path())
+        .arg("compare")
+        .arg("--require-go-truth")
+        .arg("--require-rust-actual")
+        .output()
+        .expect("python3 should be available to run the first-slice parity harness");
+
+    assert!(
+        output.status.success(),
+        "expected full accepted first-slice compare to pass; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/cloudflared-config/tests/phase_1b4_ingress.rs
+++ b/crates/cloudflared-config/tests/phase_1b4_ingress.rs
@@ -73,6 +73,17 @@ fn cli_origin_url_http_normalizes_to_http_service() {
         }
         other => panic!("expected HTTP service, found {other:?}"),
     }
+
+    assert_eq!(
+        ingress
+            .defaults
+            .keep_alive_timeout
+            .as_ref()
+            .map(|value| value.0.as_str()),
+        Some("1m30s")
+    );
+    assert_eq!(ingress.defaults.proxy_port, Some(0));
+    assert_eq!(ingress.defaults.bastion_mode, Some(false));
 }
 
 #[test]
@@ -115,6 +126,9 @@ fn harness_can_emit_ingress_related_rust_actual_artifacts() {
         cli_payload["payload"]["rules"][0]["service"]["kind"],
         "hello-world"
     );
+    assert_eq!(cli_payload["payload"]["defaults"]["keepAliveTimeout"], "1m30s");
+    assert_eq!(cli_payload["payload"]["defaults"]["proxyPort"], 0);
+    assert_eq!(cli_payload["payload"]["defaults"]["bastionMode"], false);
 
     let cli_error_artifact = output_dir.join("cli-origin-no-origin.json");
     let cli_error_payload: serde_json::Value = serde_json::from_str(
@@ -133,6 +147,21 @@ fn harness_can_emit_ingress_related_rust_actual_artifacts() {
     assert_eq!(
         ordering_payload["payload"]["ingress"][1]["service"]["kind"],
         "http"
+    );
+    assert!(ordering_payload["payload"]["warnings"].is_null());
+    assert_eq!(
+        ordering_payload["payload"]["ingress"][0]["origin_request"]["keepAliveTimeout"],
+        "1m30s"
+    );
+    assert_eq!(
+        ordering_payload["payload"]["ingress"][0]["origin_request"]["proxyPort"],
+        0
+    );
+    assert_eq!(
+        ordering_payload["payload"]["ingress"][0]["origin_request"]["ipRules"]
+            .as_array()
+            .map(|rules| rules.len()),
+        Some(2)
     );
 
     fs::remove_dir_all(output_dir).expect("temp directory should be removable");

--- a/tools/first_slice_parity.py
+++ b/tools/first_slice_parity.py
@@ -182,7 +182,7 @@ def cmd_inventory(args: argparse.Namespace, fixtures: list[Fixture]) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
 
-    print("Phase 1A fixture inventory")
+    print("First-slice fixture inventory")
     print(f"fixture root: {FIXTURE_ROOT.relative_to(REPO_ROOT).as_posix()}")
     print(f"fixtures: {len(fixtures)}")
     for fixture in fixtures:
@@ -271,7 +271,7 @@ def cmd_compare(args: argparse.Namespace, fixtures: list[Fixture]) -> int:
         fixture for fixture in selected if not fixture.go_truth_path.exists()
     ]
 
-    print("Phase 1B.5 Rust-vs-Go comparison")
+    print("First-slice Rust-vs-Go comparison")
     print(f"selected fixtures: {len(selected)}")
     print(f"missing Go truth: {len(missing_go_truth)}")
 


### PR DESCRIPTION
## What this PR does

This PR closes the remaining parity gaps in the accepted first slice.

The focus here is narrow: fix the known Rust-versus-Go mismatches in the current fixture surface, keep the compare path real, and get the first-slice comparison green without widening into broader Phase 1 work.

## Included in this PR

- fixes for the remaining ingress default-propagation mismatches
- fixes for the remaining single-origin CLI normalization mismatches
- targeted test and compare updates tied to those mismatch clusters
- small status/doc updates to reflect the new compare result

## Scope

This PR stays within the accepted first slice and only targets the known mismatch set.

## Not included

This PR does not cover:
- transport or proxying
- runtime / supervisor behavior
- metrics or management APIs
- broader CLI work
- new subsystem implementation outside the accepted first slice

## Why now

The previous step made Go truth capture and real Rust-versus-Go comparison executable.

This PR is the follow-through: close the remaining gaps so the accepted first-slice compare finishes green.

## Current status after this PR

What exists after this:
- checked-in Go truth for the accepted first-slice fixture surface
- real Rust-versus-Go compare behavior
- accepted first-slice compare passing for the targeted fixture set

What still comes next:
- broader Phase 1 work outside the accepted first slice