### PR TITLE
rust-rewrite: phase 2.1 build policy with the frozen linux artifact lanes

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -1,4 +1,4 @@
-name: On PR Merge - Build & Push
+name: On PR Merge - Build Preview Artifacts
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
       - main
     types:
       - closed
+  workflow_dispatch:
 
 concurrency:
   group: on-pr-merge-${{ github.ref }}
@@ -19,12 +20,19 @@ env:
   TARGET: x86_64-unknown-linux-gnu
   PACKAGE_NAME: cloudflared-cli
   BIN_NAME: cloudflared
-  ARTIFACT_BASENAME: cloudflared-${{ github.sha }}-x86_64-unknown-linux-gnu
 
 jobs:
   build-preview:
-    if: github.event.pull_request.merged == true
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: x86-64-v2
+            rustflags: -C target-cpu=x86-64-v2 -C strip=symbols
+          - lane: x86-64-v4
+            rustflags: -C target-cpu=x86-64-v4 -C strip=symbols
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,13 +45,14 @@ jobs:
           cargo -V
       - name: Test (stable)
         run: cargo test --workspace --locked
-      - name: Build release binary (stable)
+      - name: Build release binary (${{ matrix.lane }})
         env:
-          RUSTFLAGS: -C target-cpu=x86-64-v2 -C strip=symbols
+          RUSTFLAGS: ${{ matrix.rustflags }}
         run: |
           cargo build --release --locked --target "${TARGET}" -p "${PACKAGE_NAME}"
-      - name: Package tgz
+      - name: Package preview artifact (${{ matrix.lane }})
         run: |
+          ARTIFACT_BASENAME="cloudflared-${GITHUB_SHA}-linux-x86_64-gnu-${{ matrix.lane }}"
           rm -rf dist
           mkdir -p dist
           install -Dm755 "target/${TARGET}/release/${BIN_NAME}" "dist/${BIN_NAME}"
@@ -53,13 +62,13 @@ jobs:
           if [ -f LICENSE ]; then
             cp LICENSE dist/
           fi
-          tar -C dist -czf "${ARTIFACT_BASENAME}.tgz" .
-          sha256sum "${ARTIFACT_BASENAME}.tgz" > "${ARTIFACT_BASENAME}.sha256"
+          tar -C dist -czf "${ARTIFACT_BASENAME}.tar.gz" .
+          sha256sum "${ARTIFACT_BASENAME}.tar.gz" > "${ARTIFACT_BASENAME}.tar.gz.sha256"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_BASENAME }}
+          name: cloudflared-${{ github.sha }}-linux-x86_64-gnu-${{ matrix.lane }}
           path: |
-            ${{ env.ARTIFACT_BASENAME }}.tgz
-            ${{ env.ARTIFACT_BASENAME }}.sha256
+            cloudflared-${{ github.sha }}-linux-x86_64-gnu-${{ matrix.lane }}.tar.gz
+            cloudflared-${{ github.sha }}-linux-x86_64-gnu-${{ matrix.lane }}.tar.gz.sha256
           retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ Do not turn this file into a status report, architecture dump, dependency catalo
 - `docs/compatibility-scope.md`
   - what "compatible" means
 
+- `docs/build-artifact-policy.md`
+  - local dev build expectations
+  - CI validation policy
+  - shipped artifact policy
+
 - `docs/promotion-gates.md`
   - current big-phase model
   - active phase/task
@@ -58,6 +63,7 @@ Before answering or patching, classify the task:
 2. current repository state: use `STATUS.md`
 3. phase model / promotion boundaries: use `docs/promotion-gates.md`
 4. scope / lane / non-negotiables: use `REWRITE_CHARTER.md`
-5. dependency / allocator / runtime policy: use the matching file under `docs/`
+5. build / artifact policy: use `docs/build-artifact-policy.md`
+6. dependency / allocator / runtime policy: use the matching file under `docs/`
 
 If evidence is missing or conflicting, say so explicitly.

--- a/STATUS.md
+++ b/STATUS.md
@@ -48,6 +48,7 @@ If sources disagree, use this precedence order:
 The following top-level rewrite decisions are part of the active scaffold:
 
 - `docs/compatibility-scope.md`
