### PR TITLE
rust-rewrite: phase 2.5 deployment contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,9 @@ Do not turn this file into a status report, architecture dump, dependency catalo
 - `docs/adr/0004-fips-in-alpha-definition.md`
   - FIPS-in-alpha boundary and validation definition
 
+- `docs/adr/0005-deployment-contract.md`
+  - Linux deployment contract definition
+
 - `SKILLS.md`
   - repeatable porting workflow
 
@@ -76,6 +79,7 @@ Before answering or patching, classify the task:
 6. transport / TLS / crypto lane: use `docs/adr/0002-transport-tls-crypto-lane.md`
 7. Pingora critical path: use `docs/adr/0003-pingora-critical-path.md`
 8. FIPS-in-alpha boundary: use `docs/adr/0004-fips-in-alpha-definition.md`
-9. dependency / allocator / runtime policy: use the matching file under `docs/`
+9. deployment contract: use `docs/adr/0005-deployment-contract.md`
+10. dependency / allocator / runtime policy: use the matching file under `docs/`
 
 If evidence is missing or conflicting, say so explicitly.

--- a/STATUS.md
+++ b/STATUS.md
@@ -56,6 +56,7 @@ The following top-level rewrite decisions are part of the active scaffold:
 - `docs/adr/0002-transport-tls-crypto-lane.md`
 - `docs/adr/0003-pingora-critical-path.md`
 - `docs/adr/0004-fips-in-alpha-definition.md`
+- `docs/adr/0005-deployment-contract.md`
 
 ### Active Phase Model
 
@@ -65,7 +66,7 @@ The following top-level rewrite decisions are part of the active scaffold:
   - broader subsystem work remains mostly unported
 - Big Phase 2 is current:
   - purpose: freeze the Linux production-alpha lane
-  - active task: 2.4 FIPS-in-alpha definition
+  - active task: 2.5 deployment contract
 - Big Phase 3 is later:
   - build the minimum runnable alpha on the frozen lane
 - Big Phase 4 is later:
@@ -130,34 +131,28 @@ the Rust workspace instead of modifying the frozen reference material.
   `docs/allocator-runtime-baseline.md` and
   `docs/adr/0001-hybrid-concurrency-model.md`.
 
-## Active Phase 2.4 Focus
+## Active Phase 2.5 Focus
 
-Phase 2.4 now owns the governance definition of FIPS-in-alpha for the frozen
-Linux production-alpha lane.
+Phase 2.5 now owns the governance deployment contract for the frozen Linux
+production-alpha lane.
 
 What it covers now:
 
-- FIPS is explicitly part of the production-alpha lane as a governance
-  commitment
-- the runtime crypto boundary is explicit
-- the build/link boundary is explicit
-- the validation posture is explicit
+- the Linux-only deployment baseline is explicit
+- the GNU/glibc operational baseline is explicit
+- service/supervisor expectations are explicit
+- the bare-metal-first deployment stance is explicit
+- filesystem/layout expectations are explicit
 
 What it still must not imply:
 
-- that 2.5 is already done
-- that broader runtime, transport, Pingora, FIPS operational, deployment, or
+- that Big Phase 3 or later phases are already done
+- that packaging, installer, container, deployment automation, runtime, or
   certification work already exists
 
 ## Deferred Within Big Phase 2
 
-The following lane-freeze work is intentionally deferred beyond 2.4:
-
-- 2.5 deployment contract:
-  - glibc assumptions
-  - systemd/service expectations
-  - container vs bare-metal assumptions
-  - filesystem/layout expectations
+No additional Big Phase 2 lane-freeze tasks remain after 2.5.
 
 ## Deferred Beyond Big Phase 2
 
@@ -166,8 +161,8 @@ The following remain intentionally out of the current lane-freeze task:
 - broader platform parity beyond Linux
 - broader artifact scope beyond GNU `x86-64-v2` and `x86-64-v4`
 - broad runtime implementation outside the accepted first slice
