### PR TITLE
rust-rewrite: phase 2.4 adr fips in alpha stage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,9 @@ Do not turn this file into a status report, architecture dump, dependency catalo
 - `docs/adr/0003-pingora-critical-path.md`
   - Pingora critical-path scope decision
 
+- `docs/adr/0004-fips-in-alpha-definition.md`
+  - FIPS-in-alpha boundary and validation definition
+
 - `SKILLS.md`
   - repeatable porting workflow
 
@@ -72,6 +75,7 @@ Before answering or patching, classify the task:
 5. build / artifact policy: use `docs/build-artifact-policy.md`
 6. transport / TLS / crypto lane: use `docs/adr/0002-transport-tls-crypto-lane.md`
 7. Pingora critical path: use `docs/adr/0003-pingora-critical-path.md`
-8. dependency / allocator / runtime policy: use the matching file under `docs/`
+8. FIPS-in-alpha boundary: use `docs/adr/0004-fips-in-alpha-definition.md`
+9. dependency / allocator / runtime policy: use the matching file under `docs/`
 
 If evidence is missing or conflicting, say so explicitly.

--- a/STATUS.md
+++ b/STATUS.md
@@ -55,6 +55,7 @@ The following top-level rewrite decisions are part of the active scaffold:
 - `docs/adr/0001-hybrid-concurrency-model.md`
 - `docs/adr/0002-transport-tls-crypto-lane.md`
 - `docs/adr/0003-pingora-critical-path.md`
+- `docs/adr/0004-fips-in-alpha-definition.md`
 
 ### Active Phase Model
 
@@ -64,7 +65,7 @@ The following top-level rewrite decisions are part of the active scaffold:
   - broader subsystem work remains mostly unported
 - Big Phase 2 is current:
   - purpose: freeze the Linux production-alpha lane
-  - active task: 2.3 Pingora critical-path ADR
+  - active task: 2.4 FIPS-in-alpha definition
 - Big Phase 3 is later:
   - build the minimum runnable alpha on the frozen lane
 - Big Phase 4 is later:
@@ -129,32 +130,29 @@ the Rust workspace instead of modifying the frozen reference material.
   `docs/allocator-runtime-baseline.md` and
   `docs/adr/0001-hybrid-concurrency-model.md`.
 
-## Active Phase 2.3 Focus
+## Active Phase 2.4 Focus
 
-Phase 2.3 now owns Pingora critical-path scope freeze for the frozen Linux
-production-alpha lane.
+Phase 2.4 now owns the governance definition of FIPS-in-alpha for the frozen
+Linux production-alpha lane.
 
 What it covers now:
 
-- Pingora's relationship to the quiche transport lane is explicitly frozen
-- Pingora's initial responsibilities in the production-alpha path are explicit
-- Pingora's explicit non-responsibilities are stated
-- the first admitted Pingora crates are explicit
+- FIPS is explicitly part of the production-alpha lane as a governance
+  commitment
+- the runtime crypto boundary is explicit
+- the build/link boundary is explicit
+- the validation posture is explicit
 
 What it still must not imply:
 
-- that 2.4 through 2.5 are already done
-- that broader runtime, transport, Pingora, FIPS operational, or deployment
-  implementation already exists
+- that 2.5 is already done
+- that broader runtime, transport, Pingora, FIPS operational, deployment, or
+  certification work already exists
 
 ## Deferred Within Big Phase 2
 
-The following lane-freeze work is intentionally deferred beyond 2.3:
+The following lane-freeze work is intentionally deferred beyond 2.4:
 
-- 2.4 FIPS-in-alpha definition:
-  - runtime crypto boundary
-  - build/link boundary
-  - validation posture
 - 2.5 deployment contract:
   - glibc assumptions
   - systemd/service expectations
@@ -168,7 +166,8 @@ The following remain intentionally out of the current lane-freeze task:
 - broader platform parity beyond Linux
 - broader artifact scope beyond GNU `x86-64-v2` and `x86-64-v4`
 - broad runtime implementation outside the accepted first slice