+- `docs/build-artifact-policy.md`
 - `docs/go-rust-semantic-mapping.md`
 - `docs/dependency-policy.md`
 - `docs/allocator-runtime-baseline.md`
@@ -61,7 +62,7 @@ The following top-level rewrite decisions are part of the active scaffold:
   - broader subsystem work remains mostly unported
 - Big Phase 2 is current:
   - purpose: freeze the Linux production-alpha lane
-  - active task: 2.0 governance realignment only
+  - active task: 2.1 build and artifact policy
 - Big Phase 3 is later:
   - build the minimum runnable alpha on the frozen lane
 - Big Phase 4 is later:
@@ -126,13 +127,29 @@ the Rust workspace instead of modifying the frozen reference material.
   `docs/allocator-runtime-baseline.md` and
   `docs/adr/0001-hybrid-concurrency-model.md`.
 
+## Active Phase 2.1 Focus
+
+Phase 2.1 now owns build and artifact policy for the frozen Linux
+production-alpha lane.
+
+What it covers now:
+
+- local developer builds remain generic by default
+- PR CI validates the generic Linux workspace rather than silently hardcoding a
+  shipped CPU lane
+- shipped artifact policy is GNU only and lane-explicit
+- artifact naming, checksum naming, and workflow matrix policy are explicit
+
+What it still must not imply:
+
+- that 2.2 through 2.5 are already done
+- that broader runtime, transport, Pingora, FIPS operational, or deployment
+  implementation already exists
+
 ## Deferred Within Big Phase 2
 
-The following lane-freeze work is intentionally deferred beyond 2.0:
+The following lane-freeze work is intentionally deferred beyond 2.1:
 
-- 2.1 build and artifact policy:
-  - CI/build alignment for the real alpha lane
-  - exact GNU artifact naming, checksum naming, and matrix policy
 - 2.2 transport / TLS / crypto ADR:
   - quiche + BoringSSL
   - 0-RTT requirement

--- a/docs/build-artifact-policy.md
+++ b/docs/build-artifact-policy.md
@@ -1,0 +1,133 @@
+# Build And Artifact Policy
+
+This document defines the build, CI, and shipped-artifact policy for the frozen
+Linux production-alpha lane.
+
+It exists to keep local developer builds, CI validation, and shipped artifact
+claims aligned without implying broader implementation or release automation
+than the repository actually has.
+
+## Active lane
+
+This policy applies to the active lane only:
+
+- Linux only
+- target triple: `x86_64-unknown-linux-gnu`
+- shipped GNU artifacts only:
+  - `x86-64-v2`
+  - `x86-64-v4`
+
+This policy does not admit musl as an active alpha artifact target.
+
+## Local developer builds
+
+Local developer builds should remain generic by default.
+
+That means:
+
+- repo-default local builds must not silently hardcode a shipped CPU lane
+- `.cargo/config.toml` may carry generic release tuning
+- lane-specific `RUSTFLAGS` belong only in explicit build workflows or explicit
+  local commands
+
+Current repo posture:
+
+- `.cargo/config.toml` keeps generic release tuning only
+- no repo-default target CPU lane is hardcoded for normal local builds
+
+## CI validation policy
+
+PR CI may be narrower than release or manual artifact builds.
+
+Current PR CI policy:
+
+- validate the generic Linux workspace
+- run formatting, `cargo check`, `cargo clippy`, and `cargo test`
+- do not treat PR validation as proof that both shipped CPU lanes are fully
+  operational unless lane-specific artifact builds also run
+
+Current workflow mapping:
+
+- `.github/workflows/on-pr-push.yml` validates the generic workspace
+
+## Release artifact policy
+
+The shipped artifact policy for the production-alpha lane is GNU only and lane
+explicit.
+
+Shipped release artifacts are exactly:
+
+- `x86-64-v2`
+- `x86-64-v4`
+
+No other CPU tiers are admitted by this policy.
+No musl artifacts are admitted by this policy.
+
+## Artifact filename schema
+
+The lane must appear in the artifact filename.
+
+For release artifacts, the schema is:
+
+- `cloudflared-{version}-linux-x86_64-gnu-{lane}.tar.gz`
+
+Examples:
+
+- `cloudflared-2026.2.0-alpha.202603-linux-x86_64-gnu-x86-64-v2.tar.gz`
+- `cloudflared-2026.2.0-alpha.202603-linux-x86_64-gnu-x86-64-v4.tar.gz`
+
+For non-release preview artifacts produced by merge or manual workflows, a git
+SHA may replace `{version}` while keeping the same suffix ordering:
+
+- `cloudflared-{git-sha}-linux-x86_64-gnu-{lane}.tar.gz`
+
+## Checksum filename schema
+
+Checksum filenames must make the covered artifact obvious.
+
+The schema is:
+
+- `{artifact_filename}.sha256`
+
+Examples:
+
+- `cloudflared-2026.2.0-alpha.202603-linux-x86_64-gnu-x86-64-v2.tar.gz.sha256`
+- `cloudflared-2026.2.0-alpha.202603-linux-x86_64-gnu-x86-64-v4.tar.gz.sha256`
+
+## Workflow matrix policy
+
+The matrix policy is intentionally split by workflow type.
+
+PR validation workflows:
+
+- may stay narrower than release or manual artifact workflows
+- should validate the generic Linux workspace
+- should not silently select a shipped CPU lane by default
+
+Merge or manual artifact workflows:
+
+- may emit lane-specific preview artifacts
+- should use the explicit GNU lane matrix:
+  - `x86-64-v2`
+  - `x86-64-v4`
+- should keep lane naming explicit in uploaded artifacts and checksum files
+
+Current repo posture:
+
+- PR CI validates the generic workspace
+- merge or manual preview artifact workflows may be more specific than PR CI
+- full release publication and packaging automation are still outside this
+  policy slice unless the workflow actually exists
+
+## Explicit non-goals
+
+This policy does not:
+
+- implement transport / TLS / crypto ADR decisions beyond the already locked
+  lane statements
+- implement Pingora critical-path behavior
+- define FIPS-in-alpha operational behavior
+- define the deployment contract
+- admit packaging, installers, updater work, or broader platform support
+- imply that both lanes are production-proven merely because artifact builds can
+  be emitted