-- transport, Pingora, FIPS operational, deployment, and certification-proving
-  implementation work
+- transport, Pingora, FIPS operational, deployment, packaging, container, and
+  certification-proving implementation work
 
 ## Phase 1A Groundwork
 

--- a/docs/adr/0005-deployment-contract.md
+++ b/docs/adr/0005-deployment-contract.md
@@ -1,0 +1,163 @@
+# ADR 0005: Deployment Contract
+
+- Status: Accepted
+- Date: 2026-03-10
+
+## Context
+
+The frozen Linux production-alpha lane already fixes the platform, artifact,
+transport, Pingora, and FIPS governance direction.
+
+Those decisions still leave one governance gap: the repository needs an
+explicit Linux production-alpha deployment contract so later runtime and
+validation work does not invent operational assumptions implicitly.
+
+This ADR is governance-level deployment contract only.
+It is not runtime implementation.
+It is not packaging or installer implementation.
+It is not deployment automation.
+
+## Decision
+
+The production-alpha lane adopts a narrow Linux deployment contract.
+
+That contract means:
+
+- the governing deployment baseline is Linux only on the already frozen target
+  triple `x86_64-unknown-linux-gnu`
+- the governing operational baseline is GNU/glibc, consistent with the already
+  frozen shipped GNU artifact scope
+- the governing service model is a narrow host-supervised service model rather
+  than a broad multi-init or platform-agnostic support claim
+- the governing deployment stance is bare-metal-first rather than
+  container-first for the alpha contract
+- the governing filesystem/layout expectations must be explicit enough that
+  later packaging or deployment work can be judged against them
+
+This ADR is normative for the Linux production-alpha deployment contract.
+
+## Platform Baseline
+
+The deployment contract is Linux only.
+
+For the production-alpha lane, that means:
+
+- the governing platform remains `x86_64-unknown-linux-gnu`
+- the governing operational baseline is GNU/glibc, not musl and not a
+  multi-platform contract
+- shipped artifacts remain exactly the already frozen GNU lanes:
+  - `x86-64-v2`
+  - `x86-64-v4`
+- this ADR does not widen distro support into a broad Linux-anything claim; it
+  only freezes the contract around the existing GNU/glibc alpha lane
+
+## Service/Supervisor Expectations
+
+The deployment contract assumes a supervised long-running service environment
+on Linux hosts.
+
+For the alpha contract, that means:
+
+- the runtime is expected to operate under an external service supervisor
+  rather than as an ad hoc one-shot packaging target
+- systemd is the governing service expectation for the alpha contract
+- this expectation does not mean systemd units or service files already exist
+- broad multi-init support is not part of the governing alpha contract
+- the contract is about operational expectations, not about shipped service
+  assets in the current repository state
+
+## Deployment Stance
+
+The governing alpha deployment stance is bare-metal-first, not container-first.
+
+That means:
+
+- the deployment contract is defined first around host deployment assumptions
+  on the Linux GNU/glibc lane
+- container execution is not forbidden, but it is not the governing contract
+  for alpha acceptance
+- this ADR does not claim that container images, container deployment flows, or
+  container-specific support assets already exist
+- later container support, if admitted, must be evaluated as an explicit
+  extension of the contract rather than assumed by default
+
+## Filesystem/Layout Expectations
+
+The deployment contract requires explicit filesystem and layout expectations at
+the contract level.
+
+For the alpha contract, that means:
+
+- the executable is expected to live at a stable operator-managed host path
+- configuration, credentials, logs, and runtime state must be treated as
+  explicit operator-managed filesystem concerns rather than implicit packaging
+  side effects
+- filesystem/layout expectations must remain compatible with a supervised host
+  service model and with the current narrow first-slice config and credential
+  surfaces
+- this ADR freezes the need for explicit layout expectations without claiming
+  that final package-owned paths, installer behavior, or updater behavior
+  already exist
+
+## Rejected Alternatives
+
+### Deferring Deployment Assumptions Until Implementation
+
+Rejected because that would allow runtime, packaging, or environment choices to
+smuggle in operational assumptions before the repo defines the governing
+contract.
+
+### Container-First As The Governing Alpha Contract
+
+Rejected because the alpha lane is being frozen around a narrow Linux host
+contract, not around container image delivery as the primary operational story.
+
+### Broad Multi-Init Support In Alpha
+
+Rejected because the alpha contract must stay narrow enough to evaluate.
+Broad init-system support is widening work for later phases, not part of the
+governing alpha contract.
+
+### Broad Distro/Platform Support In Alpha
+
+Rejected because the lane is already frozen around Linux, GNU/glibc, and the
+existing shipped GNU artifact policy.
+
+### Leaving Filesystem/Layout Expectations Implicit
+
+Rejected because later packaging and deployment work cannot be reviewed
+honestly if the contract never states what host-side layout assumptions are
+allowed.
+
+## Explicit Non-Goals
+
+This ADR does not:
+
+- admit any new dependencies
+- implement runtime behavior
+- implement packaging or installers
+- implement deployment automation
+- implement container images
+- widen platform or artifact scope
+
+## Consequences
+
+- future runtime, packaging, and operational work must stay consistent with a
+  Linux GNU/glibc host contract instead of inventing deployment assumptions ad
+  hoc
+- future service assets, if added, must be judged against the narrow systemd /
+  supervised-service expectation frozen here
+- future container support, if any, must be admitted explicitly and must not be
+  described as the governing alpha contract unless governance changes
+- the repository must remain explicit that this ADR defines deployment
+  assumptions only; it does not prove deployment tooling, packaging, container
+  support, or automation already exists
+
+## Deferred Follow-Ups
+
+- Big Phase 3: realize the minimum runnable alpha against the frozen Linux GNU/
+  glibc host contract without widening platform or artifact scope
+- Big Phase 4: validate the deployment contract with real operational evidence,
+  hardening work, and measured runtime behavior in actual supervised use
+- Big Phase 5: consider any broader distro, init-system, packaging, or
+  container widening only through explicit governance change and evidence