-- transport, Pingora, FIPS operational, and deployment implementation work
+- transport, Pingora, FIPS operational, deployment, and certification-proving
+  implementation work
 
 ## Phase 1A Groundwork
 

--- a/docs/adr/0004-fips-in-alpha-definition.md
+++ b/docs/adr/0004-fips-in-alpha-definition.md
@@ -1,0 +1,162 @@
+# ADR 0004: FIPS-In-Alpha Definition
+
+- Status: Accepted
+- Date: 2026-03-10
+
+## Context
+
+The frozen Linux production-alpha lane already states that FIPS belongs in the
+production-alpha lane.
+
+ADR 0002 freezes the transport / TLS / crypto lane around quiche first and
+quiche + BoringSSL. ADR 0003 freezes Pingora as an application-layer
+critical-path component above that lane.
+
+Those decisions still leave one governance gap: the repository needs an
+explicit definition of what "FIPS-in-alpha" means without implying that a
+working FIPS implementation, certification, or deployment contract already
+exists.
+
+This ADR is governance-level definition only.
+It is not dependency admission.
+It is not runtime implementation.
+It is not a certification claim.
+
+## Decision
+
+FIPS is part of the production-alpha lane, but only as a bounded governance
+definition for the alpha crypto surface.
+
+The repository adopts the following meaning for FIPS-in-alpha:
+
+- FIPS belongs in the production-alpha lane and must be evaluated as part of
+  that lane rather than deferred to a later widening phase
+- the alpha lane must carry an explicit runtime crypto boundary rather than a
+  vague whole-program FIPS story
+- the alpha lane must carry an explicit build/link boundary for that crypto
+  surface rather than treating the entire build as implicitly in scope
+- the alpha lane must carry an explicit validation posture that distinguishes
+  governance intent from implementation proof or certification
+- the repository must not describe FIPS implementation or certification as
+  existing merely because this ADR now defines the boundary
+
+This ADR is normative for the governance meaning of FIPS-in-alpha.
+
+## Runtime Crypto Boundary
+
+The runtime crypto boundary for FIPS-in-alpha is bounded to the crypto surface
+that directly serves the frozen production-alpha transport / TLS / crypto lane.
+
+For the current alpha lane, that means:
+
+- the governing runtime crypto surface is the cryptographic and TLS machinery
+  directly required by the chosen quiche + BoringSSL lane
+- the boundary is defined as a bounded crypto surface, not as the whole
+  program, whole runtime, or every crate in the workspace
+- Pingora's application-layer responsibilities stay above the transport lane
+  and do not become a blanket claim that the entire request path is already a
+  FIPS-implemented surface
+- config loading, credentials parsing, ingress normalization, supervisors,
+  orchestrators, management surfaces, and other non-crypto program regions are
+  not implicitly treated as part of a working FIPS runtime boundary merely by
+  existing in the same binary
+
+This boundary definition does not claim that the bounded runtime crypto surface
+is implemented yet.
+
+## Build/Link Boundary
+
+The build/link boundary for FIPS-in-alpha is bounded to the admitted runtime
+crypto surface and its explicit crypto provider linkage, not to the whole
+program by association.
+
+For governance purposes, that means:
+
+- any future FIPS-in-alpha implementation must make the crypto-provider
+  linkage for the bounded runtime crypto surface explicit
+- the repository must not treat generic Linux builds, generic local builds, or
+  non-crypto crates as sufficient evidence of a FIPS-bounded build
+- artifact scope remains unchanged: Linux only, `x86_64-unknown-linux-gnu`,
+  GNU `x86-64-v2`, and GNU `x86-64-v4`
+- this ADR does not widen artifact scope, platform scope, or crate admission
+  scope
+
+This boundary definition does not claim that a working FIPS build/link path
+already exists.
+
+## Validation Posture
+
+The validation posture for FIPS-in-alpha is governance-first and evidence-bound.
+
+That means:
+
+- the repository may define the required boundary before implementation exists
+- future alpha-lane work must validate the bounded crypto surface explicitly,
+  not by broad whole-program inference
+- future validation must distinguish build/link evidence, runtime behavior
+  evidence, and any later compliance or certification evidence
+- this ADR alone is not proof of a working FIPS implementation
+- this ADR alone is not proof of certification
+- broad operational compliance claims remain out of scope until later phases
+  define and validate them explicitly
+
+## Rejected Alternatives
+
+### Saying "FIPS Belongs In Alpha" Without Defining The Boundary
+
+Rejected because that would preserve ambiguity about what part of the runtime,
+build, and validation surface is actually governed.
+
+### Deferring All FIPS Meaning Until Implementation
+
+Rejected because that would let later implementation work invent the boundary
+implicitly and would make repo claims harder to review for honesty.
+
+### Treating FIPS-In-Alpha As Equivalent To Already-Certified Implementation
+
+Rejected because governance acceptance is not the same thing as implementation
+evidence or certification.
+
+### Allowing FIPS Scope To Spread Across The Whole Program Without A Bounded Crypto Surface
+
+Rejected because an unbounded whole-program claim would silently widen scope,
+hide the real crypto boundary, and make later validation and deployment claims
+less credible.
+
+## Explicit Non-Goals
+
+This ADR does not:
+
+- admit any new dependencies
+- implement runtime behavior
+- claim that a working FIPS implementation already exists
+- claim that certification already exists
+- define the deployment contract
+- make a broad operational compliance claim beyond the alpha governance
+  definition
+
+## Consequences
+
+- future runtime, dependency, and validation work must preserve a bounded FIPS
+  crypto surface for the alpha lane instead of treating FIPS as a whole-program
+  label
+- future implementation work must make the build/link boundary explicit for the
+  admitted crypto surface
+- the repository must remain explicit that FIPS is part of the production-alpha
+  lane as a governance commitment, not as proof of working implementation or
+  certification
+- later deployment and validation phases must stay consistent with the runtime
+  and build/link boundaries frozen here
+
+## Deferred Follow-Ups
+
+- Phase 2.5: define the Linux deployment contract that any later FIPS-capable
+  alpha would have to honor operationally
+- Big Phase 3: realize the bounded runtime crypto surface and explicit
+  build/link path without widening platform or artifact scope
+- Big Phase 4: validate the implemented boundary with real runtime evidence,
+  operational evidence, and any certification-adjacent proof required for
+  credible claims
+- any broader compliance, certification, or post-alpha widening work: only
+  after explicit governance change and evidence, not by implication from this
+  ADR