--- a/docs/promotion-gates.md
+++ b/docs/promotion-gates.md
@@ -236,7 +236,7 @@ At the current repo state:
 
 - Big Phase 1 is done
 - Big Phase 2 is current
-- Phase 2.0 is the active task
-- Phases 2.1 through 2.5 remain intentionally deferred
+- Phase 2.1 is the active task
+- Phases 2.2 through 2.5 remain intentionally deferred
 - Big Phase 3 begins only after the Linux production-alpha lane is frozen in
   governance


### PR DESCRIPTION
## Summary

This PR moves the repository from **Phase 2.0** into **Phase 2.1**.

The goal here is narrow:
- make build and artifact policy explicit
- align the repo with the frozen Linux production-alpha lane
- keep the repo honest about what is real now versus what is still deferred

## What changed

### Phase status and routing
- marked **Phase 2.1** as the active Big Phase 2 task
- updated agent routing so build and artifact questions point to a dedicated source of truth
- kept later Big Phase 2 work clearly deferred

### New policy document
- added `docs/build-artifact-policy.md`
- defined local developer build expectations
- defined PR CI versus merge/manual artifact workflow expectations
- defined the admitted shipped GNU lanes:
  - `x86-64-v2`
  - `x86-64-v4`
- defined explicit artifact and checksum naming

### Workflow alignment
- updated the merge-preview workflow to build both admitted GNU lanes
- made preview artifact names lane-explicit
- made checksum filenames clearly map to the artifact they cover
- kept normal PR validation generic rather than silently hardcoding a shipped CPU lane

## Scope note

This PR is **build and artifact policy only**.

It does **not** claim that the following are implemented:
- 2.2 transport / TLS / crypto ADR
- 2.3 Pingora critical-path ADR
- 2.4 FIPS-in-alpha definition
- 2.5 deployment contract

It also does not claim broader runtime or transport completion.

## Why this matters

Phase 2.0 froze the Linux production-alpha lane at the governance level.

Phase 2.1 makes the build and artifact story match that lane:
- local developer builds stay generic by default
- PR validation stays generic
- preview artifacts now reflect the actual admitted GNU lanes explicitly

## Notes

- no new dependencies were added
- no runtime code was changed
- no frozen baseline files were modified