--- a/docs/promotion-gates.md
+++ b/docs/promotion-gates.md
@@ -236,7 +236,6 @@ At the current repo state:
 
 - Big Phase 1 is done
 - Big Phase 2 is current
-- Phase 2.4 is the active task
-- Phase 2.5 remains intentionally deferred
+- Phase 2.5 is the active task
 - Big Phase 3 begins only after the Linux production-alpha lane is frozen in
   governance


### PR DESCRIPTION
This pull request formalizes the deployment contract for the Linux production-alpha lane, shifting the governance focus from FIPS-in-alpha to an explicit deployment contract. It introduces a new ADR (`docs/adr/0005-deployment-contract.md`) and updates documentation to reflect this change, clarifying operational, platform, and service expectations. The most important changes are grouped below.

**Deployment Contract Governance**

* Added `docs/adr/0005-deployment-contract.md`, which defines the Linux-only deployment contract for the production-alpha lane, specifying platform baseline, service/supervisor expectations, bare-metal-first deployment stance, and explicit filesystem/layout requirements.

**Documentation Updates**

* Updated `STATUS.md` to reflect the shift from FIPS-in-alpha (Phase 2.4) to deployment contract (Phase 2.5) as the active governance focus, and clarified the scope and deferred tasks. [[1]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL68-R69) [[2]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL133-R155) [[3]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL169-R165)
* Added references to the new deployment contract ADR in summary sections and task classification lists in `AGENTS.md` and `STATUS.md`. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R54-R56) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L79-R83) [[3]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR59)
* Updated `docs/promotion-gates.md` to mark Phase 2.5 (deployment contract) as the current active task.