### PR TITLE
rust-rewrite: phase 2.3 adr for pingora

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    exclude-paths:
+      - "baseline-*/**"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    exclude-paths:
+      - "baseline-*/**"
+    schedule:
+      interval: "daily"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,9 @@ Do not turn this file into a status report, architecture dump, dependency catalo
 - `docs/adr/0002-transport-tls-crypto-lane.md`
   - transport / TLS / crypto lane decision
 
+- `docs/adr/0003-pingora-critical-path.md`
+  - Pingora critical-path scope decision
+
 - `SKILLS.md`
   - repeatable porting workflow
 
@@ -68,6 +71,7 @@ Before answering or patching, classify the task:
 4. scope / lane / non-negotiables: use `REWRITE_CHARTER.md`
 5. build / artifact policy: use `docs/build-artifact-policy.md`
 6. transport / TLS / crypto lane: use `docs/adr/0002-transport-tls-crypto-lane.md`
-7. dependency / allocator / runtime policy: use the matching file under `docs/`
+7. Pingora critical path: use `docs/adr/0003-pingora-critical-path.md`
+8. dependency / allocator / runtime policy: use the matching file under `docs/`
 
 If evidence is missing or conflicting, say so explicitly.

--- a/STATUS.md
+++ b/STATUS.md
@@ -54,6 +54,7 @@ The following top-level rewrite decisions are part of the active scaffold:
 - `docs/allocator-runtime-baseline.md`
 - `docs/adr/0001-hybrid-concurrency-model.md`
 - `docs/adr/0002-transport-tls-crypto-lane.md`
+- `docs/adr/0003-pingora-critical-path.md`
 
 ### Active Phase Model
 
@@ -63,7 +64,7 @@ The following top-level rewrite decisions are part of the active scaffold:
   - broader subsystem work remains mostly unported
 - Big Phase 2 is current:
   - purpose: freeze the Linux production-alpha lane
-  - active task: 2.2 transport / TLS / crypto ADR
+  - active task: 2.3 Pingora critical-path ADR
 - Big Phase 3 is later:
   - build the minimum runnable alpha on the frozen lane
 - Big Phase 4 is later:
@@ -128,32 +129,28 @@ the Rust workspace instead of modifying the frozen reference material.
   `docs/allocator-runtime-baseline.md` and
   `docs/adr/0001-hybrid-concurrency-model.md`.
 
-## Active Phase 2.2 Focus
+## Active Phase 2.3 Focus
 
-Phase 2.2 now owns transport / TLS / crypto lane freeze for the frozen Linux
+Phase 2.3 now owns Pingora critical-path scope freeze for the frozen Linux
 production-alpha lane.
 
 What it covers now:
 
-- 0-RTT is explicitly required for the alpha lane
-- quiche is explicitly chosen as the first transport implementation direction
-- quiche + BoringSSL is explicitly chosen for the alpha lane
-- quiche + OpenSSL is explicitly out for the alpha lane
-- the PQC-compatible QUIC direction is explicitly part of the chosen lane
+- Pingora's relationship to the quiche transport lane is explicitly frozen
+- Pingora's initial responsibilities in the production-alpha path are explicit
+- Pingora's explicit non-responsibilities are stated
+- the first admitted Pingora crates are explicit
 
 What it still must not imply:
 
-- that 2.3 through 2.5 are already done
+- that 2.4 through 2.5 are already done
 - that broader runtime, transport, Pingora, FIPS operational, or deployment
   implementation already exists
 
 ## Deferred Within Big Phase 2
 
-The following lane-freeze work is intentionally deferred beyond 2.2:
+The following lane-freeze work is intentionally deferred beyond 2.3:
 
-- 2.3 Pingora critical-path ADR:
-  - initial critical-path responsibilities
-  - first admitted Pingora crates
 - 2.4 FIPS-in-alpha definition:
   - runtime crypto boundary
   - build/link boundary