--- a/docs/promotion-gates.md
+++ b/docs/promotion-gates.md
@@ -236,7 +236,7 @@ At the current repo state:
 
 - Big Phase 1 is done
 - Big Phase 2 is current
-- Phase 2.3 is the active task
-- Phases 2.4 through 2.5 remain intentionally deferred
+- Phase 2.4 is the active task
+- Phase 2.5 remains intentionally deferred
 - Big Phase 3 begins only after the Linux production-alpha lane is frozen in
   governance


### PR DESCRIPTION
This pull request introduces a governance-level definition of "FIPS-in-alpha" for the production-alpha lane, formalizing its boundaries and validation posture without implying implementation or certification. The changes update documentation to reflect this new scope, replace the previous critical-path focus with FIPS-in-alpha in the active phase, and add a new ADR detailing the definition.

Governance and scope definition:

* Added `docs/adr/0004-fips-in-alpha-definition.md`, which defines the governance boundaries for FIPS-in-alpha, including explicit runtime crypto, build/link, and validation boundaries, and clarifies that this is not an implementation or certification claim.
* Updated `STATUS.md` to replace the active task from Pingora critical-path (2.3) to FIPS-in-alpha definition (2.4), and clarified the scope and deferred work accordingly. [[1]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL67-R68) [[2]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL132-L157) [[3]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL171-R170)

Documentation updates:

* Added references to `docs/adr/0004-fips-in-alpha-definition.md` in `AGENTS.md` and `STATUS.md`, and updated classification and artifact policy sections to include FIPS-in-alpha. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R51-R53) [[2]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR58)
* Updated `docs/promotion-gates.md` to reflect that Phase 2.4 (FIPS-in-alpha) is now the active task, with Phase 2.5 deferred.