--- a/docs/adr/0003-pingora-critical-path.md
+++ b/docs/adr/0003-pingora-critical-path.md
@@ -1,0 +1,111 @@
+# ADR 0003: Pingora Critical Path
+
+- Status: Accepted
+- Date: 2026-03-10
+
+## Context
+
+The frozen Linux production-alpha lane already states that Pingora is in the
+production-alpha critical path.
+
+ADR 0002 freezes the transport / TLS / crypto lane around quiche first and
+quiche + BoringSSL. That leaves one governance gap: the repository still needs
+an explicit statement of where Pingora sits relative to that transport lane and
+what Pingora initially owns in the production-alpha path.
+
+This ADR is governance-level scope freeze only.
+It does not add Pingora crates.
+It does not implement Pingora integration.
+
+## Decision
+
+Pingora is part of the production-alpha critical path, but it does not replace
+the quiche transport lane frozen in ADR 0002.
+
+The governing relationship is:
+
+- quiche remains the first transport implementation direction
+- quiche + BoringSSL remains the governing transport / TLS / crypto lane
+- Pingora sits above that lane in the production-alpha path
+- Pingora is the initial application-layer proxy path, not the transport owner
+
+This ADR is normative for Pingora scope in the production-alpha lane.
+
+## Initial Responsibilities
+
+Pingora's initial production-alpha responsibilities are:
+
+- request handling and proxy-path orchestration above the frozen quiche
+  transport lane
+- origin-facing HTTP request/response forwarding responsibilities in the alpha
+  critical path
+- connection reuse, pooling, and related request-path lifecycle concerns at the
+  application layer
+- request-path policy hooks, backpressure points, and middleware-style control
+  points that belong above transport ownership
+
+## Explicit Non-Responsibilities
+
+Pingora does not own yet:
+
+- the quiche transport lane itself
+- TLS or crypto ownership for the alpha lane
+- 0-RTT implementation ownership as a completed behavior claim
+- datagram or non-HTTP transport behavior
+- supervisor, orchestrator, or whole-program runtime governance
+- FIPS-in-alpha operational behavior
+- deployment-contract assumptions
+
+## First Admitted Pingora Crates
+
+The first admitted Pingora crates for the production-alpha path are defined as:
+
+- `pingora-core`
+- `pingora-http`
+- `pingora-proxy`
+
+This ADR does not add those crates yet.
+It only freezes the first admitted Pingora crate set at the governance level.
+
+## Rejected Alternatives
+
+### Pingora As Optional / Not Critical In The Alpha Lane
+
+Rejected because the frozen lane already states that Pingora is in the
+production-alpha critical path.
+
+### Pingora Replacing The Quiche Transport Lane
+
+Rejected because ADR 0002 already freezes quiche first and quiche + BoringSSL
+as the governing transport / TLS / crypto lane.
+
+### Pingora As A Whole-Program Governing Framework At This Stage
+
+Rejected because the alpha lane still needs a narrow, explicit scope boundary.
+Treating Pingora as the whole-program governing framework would silently widen
+its role before runtime implementation evidence exists.
+
+### Deferring All Pingora Decisions Until Runtime Implementation
+
+Rejected because that would leave the critical-path story ambiguous and allow
+the repo to drift between incompatible ownership models during later runtime
+work.
+
+## Consequences
+
+- future runtime and dependency work must treat Pingora as an application-layer
+  critical-path component above the quiche lane, not as a transport replacement
+- future dependency admission for Pingora crates must stay within the first
+  admitted crate set unless governance is changed explicitly
+- the repository must not describe Pingora integration as implemented merely
+  because this ADR freezes scope
+- later FIPS and deployment decisions must stay consistent with this Pingora ↔
+  quiche relationship
+
+## Deferred Follow-Ups
+
+- Phase 2.4: define what FIPS-in-alpha means at the runtime, build, and
+  validation boundary
+- Phase 2.5: define the Linux deployment contract
+- later implementation phases: realize the Pingora critical path above the
+  frozen quiche lane without widening platform or artifact scope

--- a/docs/promotion-gates.md
+++ b/docs/promotion-gates.md
@@ -236,7 +236,7 @@ At the current repo state:
 
 - Big Phase 1 is done
 - Big Phase 2 is current
-- Phase 2.2 is the active task
-- Phases 2.3 through 2.5 remain intentionally deferred
+- Phase 2.3 is the active task
+- Phases 2.4 through 2.5 remain intentionally deferred
 - Big Phase 3 begins only after the Linux production-alpha lane is frozen in
   governance


### PR DESCRIPTION
This pull request formalizes the governance and scope of Pingora in the production-alpha critical path by introducing a new ADR and updating documentation to reflect this decision. The main change is the addition of `docs/adr/0003-pingora-critical-path.md`, which clearly defines Pingora's role, responsibilities, and boundaries above the frozen quiche transport lane. Documentation across the project is updated to reference this new ADR and to reflect the shift in focus from transport/TLS/crypto to Pingora's critical path.

**Pingora Critical Path Governance**

* Added `docs/adr/0003-pingora-critical-path.md` to explicitly define Pingora's role in the production-alpha critical path, its initial responsibilities, non-responsibilities, and the first admitted Pingora crates.
* Updated `STATUS.md` to reference the new Pingora critical path ADR, adjust phase numbering, and clarify that Phase 2.3 now focuses on Pingora's scope freeze instead of transport/TLS/crypto. [[1]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR57) [[2]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL66-R67) [[3]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL131-L156)
* Updated `docs/promotion-gates.md` to set Phase 2.3 as the active task and defer subsequent phases, aligning with the new Pingora critical path focus.

**Documentation and Classification Updates**

* Updated `AGENTS.md` to reference the new Pingora critical path ADR in both the rewrite decisions list and task classification guidelines. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R48-R50) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L71-R75)

**Dependency Management**

* Added `.github/dependabot.yml` to enable daily automated dependency updates for Cargo, Go modules, and Python packages, with baseline paths excluded for Go and Python.