### PR TITLE
rust-rewrite: manage context window (meta)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,10 +2,17 @@
 
 Use the repository's governance split correctly.
 
+Start cold reads with `docs/ai-context-routing.md`.
+Do not load all top-level governance files by default.
+
 - `REWRITE_CHARTER.md`
   - non-negotiables
   - lane decisions
   - scope boundaries
+
+- `docs/ai-context-routing.md`
+  - minimum-file routing for cold starts
+  - staged retrieval order
 
 - `STATUS.md`
   - current implemented state
@@ -26,11 +33,20 @@ Before proposing changes:
 3. keep the answer narrow to the requested scope
 4. state uncertainty explicitly if evidence is missing
 
+For compact routing questions, prefer the local MCP snapshot surface first.
+
+Examples:
+
+- use a snapshot for questions like "what phase is active?", "which file owns this topic?", or "what is the transport/Pingora/FIPS lane?"
+- use the frozen baseline after that when the question is about behavior or parity rather than governance routing
+
 For behavior and parity questions:
 
-1. use `baseline-2026.2.0/old-impl/` code and tests first
-2. use `baseline-2026.2.0/design-audit/` second
+1. use the local MCP snapshot surface first when a compact behavior/parity routing answer is enough
+2. use `baseline-2026.2.0/old-impl/` code and tests first for grounded truth
+3. use `baseline-2026.2.0/design-audit/` second
 
 Do not claim parity from Rust code shape alone.
 Do not silently widen scope.
 Do not imply later-slice behavior exists when it does not.
+Do not edit frozen inputs (`baseline-2026.2.0/old-impl/` and `baseline-2026.2.0/design-audit/`).

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: "**/*.md"
+---
+
+# Markdown instructions for cfd-rs
+
+When editing Markdown in this repository:
+
+- preserve the repository's existing governance hierarchy
+- keep docs narrow and task-oriented
+- avoid creating parallel sources of truth when an existing governing file already owns the topic
+- do not silently widen scope from the requested document into unrelated governance rewrites
+- if evidence is incomplete or conflicting, say so explicitly
+
+## Routing and authority
+
+- start cold reads with `docs/ai-context-routing.md`
+- use `REWRITE_CHARTER.md` for non-negotiables, active lane, and scope boundaries
+- use `STATUS.md` only as the short current-state index
+- use `docs/status/*.md` for focused current-state details
+- use `docs/promotion-gates.md` for phase truth and promotion boundaries
+- use `docs/*.md` policy files for dependency, runtime, compatibility, and delivery policy
+- treat `docs/code-style.md` and `docs/engineering-standards.md` as human-facing deep references, not default AI cold-start files
+- use `AGENTS.md` and `SKILLS.md` as workflow notes, not as higher-priority governance
+
+## Current-state docs
+
+- keep `STATUS.md` short and index-like
+- put detailed current-state material in the focused files under `docs/status/`
+- prefer adding or updating the smallest focused status file rather than re-growing `STATUS.md`
+
+## Anti-drift rules
+
+- branch names and draft planning notes do not change current phase truth by themselves
+- do not import roadmap text into current-state docs unless current repository evidence supports it
+- do not duplicate phase truth across multiple files when `docs/promotion-gates.md` already owns it
+- do not duplicate stable scope or lane truth when `REWRITE_CHARTER.md` already owns it
+
+## Frozen inputs
+
+- do not edit `baseline-2026.2.0/old-impl/`
+- do not edit `baseline-2026.2.0/design-audit/`
+- if frozen inputs appear inconsistent, update repo-local governance or status docs instead
+
+## Writing style
+
+- prefer short sections with clear ownership over long omnibus docs
+- keep prose explicit and concrete
+- prefer bullets for factual inventories and gates
+- avoid decorative wording, speculative claims, and unsupported completion language
+- write so both humans and retrieval-based tools can stop reading early once they have the needed answer

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -10,7 +10,44 @@ When editing Rust code or Cargo manifests in this repository:
 - preserve externally visible behavior over stylistic rewrites
 - do not add dependencies unless the active owning slice justifies them
 - follow `docs/dependency-policy.md` before changing manifests
+- use `[workspace.dependencies]` as the default review surface for normal workspace-managed third-party dependencies
+- keep crate-local dependency truth only when the dependency is intentionally private, tool-specific, experimental, or slice-isolated
 - for first-slice work, prefer synchronous and deterministic code
 - do not introduce async/runtime structure early unless the accepted slice requires it
 - avoid repo-wide refactors unless explicitly requested
 - if evidence is incomplete, say so explicitly
+
+## Local code style
+
+- prefer explicit names, explicit intermediate variables, and straightforward control flow
+- avoid dense one-liners or clever chaining when a few named steps are easier to review
+- prefer early returns, `match`, `if let`, and `let else` over deep nesting
+- keep blank lines tight; use them to separate real steps, not to add visual padding
+- use one blank line before a multi-line final expression when setup and the final return or construction are both meaningful
+- prefer `self::` for sibling module items when that makes local ownership clearer
+- prefer `Self` and `Self::` inside `impl` blocks rather than repeating the type name
+- prefer associated constants in the owning `impl` for type-local values, and avoid non-trivial magic numbers in function bodies
+- make parse and conversion targets explicit at the operation site when that improves scanability
+- keep imports specific and tidy; avoid glob imports and noisy aliasing unless there is a strong reason
+- comments should explain why, compatibility constraints, or non-obvious invariants, not obvious syntax
+- normalize AI-generated code until it reads like repository-owned code rather than mechanically valid Rust
+- avoid `unwrap` in production code; use error propagation or `expect` only for real invariants
+- keep public doc comments practical and plain about behavior, assumptions, and caller obligations
+- prefer meaningful error type and variant names over generic failure labels
+- keep test names behavior-oriented and specific
+
+## Local engineering structure
+
+- keep one primary responsibility per crate or module
+- keep public surfaces narrower than their supporting internals
+- admit third-party APIs through owned seams rather than scattering them through unrelated crates
+- prefer direct upstream loaders or mature standard-format crates over bespoke parsing when the active slice really needs that format today
+- keep parsing, encoding, and security-relevant third-party types behind local boundaries when that keeps ownership clearer
+- prefer concrete code first; add abstraction only when a second real need or clear boundary justifies it
+- keep runtime and lifecycle ownership explicit rather than hidden in background work
+- split modules by reviewable reasoning units, not by arbitrary line count alone
+
+## Review preference
+
+When multiple valid Rust shapes exist, prefer the one that is easier to understand in one pass,
+easier to review in small slices, and more consistent with surrounding repository-owned code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,14 @@ This file is the short operating guide for coding agents in this repository.
 Keep it short.
 Do not turn this file into a status report, architecture dump, dependency catalog, or command manual.
 
+Start cold reads with `docs/ai-context-routing.md`.
+Use this file as the short operating guide, not as the full routing map.
+
 ## Use the right file
+
+- `docs/ai-context-routing.md`
+  - minimum-file routing for cold starts
+  - staged retrieval order
 
 - `REWRITE_CHARTER.md`
   - shortest non-negotiables
@@ -72,23 +79,8 @@ Do not turn this file into a status report, architecture dump, dependency catalo
 
 ## Question routing
 
-Before answering or patching, classify the task:
+Use `docs/ai-context-routing.md` for the detailed task-to-file map.
 
-1. behavior / parity: use Go code/tests first, then design-audit
-2. current repository state: use `STATUS.md`
-3. phase model / promotion boundaries: use `docs/promotion-gates.md`
-4. scope / lane / non-negotiables: use `REWRITE_CHARTER.md`
-5. build / artifact policy: use `docs/build-artifact-policy.md`
-6. transport / TLS / crypto lane: use `docs/adr/0002-transport-tls-crypto-lane.md`
-7. Pingora critical path: use `docs/adr/0003-pingora-critical-path.md`
-8. FIPS-in-alpha boundary: use `docs/adr/0004-fips-in-alpha-definition.md`
-9. deployment contract: use `docs/adr/0005-deployment-contract.md`
-10. dependency admission and workspace-dependency policy: use
-  `docs/dependency-policy.md` and
-  `docs/adr/ADR-0006-standard-format-and-workspace-dependency-admission.md`
-  Treat the root manifest as the first review surface for normal workspace-
-  managed third-party dependency truth unless isolation is intentionally
-  documented.
-11. dependency / allocator / runtime policy: use the matching file under `docs/`
+For repo-state, active-phase, scope-lane, runtime-deps, lane-decisions, behavior-baseline, and governing-files questions, prefer the local MCP snapshot surface first before loading larger docs or frozen trees.
 
 If evidence is missing or conflicting, say so explicitly.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,427 +1,49 @@
 # Cloudflared Rust Rewrite Status
 
-## Classification
+This file is the short index for current repository state.
 
-This repository is currently a rewrite workspace with a frozen Go reference
-implementation and an intentionally narrow Rust first slice.
+Use it as the first status read, then load only the focused status file that
+matches the question.
 
-It is not yet a parity-complete Rust implementation workspace. The repository
-now contains a Cargo workspace skeleton plus accepted first-slice behavior in
-`crates/cloudflared-config/` for config discovery/loading, credentials
-origin-cert decoding, ingress normalization and matching, and a real
-first-slice Go-truth compare harness whose accepted fixture surface currently
-compares green. It also now contains a narrow Phase 3.3 QUIC tunnel core in
-`crates/cloudflared-cli/` that owns startup, supervision, transport session
-establishment, and runtime config handoff while still stopping honestly before
-later Pingora and broader wire/protocol slices. Most broader production-alpha
-subsystem behavior is still unported.
+## Current Summary
 
-The scaffold is intentionally real but minimal:
-
-- the workspace builds as a Rust scaffold with partial first-slice behavior
-- the runnable binary now exposes only the admitted Phase 3.3 launch,
-  runtime/lifecycle, and QUIC tunnel-core surface
-- policy and governance documents define the rewrite boundary
-- manifests should reflect only code that exists today, not speculative future
-  subsystem work
-
-## Decided Now
-
-### Compatibility Baseline
-
-- The primary rewrite target is the frozen Go snapshot in `baseline-2026.2.0/old-impl/`.
-- The target release is `2026.2.0`, as recorded at the top of
-  `baseline-2026.2.0/old-impl/RELEASE_NOTES`.
-- The documentation set in `baseline-2026.2.0/design-audit/` is the derived reference
-  and navigation layer for that snapshot.
-- The Rust workspace version must track that Go release baseline and use the
-  format `<go-release>-alpha.YYYYmm`. The current workspace version is
-  `2026.2.0-alpha.202603`.
-
-### Source Precedence
-
-If sources disagree, use this precedence order:
-
-1. `baseline-2026.2.0/old-impl/` code and tests
-2. `baseline-2026.2.0/design-audit/`
-3. `AGENTS.md`
-4. `SKILLS.md`
-
-### Governance Documents
-
-The following top-level rewrite decisions are part of the active scaffold:
-
-- `docs/compatibility-scope.md`
-- `docs/build-artifact-policy.md`
-- `docs/go-rust-semantic-mapping.md`
-- `docs/dependency-policy.md`
-- `docs/allocator-runtime-baseline.md`
-- `docs/adr/0001-hybrid-concurrency-model.md`
-- `docs/adr/0002-transport-tls-crypto-lane.md`
-- `docs/adr/0003-pingora-critical-path.md`
-- `docs/adr/0004-fips-in-alpha-definition.md`
-- `docs/adr/0005-deployment-contract.md`
-- `docs/adr/ADR-0006-standard-format-and-workspace-dependency-admission.md`
-
-### Active Phase Model
-
-- Big Phase 1 is done:
-  - truth freeze is in place
-  - the accepted first-slice compare is green
-  - broader subsystem work remains mostly unported
-- Big Phase 2 is closed and frozen:
-  - purpose was to freeze the Linux production-alpha lane
-  - tasks 2.0 through 2.6 are complete at the governance level
-- Big Phase 3 is current:
-  - purpose: build the minimum runnable alpha on the frozen lane
-  - active task: 3.3 QUIC tunnel core
-- Big Phase 4 is later:
-  - harden, validate, measure, and prove the alpha in real use
-- Big Phase 5 is later:
-  - widen intentionally only after the alpha is credible
-
-### Active Lane
-
-- Linux only
-- target triple: `x86_64-unknown-linux-gnu`
-- shipped GNU artifacts only:
-  - `x86-64-v2`
-  - `x86-64-v4`
-- 0-RTT is required
-- quiche first
-- quiche + BoringSSL
-- Pingora is in the production-alpha critical path
-- FIPS belongs in the production-alpha lane
-- Cloudflare-owned crates are preferred where they genuinely fit, but are not
-  mandatory by default
-
-### Current Workspace Shape
-
-- `baseline-2026.2.0/old-impl/` contains the frozen Go source of truth
-- `baseline-2026.2.0/design-audit/` contains the extracted spec set
-- `docs/` contains rewrite-program decisions and semantic guidance
-- `crates/` contains only minimal Rust crate skeletons
-
-Current crate intent:
-
-- `crates/cloudflared-cli`: narrow admitted alpha entry surface for help,
-  version, config-backed startup validation, the current runtime/lifecycle
-  owner, and the current QUIC transport core
-- `crates/cloudflared-config`: owning crate for the accepted first-slice
-  domain skeleton and future config, credentials, and ingress normalization
-  behavior
-- `crates/cloudflared-config/tests/`: first-slice parity harness and fixtures
-- `crates/cloudflared-core`: future shared types and cross-cutting primitives
-- `crates/cloudflared-proto`: future wire-format and RPC boundary
-
-### Frozen Inputs
-
-The following directories are immutable inputs to the rewrite program and must
-not be edited during normal rewrite work:
-
-- `baseline-2026.2.0/old-impl/`
-- `baseline-2026.2.0/design-audit/`
-
-If those inputs appear inconsistent, update top-level governance documents or
-the Rust workspace instead of modifying the frozen reference material.
-
-### Dependency And Runtime Baseline
-
-- The workspace already has a scaffold and should remain minimal and honest.
-- The runnable binary must use `mimalloc` as the process allocator.
-- The required `mimalloc` feature set is:
-  - `override`
-  - `no_thp`
-  - `local_dynamic_tls`
-  - `extended`
-- Allocator choice belongs only at the runnable binary boundary.
-  - Tokio is now admitted at the binary boundary for the active runtime/
-    lifecycle shell that underpins the current Phase 3.3 tunnel core.
-- Async runtime choice is governed by
-  `docs/allocator-runtime-baseline.md` and
-  `docs/adr/0001-hybrid-concurrency-model.md`.
-
-## Active Phase 3.3 Focus
-
-Phase 3.3 now owns the QUIC tunnel core for the frozen Linux
-production-alpha lane.
-
-What it covers now:
-
-- `run` now enters a real quiche-based transport service under the runtime
-  boundary
-- connection/session ownership and QUIC handshake state are explicit
-- runtime-owned config handoff now feeds the transport identity boundary
-- reconnect/restart policy remains owned by runtime supervision rather than
-  transport internals or the CLI shell
-- the current transport core stops honestly after QUIC establishment where the
-  later wire/protocol registration and Pingora slices do not yet exist
-
-What it still must not imply:
-
-- that Pingora integration exists
-- that wire/protocol behavior beyond the transport-owned boundary exists
-- that security/compliance operational behavior exists
-- that standard-format crate integration beyond active-slice need exists
-- that packaging, installers, updaters, or deployment tooling already exist
-
-## Deferred Within Big Phase 3
-
-The following later Big Phase 3 slices remain intentionally deferred:
-
-- 3.4 Pingora integration path above that transport lane
-- 3.5 wire/protocol boundary
-- 3.6 security/compliance operational boundary
-- 3.7 standard-format crate integration boundary
-
-## Deferred Beyond Big Phase 3
-
-The following remain intentionally out of the current executable-surface task:
-
-- broader platform parity beyond Linux
-- broader artifact scope beyond GNU `x86-64-v2` and `x86-64-v4`
-- transport, Pingora, wire/protocol, security/compliance, and
-  standard-format integration work outside their later owning slices
-- packaging, deployment tooling, container support, and
-  certification-proving work beyond the current numbered Big Phase 3 slice list
-
-## Phase 1A Groundwork
-
-Phase 1A groundwork now exists for the accepted first slice.
+This repository is a real but partial Rust rewrite workspace.
 
 What exists now:
 
-- explicit first-slice fixture taxonomy under `crates/cloudflared-config/tests/fixtures/first-slice/`
-- executable harness entrypoint at `tools/first_slice_parity.py`
-- checked-in JSON golden artifact contract for Go truth and Rust actual reports
-- Rust-side helper scaffolding and ignored parity tests in
-  `crates/cloudflared-config/tests/`
+- accepted first-slice config, credentials, and ingress behavior in
+  `crates/cloudflared-config/`
+- parity-backed accepted first-slice compare closure for the admitted fixture surface
+- a narrow Phase 3.3 QUIC tunnel core in `crates/cloudflared-cli/`
+- frozen Go baseline and design-audit references
+- governance and policy docs that freeze the Linux production-alpha lane
 
 What does not exist yet:
 
-- complete later-slice behavior outside the accepted first slice
+- Pingora integration
+- later wire/protocol slices
+- security/compliance operational behavior
+- parity-complete broader subsystem coverage
+- broader platform scope beyond the frozen Linux lane
 
-Implication:
+## Focused Status Files
 
-- the repo can now inventory and mechanically gate the first-slice parity
-  contract
-- the repo still must not claim broader rewrite parity is complete
+- `docs/status/rewrite-foundation.md`
+  - baseline, lane, source precedence, workspace shape, and runtime baseline
 
-## Phase 1B.1 Domain Skeleton
+- `docs/status/active-surface.md`
+  - current executable surface and immediate deferred scope
 
-Phase 1B.1 groundwork now exists in `crates/cloudflared-config/`.
+- `docs/status/first-slice-parity.md`
+  - first-slice implementation history and parity-backed closure state
 
-What exists now:
+- `docs/status/porting-rules.md`
+  - first implementation gate, recommended first slice, and done definition
 
-- admitted first-slice crate dependencies only in `crates/cloudflared-config/Cargo.toml`
-- explicit module layout for discovery, raw config, normalized config,
-  credentials, ingress, and error taxonomy
-- honest public APIs for raw YAML loading, credential JSON loading, and raw to
-  normalized config conversion boundaries
-- narrow unit tests covering shape-level parsing and invariants
+## Routing
 
-What does not exist yet:
-
-- parity-complete config discovery behavior
-- origin-cert PEM decoding behavior
-- ingress validation and deterministic matching behavior
-- Rust actual artifact emission for the Phase 1A harness
-
-Implication:
-
-- `cloudflared-config` is now a real owning crate for the accepted first slice
-- the crate still must not be described as a completed first-slice port
-
-## Phase 1B.2 Config Loading Path
-
-Phase 1B.2 behavior now exists for the targeted config-loading fixtures.
-
-What exists now:
-
-- deterministic config discovery with default search order and auto-create side effects
-- YAML file loading into the crate's raw config representation
-- raw-to-normalized conversion for the currently targeted config surface
-- narrow ingress validation for the current invalid and unicode config fixtures
-- Rust actual artifact emission for targeted config discovery and config loading fixtures
-
-What does not exist yet:
-
-- Go truth outputs for comparison
-- full credentials and origin-cert behavior parity
-- full ingress validation and deterministic matching behavior
-- CLI-origin ingress normalization artifacts
-
-Implication:
-
-- the accepted first slice now has a real config-loading path in Rust
-- the repository still must not claim first-slice parity is complete
-
-## Phase 1B.3 Credentials And Origin-Cert Path
-
-Phase 1B.3 behavior now exists for the targeted credentials/origin-cert
-fixtures.
-
-What exists now:
-
-- source-backed PEM scanning for origin certificates
-- tolerance for legacy `PRIVATE KEY` and `CERTIFICATE` blocks during scanning
-- rejection for unknown PEM block types and multiple token blocks
-- origin-cert JSON token extraction with endpoint lowercasing
-- account-id refresh validation through the `OriginCertUser` read path
-- Rust actual artifact emission for the targeted `credentials-origin-cert`
-  fixtures
-
-What does not exist yet:
-
-- Go truth outputs for comparison
-- default origin-cert search-path resolution behavior
-- tunnel credential file artifact fixtures
-- full ingress normalization artifact coverage
-- full first-slice parity comparisons
-
-Implication:
-
-- the accepted first slice now has a real credentials/origin-cert path in Rust
-- the repository still must not claim first-slice parity is complete
-
-## Phase 1B.4 Ingress Normalization And Matching Path
-
-Phase 1B.4 behavior now exists for the targeted ingress normalization,
-ordering/defaulting, and CLI single-origin fixtures.
-
-What exists now:
-
-- semantic ingress service normalization for the current fixture surface
-- deterministic user-rule matching with host:port stripping and catch-all fallback
-- punycode-aware hostname matching for the current IDN ingress fixture surface
-- preserved no-ingress default 503 contract through normalized config output
-- narrow CLI single-origin synthesis for `--hello-world`, `--bastion`, `--url`,
-  and `--unix-socket`
-- Rust actual artifact emission for targeted ingress-related fixture categories
-
-What does not exist yet:
-
-- Go truth outputs for comparison
-- internal ingress-rule matching and negative rule-index behavior
-- full regex-path semantics for general ingress matching
-- full tunnel credential JSON artifact coverage
-- full first-slice parity comparisons
-
-Implication:
-
-- the accepted first slice now has a real ingress normalization and matching
-  path in Rust for the current fixture surface
-- the repository still must not claim first-slice parity is complete
-
-## Phase 1B.5 Go Truth Capture And Real Compare Path
-
-Phase 1B.5 harness behavior now exists for the accepted first-slice fixture
-surface.
-
-What exists now:
-
-- checked-in Go truth artifacts under
-  `crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/` for
-  all 21 accepted first-slice fixtures
-- a source-backed `capture-go-truth` workflow that stages a small Go helper in
-  a temporary module and imports the frozen Go baseline via `replace`
-- a real `compare` workflow that emits fresh Rust actual artifacts and compares
-  them against the checked-in Go truth artifacts
-- explicit mismatch reporting for exact, error-category, structural, semantic,
-  and warning-or-report comparison modes
-- a passing Go-truth presence gate and a passing real-compare smoke subset in
-  the Rust test suite
-
-What does not exist yet:
-
-- closed first-slice Rust-versus-Go parity mismatches
-
-Implication:
-
-- the repository now has a real first-slice parity loop rather than a Rust-only
-  artifact scaffold
-- the repository still must not claim broader rewrite parity while most later-slice
-  subsystems remain unported
-
-## Phase 1B.6 First-Slice Parity Closure
-
-Phase 1B.6 behavior now closes the known accepted first-slice Rust-versus-Go
-parity mismatches.
-
-What exists now:
-
-- config-backed normalized ingress payloads now materialize Go-effective
-  `originRequest` defaults and carry inherited IP rules into each rule payload
-- CLI single-origin ingress normalization now matches Go truth for default-field
-  representation, including `false`, `0`, and `1m30s`
-- normalized-config artifact emission now matches Go truth for `warnings: null`
-  when no warnings are present
-- the full accepted first-slice compare is green: 21 compared, 21 matched,
-  0 mismatched
-
-What does not exist yet:
-
-- internal ingress-rule matching and negative rule-index behavior
-- full regex-path semantics for general ingress matching
-- tunnel credential JSON fixture coverage
-- any later-slice behavior outside the accepted first slice
-
-Implication:
-
-- the accepted first slice is now parity-backed against the checked-in Go truth
-  fixture surface
-- the repository still must not claim full-rewrite completion
-
-## First Implementation Gate
-
-No large-scale subsystem implementation should begin until all of the following
-are true:
-
-1. `docs/compatibility-scope.md` is accepted
-2. `docs/go-rust-semantic-mapping.md` is accepted
-3. `docs/dependency-policy.md` is accepted
-4. `docs/allocator-runtime-baseline.md` is accepted
-5. `docs/adr/0001-hybrid-concurrency-model.md` is accepted
-6. the workspace skeleton is accepted
-7. the first subsystem slice and its parity checks are frozen
-
-## Recommended First Slice
-
-Port config, credentials, and ingress normalization first.
-
-Reason:
-
-- the behavior is heavily documented
-- the inputs and outputs are comparatively deterministic
-- the slice is lower risk than transports, supervisors, or streaming bridges
-- it freezes CLI/config/env precedence and credential parsing early
-- it freezes ingress validation and default no-ingress behavior early
-- it unlocks later runtime assembly work without starting in the highest-risk
-  concurrency areas
-
-Scope boundary for the first slice:
-
-- include config discovery, parsing, validation, and credential handling
-- include ingress parsing, validation, normalization, and deterministic rule
-  matching
-- include CLI-origin synthesis only to the extent needed to normalize
-  single-origin ingress inputs
-- exclude proxying, transports, supervisor logic, metrics servers, management,
-  and orchestration
-
-Current scaffold implication:
-
-- narrow first-slice implementation code is now present
-- the crate layout still reserves the correct boundaries for the remainder of
-  this first slice
-- manifests should stay sparse while the remaining slice behavior lands
-
-## Done Means
-
-A subsystem should not be called "ported" unless:
-
-- behavior matches `baseline-2026.2.0/old-impl/`
-- relevant config or CLI surface matches `baseline-2026.2.0/old-impl/`
-- relevant wire bytes match `baseline-2026.2.0/old-impl/` where applicable
-- documented quirks are either preserved or explicitly waived
-- parity tests are documented and passing
+- for current repository state: start here, then load the smallest focused
+  status file above
+- for phase model or promotion boundaries: use `docs/promotion-gates.md`
+- for scope and non-negotiables: use `REWRITE_CHARTER.md`
+- for behavior and parity truth: use the frozen Go baseline first

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+# Documentation Map
+
+This directory holds repository policy, scope, and phase documents.
+
+Use this directory as an index, not a default full-context load.
+
+For MCP-backed retrieval, prefer this order: snapshot, then brief, then bundle, then targeted reads.
+
+## Start Here
+
+- `docs/ai-context-routing.md`
+  - minimum-file routing for AI and human cold starts
+  - staged retrieval sequence
+
+- `docs/compatibility-scope.md`
+  - what "compatible" means
+
+- `docs/promotion-gates.md`
+  - current phase model
+  - promotion boundaries
+
+- `docs/dependency-policy.md`
+  - dependency admission
+  - workspace dependency truth
+
+- `docs/allocator-runtime-baseline.md`
+  - allocator and runtime baseline
+
+## Policy Groups
+
+- current repository state:
+  - `STATUS.md`
+  - `docs/status/rewrite-foundation.md`
+  - `docs/status/active-surface.md`
+  - `docs/status/first-slice-parity.md`
+  - `docs/status/porting-rules.md`
+
+- scope and compatibility:
+  - `docs/compatibility-scope.md`
+  - `docs/first-slice-freeze.md`
+
+- phase and delivery control:
+  - `docs/promotion-gates.md`
+  - `docs/build-artifact-policy.md`
+
+- runtime and dependency rules:
+  - `docs/allocator-runtime-baseline.md`
+  - `docs/go-rust-semantic-mapping.md`
+  - `docs/dependency-policy.md`
+
+- human-facing Rust coding references:
+  - `docs/code-style.md`
+  - `docs/engineering-standards.md`
+  - use these as deeper reference docs; for AI cold starts prefer `.github/instructions/rust.instructions.md` first
+
+- ADRs:
+  - `docs/adr/`
+
+Load the smallest relevant file first.

--- a/docs/ai-context-routing.md
+++ b/docs/ai-context-routing.md
@@ -1,0 +1,154 @@
+# AI Context Routing
+
+This file is the thin entry map for AI and human cold starts.
+
+Use it to choose the minimum files and tools needed for a task before loading
+larger documents.
+
+## Retrieval Order
+
+Use this sequence unless the task clearly needs something else:
+
+1. classify the task
+2. load the smallest governing file first
+3. use targeted search only after the first governing file is known
+4. read only the relevant file region or subsection
+5. expand to neighboring docs only if evidence is still missing
+
+Do not start by loading all top-level governance docs.
+
+## Task To Minimum Context
+
+### Scope, lane, and rewrite boundaries
+
+Load first:
+
+- `REWRITE_CHARTER.md`
+
+Load next only if needed:
+
+- `docs/compatibility-scope.md`
+- `docs/promotion-gates.md`
+
+### Current repository state
+
+Load first:
+
+- `STATUS.md`
+
+Load next only if needed:
+
+- `docs/status/rewrite-foundation.md`
+- `docs/status/active-surface.md`
+- `docs/status/first-slice-parity.md`
+- `docs/status/porting-rules.md`
+- `docs/promotion-gates.md`
+
+### Behavior and parity
+
+Load first:
+
+- `baseline-2026.2.0/old-impl/` code and tests
+
+Load next only if needed:
+
+- `baseline-2026.2.0/design-audit/REPO_SOURCE_INDEX.md`
+- `baseline-2026.2.0/design-audit/REPO_REFERENCE.md`
+- other `baseline-2026.2.0/design-audit/*.md` files for the specific surface
+
+Never claim parity from Rust code shape alone.
+
+### Active implementation slice and promotion boundaries
+
+Load first:
+
+- `STATUS.md`
+- `docs/status/active-surface.md`
+
+Load next only if needed:
+
+- `docs/promotion-gates.md`
+- `docs/status/first-slice-parity.md`
+- `docs/first-slice-freeze.md`
+
+### Dependency, allocator, and runtime policy
+
+Load first:
+
+- `docs/dependency-policy.md`
+- `docs/allocator-runtime-baseline.md`
+
+Load next only if needed:
+
+- `docs/go-rust-semantic-mapping.md`
+- `docs/adr/0001-hybrid-concurrency-model.md`
+- `docs/adr/ADR-0006-standard-format-and-workspace-dependency-admission.md`
+
+### Rust code generation, review style, and local structure
+
+Load first:
+
+- `.github/instructions/rust.instructions.md`
+
+Load next only if needed:
+
+- `docs/code-style.md`
+- `docs/engineering-standards.md`
+
+Use the docs files as deeper human-readable explanation, not as the default first-load source for AI code edits.
+
+### Transport, Pingora, FIPS, and deployment lane decisions
+
+Load first:
+
+- `docs/adr/0002-transport-tls-crypto-lane.md`
+- `docs/adr/0003-pingora-critical-path.md`
+- `docs/adr/0004-fips-in-alpha-definition.md`
+- `docs/adr/0005-deployment-contract.md`
+
+### Agent workflow and operating rules
+
+Load first:
+
+- `AGENTS.md`
+- `SKILLS.md`
+
+These files are workflow notes.
+They do not override charter, status, or policy docs.
+
+## MCP Routing
+
+When using the local read-only MCP server:
+
+1. use a compact context snapshot first for repo-state or active-phase questions
+2. use a context brief when you need the first file to open and its likely follow-ups
+3. use a curated context bundle when the task matches one
+4. use governance routing to identify the likely directory or file group
+5. list or search only the smallest relevant path set
+6. inspect file metadata or snippets before reading file content
+7. read only the needed lines or chunk
+8. widen the search only if the first path set does not answer the question
+
+The MCP server should be used for small grounded slices, not broad document dumping.
+
+Choose the smallest MCP surface that fits the question:
+
+- use a snapshot for short status, phase, scope, or dependency-baseline answers
+- use a brief when you need the first file to open and the next two or three likely follow-ups
+- use a bundle when you need a curated multi-file pack for a known question type
+- use search, listing, metadata, and line reads only after the smallest curated surface stops being enough
+
+Examples:
+
+- use a snapshot for questions like "what phase is active now?", "what owns dependency truth?", "which file owns this topic?", or "what is the transport/Pingora/FIPS lane?"
+- use a brief for questions like "which file should I open first for repo state or parity work?"
+- use a bundle for questions like "give me the narrow file pack for runtime/dependency policy" or "give me the baseline files for behavior/parity routing"
+
+## Anti-Drift Rules
+
+- `REWRITE_CHARTER.md` wins over summaries, plans, and workflow notes
+- `STATUS.md` describes what exists now
+- `docs/*.md` define policy and phase boundaries
+- branch names and draft planning notes do not change current phase truth by themselves
+- `baseline-2026.2.0/old-impl/` and `baseline-2026.2.0/design-audit/` are frozen inputs
+- missing evidence should be stated explicitly

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -1,0 +1,998 @@
+# Code Style
+
+This is a human-facing reference document.
+For default AI code-edit guidance, start with `.github/instructions/rust.instructions.md` and load this file only when deeper explanation is useful.
+
+## Purpose
+
+This document defines how Rust code in this repository should **look and read**.
+
+This is a **code style** document, not an architecture document. It focuses on:
+
+- naming
+- local readability
+- control flow
+- comments and docs
+- tests
+- common code-shape preferences
+
+It does **not** define:
+
+- crate boundaries
+- module decomposition policy
+- dependency admission
+- abstraction strategy
+- design-pattern policy
+- lifecycle/state modeling
+
+Those belong in `docs/engineering-standards.md`.
+
+---
+
+## 1. Style: Explicit and readable
+
+This repository prefers code that is easy to understand in one pass.
+
+Prefer:
+
+- explicit names
+- explicit local variables
+- straightforward control flow
+- small named helpers
+
+Avoid:
+
+- dense one-liners
+- clever chaining
+- compressed logic that saves lines but costs readability
+
+Example:
+
+Good:
+
+```rust
+let hostname = normalize_hostname(raw_hostname)?;
+let service = parse_service(raw_service)?;
+let rule = self::IngressRule::new(hostname, service);
+```
+
+Less preferred:
+
+```rust
+let rule = self::IngressRule::new(
+    normalize_hostname(raw_hostname)?,
+    parse_service(raw_service)?,
+);
+```
+
+---
+
+## 2. Style: Clear naming
+
+Names should explain purpose immediately.
+
+Prefer names that describe the domain role:
+
+- `config_path`
+- `credential_source`
+- `origin_service`
+- `ingress_rule`
+- `normalized_hostname`
+
+Avoid vague names:
+
+- `data`
+- `value`
+- `thing`
+- `helper`
+- `util`
+- `manager`
+- `handler`
+
+Example:
+
+Good:
+
+```rust
+let credential_path = find_credential_path()?;
+```
+
+Bad:
+
+```rust
+let data = find_credential_path()?;
+```
+
+---
+
+## 3. Style: Prefer idiomatic Rust when practical
+
+Prefer idiomatic Rust when it improves clarity, correctness, and maintainability.
+
+Prefer:
+
+- standard library and conventional Rust patterns
+- `?` for straightforward error propagation
+- `Option` and `Result` used directly rather than reinvented status patterns
+- `Self`, `Self::`, and local module paths when they improve readability
+
+Avoid:
+
+- forcing habits from other languages when Rust already has a clearer idiom
+- verbose ceremony that obscures the actual behavior
+- clever patterns that are technically idiomatic but harder to review than a simpler alternative
+
+Example:
+
+Good:
+
+```rust
+fn load(path: &Path) -> Result<Self, LoadError> {
+    let text = std::fs::read_to_string(path)?;
+
+    Self::parse(text.as_str())
+}
+```
+
+Less preferred:
+
+```rust
+fn load(path: &Path) -> Result<Self, LoadError> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Self::parse(text.as_str()),
+        Err(err) => Err(LoadError::from(err)),
+    }
+}
+```
+
+---
+
+## 4. Style: Trait names describe capability or role
+
+Trait names should describe behavior, capability, or a clear contract.
+
+Prefer:
+
+- capability-oriented names such as `Resolver`, `Normalizer`, `CredentialSource`, `OriginProvider`
+- adjective-style names when the trait reads naturally that way, such as `Reloadable`
+- `Ext` suffix only for narrow extension traits, especially when extending external types
+
+Avoid:
+
+- vague trait names such as `Manager`, `Handler`, `Helper`, or `Processor` unless the domain meaning is truly specific
+- naming a trait like a concrete implementation
+- using `Ext` for primary domain traits
+
+Example:
+
+Good:
+
+```rust
+pub trait OriginProvider {
+    fn origin_service(&self) -> &self::OriginService;
+}
+```
+
+Good:
+
+```rust
+pub trait RequestExt {
+    fn header_str(&self, name: &str) -> Option<&str>;
+}
+```
+
+Less preferred:
+
+```rust
+pub trait OriginManager {
+    fn origin_service(&self) -> &self::OriginService;
+}
+```
+
+---
+
+## 5. Style: Tight vertical spacing
+
+Do not add blank lines just to visually group things.
+
+Prefer:
+
+- one logical block per contiguous chunk
+- blank lines only when separating genuinely different steps
+- compact functions that do not look artificially stretched
+
+Avoid:
+
+- empty lines between closely related statements
+- “air padding” that makes short functions look longer than they are
+
+Example:
+
+Good:
+
+```rust
+let hostname = normalize_hostname(raw.hostname)?;
+let service = parse_service(raw.service)?;
+let rule = self::IngressRule::new(hostname, service);
+
+validate_rule(&rule)?;
+register_rule(rule);
+```
+
+Less preferred:
+
+```rust
+let hostname = normalize_hostname(raw.hostname)?;
+
+let service = parse_service(raw.service)?;
+
+let rule = self::IngressRule::new(hostname, service);
+
+validate_rule(&rule)?;
+
+register_rule(rule);
+```
+
+---
+
+## 6. Style: Boring control flow
+
+Code should be unsurprising to read.
+
+Prefer:
+
+- early returns for invalid states
+- `match` for meaningful branching
+- `if let` or `let else` for simple guards
+
+Avoid:
+
+- deep nesting when a guard clause is clearer
+- clever control flow that hides the important path
+
+Example:
+
+Good:
+
+```rust
+let Some(path) = credential_path else {
+    return Err(ConfigLoadError::MissingCredentialFile);
+};
+```
+
+Good:
+
+```rust
+match origin {
+    Origin::Local(service) => load_local(service),
+    Origin::Remote(url) => load_remote(url),
+}
+```
+
+---
+
+## 7. Style: Long sequential functions indicate chunking
+
+A long function made of many sequential steps is usually a sign that named helper functions would improve readability.
+
+Prefer:
+
+- small named helpers when a function has many consecutive stages
+- a visible top-level flow with implementation details extracted below
+
+Avoid:
+
+- long “do this, then this, then this” functions with no named sub-steps
+
+Example:
+
+Good:
+
+```rust
+fn load_ingress(raw: &RawIngress) -> Result<IngressRule, LoadError> {
+    let hostname = parse_hostname(raw)?;
+    let service = parse_service(raw)?;
+    validate_ingress(&hostname, &service)?;
+
+    Ok(self::IngressRule::new(hostname, service))
+}
+```
+
+Less preferred:
+
+```rust
+fn load_ingress(raw: &RawIngress) -> Result<IngressRule, LoadError> {
+    let hostname = normalize_hostname(raw.hostname.as_str())?;
+    let service = parse_service(raw.service.as_str())?;
+
+    if hostname.is_empty() {
+        return Err(LoadError::InvalidHostname);
+    }
+
+    if service.is_unsupported() {
+        return Err(LoadError::UnsupportedService);
+    }
+
+    if raw.origin_request.is_some() {
+        // more mapping...
+    }
+
+    // more parsing...
+    // more normalization...
+    // more validation...
+
+    Ok(self::IngressRule::new(hostname, service))
+}
+```
+
+---
+
+## 8. Style: Separate setup from a multi-line final expression
+
+If a multi-line block ends with a meaningful final expression, add one blank line after preparatory statements before that final expression.
+
+This applies to:
+
+- final `Ok(...)` / `Err(...)`
+- struct construction
+- a final function call in a block
+- a final expression inside a `match` arm or `if` block
+
+Prefer:
+
+- one blank line between setup and the final expression in a multi-line block
+
+Avoid:
+
+- crowding the final expression directly under setup when the block is already doing more than one step
+
+Example:
+
+Good:
+
+```rust
+fn build_rule(raw: RawRule) -> Result<self::IngressRule, LoadError> {
+    let hostname = parse_hostname(&raw)?;
+    let service = parse_service(&raw)?;
+    let origin_request = parse_origin_request(&raw)?;
+
+    Ok(self::IngressRule {
+        hostname,
+        service,
+        origin_request,
+    })
+}
+```
+
+Good:
+
+```rust
+match source {
+    Source::File(path) => {
+        let path = validate_path(path)?;
+
+        load_file(path)
+    }
+    Source::Inline(text) => load_inline(text),
+}
+```
+
+Less preferred:
+
+```rust
+fn build_rule(raw: RawRule) -> Result<self::IngressRule, LoadError> {
+    let hostname = parse_hostname(&raw)?;
+    let service = parse_service(&raw)?;
+    let origin_request = parse_origin_request(&raw)?;
+    Ok(self::IngressRule {
+        hostname,
+        service,
+        origin_request,
+    })
+}
+```
+
+---
+
+## 9. Style: Visible intermediate steps
+
+Use intermediate variables when they make the flow easier to scan.
+
+Prefer named steps when:
+
+- each step has meaning
+- errors can happen
+- values are reused
+- the expression becomes visually dense
+
+Example:
+
+Good:
+
+```rust
+let hostname = normalize_hostname(raw.hostname)?;
+let service = parse_service(raw.service)?;
+let rule = self::IngressRule::new(hostname, service);
+```
+
+Acceptable when still simple:
+
+```rust
+let rule = self::IngressRule::new(hostname, service);
+```
+
+---
+
+## 10. Style: Prefer `self::` for sibling items
+
+When referring to types or functions defined in the same module, prefer `self::` to make local ownership obvious.
+
+This reduces ambiguity and makes it easier for reviewers to see that the item is local to the current module.
+
+Prefer:
+
+- `self::IngressRule`
+- `self::normalize_hostname`
+- `self::LoadError`
+
+Over:
+
+- bare local type or function names when the origin is not immediately obvious
+
+Example:
+
+Good:
+
+```rust
+fn build_rule(hostname: Hostname, service: Service) -> self::IngressRule {
+    self::IngressRule::new(hostname, service)
+}
+```
+
+Less preferred:
+
+```rust
+fn build_rule(hostname: Hostname, service: Service) -> IngressRule {
+    IngressRule::new(hostname, service)
+}
+```
+
+---
+
+## 11. Style: Prefer `Self` and `Self::` inside `impl`
+
+Inside an `impl`, prefer `Self` and `Self::` when they make the code easier to scan and reduce repeated type names.
+
+Prefer:
+
+- `Self`
+- `Self::new(...)`
+- `Self::DEFAULT_RETRY_LIMIT`
+
+Over:
+
+- repeating the full type name inside its own implementation
+
+Example:
+
+Good:
+
+```rust
+impl IngressRule {
+    fn new(hostname: Hostname, service: Service) -> Self {
+        Self { hostname, service }
+    }
+}
+```
+
+Less preferred:
+
+```rust
+impl IngressRule {
+    fn new(hostname: Hostname, service: Service) -> IngressRule {
+        IngressRule { hostname, service }
+    }
+}
+```
+
+---
+
+## 12. Style: Put related constants in the owning `impl`
+
+If a constant exists only to support a specific type, prefer an associated `const` inside that type’s `impl` instead of a file-scope constant.
+
+Prefer:
+
+- `impl Foo { const DEFAULT_TIMEOUT_SECS: u64 = 30; }`
+
+Avoid:
+
+- file-scope constants when the value is only meaningful for one type
+
+Example:
+
+Good:
+
+```rust
+impl TunnelConfig {
+    const DEFAULT_RETRY_LIMIT: usize = 3;
+
+    fn retry_limit(&self) -> usize {
+        Self::DEFAULT_RETRY_LIMIT
+    }
+}
+```
+
+Less preferred:
+
+```rust
+const DEFAULT_RETRY_LIMIT: usize = 3;
+
+impl TunnelConfig {
+    fn retry_limit(&self) -> usize {
+        DEFAULT_RETRY_LIMIT
+    }
+}
+```
+
+---
+
+## 13. Style: Avoid magic numbers in function bodies
+
+Do not hardcode numeric values in function bodies when the value has meaning.
+
+Prefer:
+
+- named constants for meaningful values
+- inline literals only for obvious trivial values such as `0`, `1`, or similar universally understood values
+
+Example:
+
+Good:
+
+```rust
+impl RetryPolicy {
+    const MAX_RETRIES: usize = 3;
+    const BASE_DELAY_MS: u64 = 250;
+
+    fn backoff_ms(attempt: usize) -> u64 {
+        attempt.min(Self::MAX_RETRIES) as u64 * Self::BASE_DELAY_MS
+    }
+}
+```
+
+Less preferred:
+
+```rust
+fn backoff_ms(attempt: usize) -> u64 {
+    attempt.min(3) as u64 * 250
+}
+```
+
+---
+
+## 14. Style: Put parse and conversion types at the operation site
+
+When parsing or converting, prefer making the target type explicit at the operation site rather than on the binding.
+
+This makes the conversion easier to spot and reduces “where did that type come from?” scanning.
+
+Prefer:
+
+```rust
+let hostname = raw.parse::<self::Hostname>()?;
+```
+
+Over:
+
+```rust
+let hostname: self::Hostname = raw.parse()?;
+```
+
+Example:
+
+Good:
+
+```rust
+let service = raw_service.parse::<self::OriginService>()?;
+```
+
+Less preferred:
+
+```rust
+let service: self::OriginService = raw_service.parse()?;
+```
+
+---
+
+## 15. Style: Avoid nested `match` when a flatter shape is possible
+
+Nested `match` blocks should be rare.
+
+If pattern branching becomes nested, prefer:
+
+- helper extraction
+- `if let`
+- `let else`
+- a flatter outer `match`
+- precomputing an intermediate value
+
+Example:
+
+Good:
+
+```rust
+match source {
+    Source::File(path) => {
+        let path = validate_path(path)?;
+
+        load_file(path)
+    }
+    Source::Inline(text) => load_inline(text),
+}
+```
+
+Less preferred:
+
+```rust
+match source {
+    Source::File(path) => match validate_path(path) {
+        Ok(path) => load_file(path),
+        Err(err) => Err(err),
+    },
+    Source::Inline(text) => load_inline(text),
+}
+```
+
+---
+
+## 16. Style: Comments explain why
+
+Comments should explain:
+
+- why something exists
+- compatibility requirements
+- invariants
+- non-obvious behavior
+- tradeoffs
+
+Do not comment obvious syntax.
+
+Bad:
+
+```rust
+// Increment retry count.
+retry_count += 1;
+```
+
+Good:
+
+```rust
+// Retries are counted before backoff selection so metrics match the caller-visible attempt number.
+retry_count += 1;
+```
+
+---
+
+## 17. Style: Explain quirks explicitly
+
+If code exists because of a compatibility quirk, parser oddity, protocol edge case, or other non-obvious reason, add a comment that explains it.
+
+Prefer comments that explain:
+
+- what the quirk is
+- why the code exists
+- what would break if it were “cleaned up” without understanding the reason
+
+Example:
+
+Good:
+
+```rust
+// The legacy config format treats an empty hostname as a catch-all rule.
+// Preserve that behavior here for compatibility with the accepted parity baseline.
+let hostname = if raw.hostname.is_empty() {
+    self::Hostname::catch_all()
+} else {
+    parse_hostname(raw.hostname.as_str())?
+};
+```
+
+---
+
+## 18. Style: Practical doc comments
+
+Public doc comments should explain:
+
+- what the item does
+- what assumptions it makes
+- what the caller must preserve
+- how it should be used
+
+Prefer plain language.
+
+Good:
+
+```rust
+/// Normalizes a hostname into the repository's canonical ingress form.
+///
+/// This does not perform DNS validation.
+fn normalize_hostname(input: &str) -> Result<Hostname, NormalizeError> {
+```
+
+Avoid:
+
+- long tutorial prose
+- decorative language
+- repeating the function name in sentence form without useful content
+
+---
+
+## 19. Style: Quiet imports
+
+Imports should be tidy and predictable.
+
+Prefer:
+
+- specific imports when they improve readability
+- stable grouping
+- minimal aliasing
+
+Avoid:
+
+- glob imports unless clearly justified
+- aliases that make code harder to follow
+- noisy import walls
+
+Good:
+
+```rust
+use std::path::PathBuf;
+
+use crate::config::TunnelConfig;
+use crate::error::ConfigLoadError;
+```
+
+Less preferred:
+
+```rust
+use crate::*;
+use std::*;
+```
+
+---
+
+## 20. Style: Meaningful errors
+
+Error names and messages should help the reader understand what failed.
+
+Prefer:
+
+- `InvalidHostname`
+- `MissingCredentialFile`
+- `UnsupportedProtocol`
+- `ConfigLoadError`
+
+Avoid:
+
+- `Failure`
+- `BadInput`
+- `UnknownError`
+- `InternalError`
+
+Example:
+
+Good:
+
+```rust
+return Err(ConfigLoadError::MissingCredentialFile);
+```
+
+Less preferred:
+
+```rust
+return Err(ConfigLoadError::Failure);
+```
+
+---
+
+## 21. Style: Do not use `unwrap` in production code
+
+Do not use `unwrap` in runtime, library, or production-path code.
+
+If a failure must panic intentionally, prefer `expect` with a message that explains the invariant or assumption.
+
+`unwrap` is acceptable in:
+
+- tests
+- temporary development tooling
+- short-lived local experiments that are not production paths
+
+Prefer:
+
+```rust
+let config = raw.parse::<self::TunnelConfig>()
+    .expect("embedded test fixture must parse as TunnelConfig");
+```
+
+Over:
+
+```rust
+let config = raw.parse::<self::TunnelConfig>().unwrap();
+```
+
+In production code, prefer proper error propagation when possible:
+
+```rust
+let config = raw.parse::<self::TunnelConfig>()?;
+```
+
+---
+
+## 22. Style: Tests read like behavior
+
+Test names should describe behavior, not implementation trivia.
+
+Prefer:
+
+- `loads_default_origin_when_not_configured`
+- `rejects_invalid_service_url`
+- `preserves_rule_order_during_normalization`
+
+Avoid:
+
+- `test_1`
+- `basic_case`
+- `works`
+
+Good:
+
+```rust
+#[test]
+fn rejects_invalid_service_url() {
+```
+
+---
+
+## 23. Style: Keep boolean names readable
+
+Boolean names should read clearly at the call site.
+
+Prefer:
+
+- `is_enabled`
+- `has_credentials`
+- `should_reload`
+- `was_loaded_from_disk`
+
+Avoid:
+
+- `flag`
+- `check`
+- `status`
+
+Example:
+
+Good:
+
+```rust
+if should_reload {
+    reload_config()?;
+}
+```
+
+Less preferred:
+
+```rust
+if flag {
+    reload_config()?;
+}
+```
+
+---
+
+## 24. Style: Prefer positive conditions when practical
+
+Prefer conditions that read directly.
+
+Good:
+
+```rust
+if has_credentials {
+    load_credentials()?;
+}
+```
+
+Less preferred:
+
+```rust
+if !missing_credentials {
+    load_credentials()?;
+}
+```
+
+Avoid double negatives unless they are truly the clearest form.
+
+---
+
+## 25. Style: Keep method chains short when they carry meaning
+
+Short chains are fine. Once a chain starts carrying multiple semantic steps, break it into named variables.
+
+Good:
+
+```rust
+let hostname = raw.hostname.trim();
+let hostname = normalize_hostname(hostname)?;
+```
+
+Less preferred:
+
+```rust
+let hostname = raw.hostname.trim().to_ascii_lowercase().parse::<self::Hostname>()?;
+```
+
+---
+
+## 26. Style: Keep field order stable in struct construction
+
+When constructing a struct, prefer the same field order as the type definition unless there is a strong readability reason not to.
+
+This makes review easier because readers can compare faster.
+
+Good:
+
+```rust
+Self {
+    hostname,
+    service,
+    origin_request,
+}
+```
+
+---
+
+## 27. Style: One obvious local pattern is better than many equivalent ones
+
+If the repository has a preferred local pattern, use it consistently.
+
+Examples:
+
+- prefer `Self` over repeating the type name inside its own `impl`
+- prefer `self::` for sibling items
+- prefer explicit parse types at the operation site
+- prefer early guards over deep nesting
+
+Consistency lowers review cost more than micro-optimizing every line.
+
+---
+
+## 28. Style: AI-generated code must be normalized
+
+AI-generated code is only acceptable after it reads like repository-owned code.
+
+Common AI drift signs:
+
+- vague naming
+- repetitive helper structure
+- too many obvious comments
+- mechanically correct but semantically weak naming
+- dense combinators where direct control flow is clearer
+
+Rule:
+
+- valid Rust is not enough
+- merged Rust must read like intentional repository code
+
+---
+
+## Quick rule of thumb
+
+When choosing between two valid versions, prefer the one that is:
+
+1. easier to understand in one pass
+2. easier to review
+3. more explicit about local intent
+4. more consistent with surrounding code
+
+Consistency is a feature.

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -1,0 +1,191 @@
+# Engineering Standards
+
+This is a human-facing reference document.
+For default AI code-edit guidance, start with `.github/instructions/rust.instructions.md` and load this file only when deeper explanation is useful.
+
+## Purpose
+
+This document defines how Rust code in this repository should be **structured and owned**.
+
+It is the authority for:
+
+- crate boundaries
+- module decomposition
+- dependency admission and containment
+- abstraction thresholds
+- design-pattern usage
+- runtime and lifecycle ownership
+- public API discipline
+
+This is an **engineering structure** document, not a local code appearance document.
+For naming, spacing, comments, control flow, tests, and other local readability rules, see `docs/code-style.md`.
+
+---
+
+## 1. Standard: One owner per responsibility boundary
+
+Each crate and module should have one primary responsibility.
+
+Prefer:
+
+- crates with one clear area of ownership
+- modules with one main reason to change
+- names that reflect responsibility directly
+
+Avoid:
+
+- mixing unrelated responsibilities in one crate or module
+- broad "common" or "misc" layers that become dependency magnets
+- placing code together only because it is technically convenient
+
+Review signal:
+
+- if a module needs many unrelated imports, many unrelated tests, or many different kinds of changes, it may own too much
+
+---
+
+## 2. Standard: Public surfaces stay smaller than internals
+
+Public APIs should be narrow, intentional, and harder to misuse than the internals that support them.
+
+Prefer:
+
+- small public types
+- small public traits
+- private helpers by default
+- thin owned facades over implementation detail
+
+Avoid:
+
+- making items public "just in case"
+- exposing internal helpers as part of the crate contract too early
+- wide public module trees with weak ownership boundaries
+
+Review signal:
+
+- if another crate can touch too much of an implementation directly, the public surface is too wide
+
+---
+
+## 3. Standard: Dependencies enter through owned seams
+
+External crates should enter the repository through clear local boundaries.
+
+Prefer:
+
+- thin adapters around third-party crates when they reduce spread
+- local wrapper types where they improve ownership clarity
+- shared dependencies declared in `[workspace.dependencies]` when they are intentionally shared
+
+Avoid:
+
+- scattering direct third-party APIs across unrelated crates
+- letting external type shapes define unrelated internal APIs
+- per-crate dependency drift without an explicit reason
+
+Review signal:
+
+- if changing or replacing a dependency would require touching many unrelated crates, the seam is too wide
+
+---
+
+## 4. Standard: Add abstraction only after a real need exists
+
+This repository prefers concrete code first, abstraction second.
+
+Prefer:
+
+- concrete structs, enums, and functions for the first real path
+- abstraction after a second real use case or a clear boundary need
+- explicit duplication over premature indirection when the shape is still unstable
+
+Avoid:
+
+- speculative traits
+- generic wrappers with only one real implementation
+- adding indirection because it merely looks more architectural
+
+Review signal:
+
+- if an abstraction exists, its current benefit should be obvious without needing a future-looking argument
+
+---
+
+## 5. Standard: Encode important invariants in types, not every invariant
+
+Use Rust's type system where it clearly removes invalid states or reduces meaningful misuse.
+
+Prefer:
+
+- newtypes for real semantic distinctions
+- enums for closed state sets
+- builders when construction is genuinely wide or staged
+- typestate when lifecycle misuse is a real risk and the benefit is clear
+
+Avoid:
+
+- type-level cleverness for style points
+- typestate for trivial flows
+- generic or phantom-type machinery that is harder to understand than the invariant it protects
+
+Review signal:
+
+- if the type machinery is more complex than the bug class it prevents, it is probably too much
+
+---
+
+## 6. Standard: Runtime and lifecycle ownership must be explicit
+
+Long-lived runtime behavior must have an obvious owner.
+
+Prefer:
+
+- explicit ownership of startup, shutdown, reload, and supervision paths
+- clearly named runtime or lifecycle modules
+- visible handoff points between config, runtime, transport, and proxy layers
+
+Avoid:
+
+- hidden background work
+- lifecycle behavior spread across unrelated modules
+- "spawn and hope" patterns with unclear ownership
+
+Review signal:
+
+- if shutdown, reload, or task ownership is hard to trace, lifecycle ownership is too diffuse
+
+---
+
+## 7. Standard: Module decomposition should follow reviewable reasoning units
+
+Modules should be sized and split for understanding, not just compilation.
+
+Prefer:
+
+- modules that a reviewer can understand in one focused sitting
+- top-level flow that stays visible
+- submodules for detail, boundary-specific logic, or format-specific logic when that improves navigation
+
+Avoid:
+
+- giant files that collect everything about a feature
+- decomposition based only on line count
+- fragmentation into tiny files that add movement without adding clarity
+
+Review signal:
+
+- if a reviewer must scroll repeatedly just to recover the main flow, decomposition is probably too weak
+
+---
+
+## Quick rule of thumb
+
+When choosing between two valid designs, prefer the one that:
+
+1. has clearer ownership
+2. has a narrower public surface
+3. contains third-party details more effectively
+4. is easier to review in small slices
+5. keeps runtime and boundary behavior more explicit
+
+Smaller, clearer, more owned boundaries win.

--- a/docs/status/active-surface.md
+++ b/docs/status/active-surface.md
@@ -1,0 +1,48 @@
+# Active Surface Status
+
+This file captures the currently admitted executable surface and the immediate
+deferred scope around it.
+
+## Active Phase 3.3 Focus
+
+Phase 3.3 now owns the QUIC tunnel core for the frozen Linux
+production-alpha lane.
+
+What it covers now:
+
+- `run` now enters a real quiche-based transport service under the runtime
+  boundary
+- connection/session ownership and QUIC handshake state are explicit
+- runtime-owned config handoff now feeds the transport identity boundary
+- reconnect/restart policy remains owned by runtime supervision rather than
+  transport internals or the CLI shell
+- the current transport core stops honestly after QUIC establishment where the
+  later wire/protocol registration and Pingora slices do not yet exist
+
+What it still must not imply:
+
+- that Pingora integration exists
+- that wire/protocol behavior beyond the transport-owned boundary exists
+- that security/compliance operational behavior exists
+- that standard-format crate integration beyond active-slice need exists
+- that packaging, installers, updaters, or deployment tooling already exist
+
+## Deferred Within Big Phase 3
+
+The following later Big Phase 3 slices remain intentionally deferred:
+
+- 3.4 Pingora integration path above that transport lane
+- 3.5 wire/protocol boundary
+- 3.6 security/compliance operational boundary
+- 3.7 standard-format crate integration boundary
+
+## Deferred Beyond Big Phase 3
+
+The following remain intentionally out of the current executable-surface task:
+
+- broader platform parity beyond Linux
+- broader artifact scope beyond GNU `x86-64-v2` and `x86-64-v4`
+- transport, Pingora, wire/protocol, security/compliance, and
+  standard-format integration work outside their later owning slices
+- packaging, deployment tooling, container support, and
+  certification-proving work beyond the current numbered Big Phase 3 slice list

--- a/docs/status/first-slice-parity.md
+++ b/docs/status/first-slice-parity.md
@@ -1,0 +1,191 @@
+# First Slice And Parity Status
+
+This file captures the accepted first-slice implementation history and the
+current parity-backed state for that slice.
+
+## Phase 1A Groundwork
+
+Phase 1A groundwork now exists for the accepted first slice.
+
+What exists now:
+
+- explicit first-slice fixture taxonomy under `crates/cloudflared-config/tests/fixtures/first-slice/`
+- executable harness entrypoint at `tools/first_slice_parity.py`
+- checked-in JSON golden artifact contract for Go truth and Rust actual reports
+- Rust-side helper scaffolding and ignored parity tests in
+  `crates/cloudflared-config/tests/`
+
+What does not exist yet:
+
+- complete later-slice behavior outside the accepted first slice
+
+Implication:
+
+- the repo can now inventory and mechanically gate the first-slice parity
+  contract
+- the repo still must not claim broader rewrite parity is complete
+
+## Phase 1B.1 Domain Skeleton
+
+Phase 1B.1 groundwork now exists in `crates/cloudflared-config/`.
+
+What exists now:
+
+- admitted first-slice crate dependencies only in `crates/cloudflared-config/Cargo.toml`
+- explicit module layout for discovery, raw config, normalized config,
+  credentials, ingress, and error taxonomy
+- honest public APIs for raw YAML loading, credential JSON loading, and raw to
+  normalized config conversion boundaries
+- narrow unit tests covering shape-level parsing and invariants
+
+What does not exist yet:
+
+- parity-complete config discovery behavior
+- origin-cert PEM decoding behavior
+- ingress validation and deterministic matching behavior
+- Rust actual artifact emission for the Phase 1A harness
+
+Implication:
+
+- `cloudflared-config` is now a real owning crate for the accepted first slice
+- the crate still must not be described as a completed first-slice port
+
+## Phase 1B.2 Config Loading Path
+
+Phase 1B.2 behavior now exists for the targeted config-loading fixtures.
+
+What exists now:
+
+- deterministic config discovery with default search order and auto-create side effects
+- YAML file loading into the crate's raw config representation
+- raw-to-normalized conversion for the currently targeted config surface
+- narrow ingress validation for the current invalid and unicode config fixtures
+- Rust actual artifact emission for targeted config discovery and config loading fixtures
+
+What does not exist yet:
+
+- Go truth outputs for comparison
+- full credentials and origin-cert behavior parity
+- full ingress validation and deterministic matching behavior
+- CLI-origin ingress normalization artifacts
+
+Implication:
+
+- the accepted first slice now has a real config-loading path in Rust
+- the repository still must not claim first-slice parity is complete
+
+## Phase 1B.3 Credentials And Origin-Cert Path
+
+Phase 1B.3 behavior now exists for the targeted credentials/origin-cert
+fixtures.
+
+What exists now:
+
+- source-backed PEM scanning for origin certificates
+- tolerance for legacy `PRIVATE KEY` and `CERTIFICATE` blocks during scanning
+- rejection for unknown PEM block types and multiple token blocks
+- origin-cert JSON token extraction with endpoint lowercasing
+- account-id refresh validation through the `OriginCertUser` read path
+- Rust actual artifact emission for the targeted `credentials-origin-cert`
+  fixtures
+
+What does not exist yet:
+
+- Go truth outputs for comparison
+- default origin-cert search-path resolution behavior
+- tunnel credential file artifact fixtures
+- full ingress normalization artifact coverage
+- full first-slice parity comparisons
+
+Implication:
+
+- the accepted first slice now has a real credentials/origin-cert path in Rust
+- the repository still must not claim first-slice parity is complete
+
+## Phase 1B.4 Ingress Normalization And Matching Path
+
+Phase 1B.4 behavior now exists for the targeted ingress normalization,
+ordering/defaulting, and CLI single-origin fixtures.
+
+What exists now:
+
+- semantic ingress service normalization for the current fixture surface
+- deterministic user-rule matching with host:port stripping and catch-all fallback
+- punycode-aware hostname matching for the current IDN ingress fixture surface
+- preserved no-ingress default 503 contract through normalized config output
+- narrow CLI single-origin synthesis for `--hello-world`, `--bastion`, `--url`,
+  and `--unix-socket`
+- Rust actual artifact emission for targeted ingress-related fixture categories
+
+What does not exist yet:
+
+- Go truth outputs for comparison
+- internal ingress-rule matching and negative rule-index behavior
+- full regex-path semantics for general ingress matching
+- full tunnel credential JSON artifact coverage
+- full first-slice parity comparisons
+
+Implication:
+
+- the accepted first slice now has a real ingress normalization and matching
+  path in Rust for the current fixture surface
+- the repository still must not claim first-slice parity is complete
+
+## Phase 1B.5 Go Truth Capture And Real Compare Path
+
+Phase 1B.5 harness behavior now exists for the accepted first-slice fixture
+surface.
+
+What exists now:
+
+- checked-in Go truth artifacts under
+  `crates/cloudflared-config/tests/fixtures/first-slice/golden/go-truth/` for
+  all 21 accepted first-slice fixtures
+- a source-backed `capture-go-truth` workflow that stages a small Go helper in
+  a temporary module and imports the frozen Go baseline via `replace`
+- a real `compare` workflow that emits fresh Rust actual artifacts and compares
+  them against the checked-in Go truth artifacts
+- explicit mismatch reporting for exact, error-category, structural, semantic,
+  and warning-or-report comparison modes
+- a passing Go-truth presence gate and a passing real-compare smoke subset in
+  the Rust test suite
+
+What does not exist yet:
+
+- closed first-slice Rust-versus-Go parity mismatches
+
+Implication:
+
+- the repository now has a real first-slice parity loop rather than a Rust-only
+  artifact scaffold
+- the repository still must not claim broader rewrite parity while most later-slice
+  subsystems remain unported
+
+## Phase 1B.6 First-Slice Parity Closure
+
+Phase 1B.6 behavior now closes the known accepted first-slice Rust-versus-Go
+parity mismatches.
+
+What exists now:
+
+- config-backed normalized ingress payloads now materialize Go-effective
+  `originRequest` defaults and carry inherited IP rules into each rule payload
+- CLI single-origin ingress normalization now matches Go truth for default-field
+  representation, including `false`, `0`, and `1m30s`
+- normalized-config artifact emission now matches Go truth for `warnings: null`
+  when no warnings are present
+- the full accepted first-slice compare is green: 21 compared, 21 matched,
+  0 mismatched
+
+What does not exist yet:
+
+- internal ingress-rule matching and negative rule-index behavior
+- full regex-path semantics for general ingress matching
+- tunnel credential JSON fixture coverage
+- any later-slice behavior outside the accepted first slice
+
+Implication:
+
+- the accepted first slice is now parity-backed against the checked-in Go truth
+  fixture surface
+- the repository still must not claim full-rewrite completion

--- a/docs/status/porting-rules.md
+++ b/docs/status/porting-rules.md
@@ -1,0 +1,58 @@
+# Porting Rules Status
+
+This file captures the current implementation gate, the recommended first slice,
+and the repository's definition of done.
+
+## First Implementation Gate
+
+No large-scale subsystem implementation should begin until all of the following
+are true:
+
+1. `docs/compatibility-scope.md` is accepted
+2. `docs/go-rust-semantic-mapping.md` is accepted
+3. `docs/dependency-policy.md` is accepted
+4. `docs/allocator-runtime-baseline.md` is accepted
+5. `docs/adr/0001-hybrid-concurrency-model.md` is accepted
+6. the workspace skeleton is accepted
+7. the first subsystem slice and its parity checks are frozen
+
+## Recommended First Slice
+
+Port config, credentials, and ingress normalization first.
+
+Reason:
+
+- the behavior is heavily documented
+- the inputs and outputs are comparatively deterministic
+- the slice is lower risk than transports, supervisors, or streaming bridges
+- it freezes CLI/config/env precedence and credential parsing early
+- it freezes ingress validation and default no-ingress behavior early
+- it unlocks later runtime assembly work without starting in the highest-risk
+  concurrency areas
+
+Scope boundary for the first slice:
+
+- include config discovery, parsing, validation, and credential handling
+- include ingress parsing, validation, normalization, and deterministic rule
+  matching
+- include CLI-origin synthesis only to the extent needed to normalize
+  single-origin ingress inputs
+- exclude proxying, transports, supervisor logic, metrics servers, management,
+  and orchestration
+
+Current scaffold implication:
+
+- narrow first-slice implementation code is now present
+- the crate layout still reserves the correct boundaries for the remainder of
+  this first slice
+- manifests should stay sparse while the remaining slice behavior lands
+
+## Done Means
+
+A subsystem should not be called "ported" unless:
+
+- behavior matches `baseline-2026.2.0/old-impl/`
+- relevant config or CLI surface matches `baseline-2026.2.0/old-impl/`
+- relevant wire bytes match `baseline-2026.2.0/old-impl/` where applicable
+- documented quirks are either preserved or explicitly waived
+- parity tests are documented and passing

--- a/docs/status/rewrite-foundation.md
+++ b/docs/status/rewrite-foundation.md
@@ -1,0 +1,148 @@
+# Rewrite Foundation Status
+
+This file captures the current repository-wide foundation state.
+
+Use it when the question is about what the workspace is, which lane is active,
+which governance documents are current, or which crates currently own real
+behavior.
+
+## Classification
+
+This repository is currently a rewrite workspace with a frozen Go reference
+implementation and an intentionally narrow Rust first slice.
+
+It is not yet a parity-complete Rust implementation workspace. The repository
+now contains a Cargo workspace skeleton plus accepted first-slice behavior in
+`crates/cloudflared-config/` for config discovery/loading, credentials
+origin-cert decoding, ingress normalization and matching, and a real
+first-slice Go-truth compare harness whose accepted fixture surface currently
+compares green. It also now contains a narrow Phase 3.3 QUIC tunnel core in
+`crates/cloudflared-cli/` that owns startup, supervision, transport session
+establishment, and runtime config handoff while still stopping honestly before
+later Pingora and broader wire/protocol slices. Most broader production-alpha
+subsystem behavior is still unported.
+
+The scaffold is intentionally real but minimal:
+
+- the workspace builds as a Rust scaffold with partial first-slice behavior
+- the runnable binary now exposes only the admitted Phase 3.3 launch,
+  runtime/lifecycle, and QUIC tunnel-core surface
+- policy and governance documents define the rewrite boundary
+- manifests should reflect only code that exists today, not speculative future
+  subsystem work
+
+## Decided Now
+
+### Compatibility Baseline
+
+- The primary rewrite target is the frozen Go snapshot in `baseline-2026.2.0/old-impl/`.
+- The target release is `2026.2.0`, as recorded at the top of
+  `baseline-2026.2.0/old-impl/RELEASE_NOTES`.
+- The documentation set in `baseline-2026.2.0/design-audit/` is the derived reference
+  and navigation layer for that snapshot.
+- The Rust workspace version must track that Go release baseline and use the
+  format `<go-release>-alpha.YYYYmm`. The current workspace version is
+  `2026.2.0-alpha.202603`.
+
+### Source Precedence
+
+If sources disagree, use this precedence order:
+
+1. `baseline-2026.2.0/old-impl/` code and tests
+2. `baseline-2026.2.0/design-audit/`
+3. `AGENTS.md`
+4. `SKILLS.md`
+
+### Governance Documents
+
+The following top-level rewrite decisions are part of the active scaffold:
+
+- `docs/compatibility-scope.md`
+- `docs/build-artifact-policy.md`
+- `docs/go-rust-semantic-mapping.md`
+- `docs/dependency-policy.md`
+- `docs/allocator-runtime-baseline.md`
+- `docs/adr/0001-hybrid-concurrency-model.md`
+- `docs/adr/0002-transport-tls-crypto-lane.md`
+- `docs/adr/0003-pingora-critical-path.md`
+- `docs/adr/0004-fips-in-alpha-definition.md`
+- `docs/adr/0005-deployment-contract.md`
+- `docs/adr/ADR-0006-standard-format-and-workspace-dependency-admission.md`
+
+### Active Phase Model
+
+- Big Phase 1 is done:
+  - truth freeze is in place
+  - the accepted first-slice compare is green
+  - broader subsystem work remains mostly unported
+- Big Phase 2 is closed and frozen:
+  - purpose was to freeze the Linux production-alpha lane
+  - tasks 2.0 through 2.6 are complete at the governance level
+- Big Phase 3 is current:
+  - purpose: build the minimum runnable alpha on the frozen lane
+  - active task: 3.3 QUIC tunnel core
+- Big Phase 4 is later:
+  - harden, validate, measure, and prove the alpha in real use
+- Big Phase 5 is later:
+  - widen intentionally only after the alpha is credible
+
+### Active Lane
+
+- Linux only
+- target triple: `x86_64-unknown-linux-gnu`
+- shipped GNU artifacts only:
+  - `x86-64-v2`
+  - `x86-64-v4`
+- 0-RTT is required
+- quiche first
+- quiche + BoringSSL
+- Pingora is in the production-alpha critical path
+- FIPS belongs in the production-alpha lane
+- Cloudflare-owned crates are preferred where they genuinely fit, but are not
+  mandatory by default
+
+### Current Workspace Shape
+
+- `baseline-2026.2.0/old-impl/` contains the frozen Go source of truth
+- `baseline-2026.2.0/design-audit/` contains the extracted spec set
+- `docs/` contains rewrite-program decisions and semantic guidance
+- `crates/` contains only minimal Rust crate skeletons
+
+Current crate intent:
+
+- `crates/cloudflared-cli`: narrow admitted alpha entry surface for help,
+  version, config-backed startup validation, the current runtime/lifecycle
+  owner, and the current QUIC transport core
+- `crates/cloudflared-config`: owning crate for the accepted first-slice
+  domain skeleton and future config, credentials, and ingress normalization
+  behavior
+- `crates/cloudflared-config/tests/`: first-slice parity harness and fixtures
+- `crates/cloudflared-core`: future shared types and cross-cutting primitives
+- `crates/cloudflared-proto`: future wire-format and RPC boundary
+
+### Frozen Inputs
+
+The following directories are immutable inputs to the rewrite program and must
+not be edited during normal rewrite work:
+
+- `baseline-2026.2.0/old-impl/`
+- `baseline-2026.2.0/design-audit/`
+
+If those inputs appear inconsistent, update top-level governance documents or
+the Rust workspace instead of modifying the frozen reference material.
+
+### Dependency And Runtime Baseline
+
+- The workspace already has a scaffold and should remain minimal and honest.
+- The runnable binary must use `mimalloc` as the process allocator.
+- The required `mimalloc` feature set is:
+  - `override`
+  - `no_thp`
+  - `local_dynamic_tls`
+  - `extended`
+- Allocator choice belongs only at the runnable binary boundary.
+  - Tokio is now admitted at the binary boundary for the active runtime/
+    lifecycle shell that underpins the current Phase 3.3 tunnel core.
+- Async runtime choice is governed by
+  `docs/allocator-runtime-baseline.md` and
+  `docs/adr/0001-hybrid-concurrency-model.md`.

--- a/tools/mcp-cfd-rs/src/main.rs
+++ b/tools/mcp-cfd-rs/src/main.rs
@@ -32,9 +32,47 @@ struct SearchRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+struct ListPathsRequest {
+    base_path: Option<String>,
+    extensions: Option<Vec<String>>,
+    recursive: Option<bool>,
+    max_results: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SearchPathsRequest {
+    query: String,
+    paths: Vec<String>,
+    max_results: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ContextBundleRequest {
+    bundle: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ContextSnapshotRequest {
+    snapshot: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 struct ReadFileRequest {
     path: String,
     max_chars: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ReadFileLinesRequest {
+    path: String,
+    start_line: u32,
+    end_line: u32,
+    max_chars: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct FileMetadataRequest {
+    path: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -42,6 +80,56 @@ struct SearchHit {
     path: String,
     score: usize,
     snippet: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PathEntry {
+    path: String,
+    kind: &'static str,
+    size_bytes: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct FileMetadata {
+    path: String,
+    kind: &'static str,
+    size_bytes: u64,
+    line_count: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct BundleEntry {
+    path: String,
+    reason: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct ContextBundle {
+    bundle: &'static str,
+    summary: &'static str,
+    entries: Vec<BundleEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct ContextBrief {
+    bundle: &'static str,
+    summary: &'static str,
+    first_path: String,
+    next_paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotFact {
+    label: &'static str,
+    value: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct ContextSnapshot {
+    snapshot: &'static str,
+    summary: &'static str,
+    facts: Vec<SnapshotFact>,
+    source_paths: Vec<String>,
 }
 
 #[tool_router]
@@ -88,6 +176,129 @@ impl CfdRsMemory {
         search_roots(&self.repo_root, &roots, &query, max_results).await
     }
 
+    #[tool(
+        description = "List repo paths under a repo-relative directory, with optional recursion and \
+                       extension filtering."
+    )]
+    async fn list_paths(
+        &self,
+        Parameters(ListPathsRequest {
+            base_path,
+            extensions,
+            recursive,
+            max_results,
+        }): Parameters<ListPathsRequest>,
+    ) -> String {
+        let base_path = base_path.unwrap_or_else(|| ".".to_string());
+        let recursive = recursive.unwrap_or(false);
+        let max_results = max_results.unwrap_or(100).clamp(1, 500) as usize;
+
+        let base_path_canon =
+            match resolve_repo_path(&self.repo_root, &self.repo_root_canon, base_path.as_str()) {
+                Ok(path) => path,
+                Err(error) => {
+                    return to_json(serde_json::json!({
+                        "error": error,
+                        "path": base_path
+                    }));
+                }
+            };
+
+        let filter_extensions = normalize_extensions(extensions.as_deref());
+
+        let entries = collect_paths(
+            &self.repo_root,
+            &base_path_canon,
+            recursive,
+            filter_extensions.as_ref(),
+            max_results,
+        )
+        .await;
+
+        to_json(entries)
+    }
+
+    #[tool(
+        description = "Search only the provided repo-relative files or directories, returning small \
+                       grounded hits."
+    )]
+    async fn search_paths(
+        &self,
+        Parameters(SearchPathsRequest {
+            query,
+            paths,
+            max_results,
+        }): Parameters<SearchPathsRequest>,
+    ) -> String {
+        if paths.is_empty() {
+            return to_json(serde_json::json!({
+                "error": "paths must not be empty"
+            }));
+        }
+
+        let mut roots = Vec::new();
+        for path in paths {
+            match resolve_repo_path(&self.repo_root, &self.repo_root_canon, path.as_str()) {
+                Ok(root) => roots.push(root),
+                Err(error) => {
+                    return to_json(serde_json::json!({
+                        "error": error,
+                        "path": path
+                    }));
+                }
+            }
+        }
+
+        let max_results = max_results.unwrap_or(5).clamp(1, 20) as usize;
+
+        search_roots(&self.repo_root, &roots, &query, max_results).await
+    }
+
+    #[tool(description = "Return a curated narrow context bundle for a common repository question type.")]
+    async fn get_context_bundle(
+        &self,
+        Parameters(ContextBundleRequest { bundle }): Parameters<ContextBundleRequest>,
+    ) -> String {
+        match context_bundle(bundle.trim()) {
+            Some(bundle) => to_json(bundle),
+            None => to_json(serde_json::json!({
+                "error": "unknown bundle",
+                "supported_bundles": supported_bundle_names()
+            })),
+        }
+    }
+
+    #[tool(description = "Return a compact first-read brief for a curated repository context bundle.")]
+    async fn get_context_brief(
+        &self,
+        Parameters(ContextBundleRequest { bundle }): Parameters<ContextBundleRequest>,
+    ) -> String {
+        match context_brief(bundle.trim()) {
+            Some(brief) => to_json(brief),
+            None => to_json(serde_json::json!({
+                "error": "unknown bundle",
+                "supported_bundles": supported_bundle_names()
+            })),
+        }
+    }
+
+    #[tool(
+        description = "Return a compact source-backed snapshot for common repo-state or phase-state \
+                       questions."
+    )]
+    async fn get_context_snapshot(
+        &self,
+        Parameters(ContextSnapshotRequest { snapshot }): Parameters<ContextSnapshotRequest>,
+    ) -> String {
+        match context_snapshot(snapshot.trim()) {
+            Some(snapshot) => to_json(snapshot),
+            None => to_json(serde_json::json!({
+                "error": "unknown snapshot",
+                "supported_snapshots": supported_snapshot_names()
+            })),
+        }
+    }
+
     #[tool(description = "Read a repo file with truncation and repo-boundary enforcement.")]
     async fn read_file(
         &self,
@@ -95,27 +306,19 @@ impl CfdRsMemory {
     ) -> String {
         let max_chars = max_chars.unwrap_or(4000).clamp(200, 12000) as usize;
 
-        if invalid_repo_relative_path(&path) {
-            return to_json(serde_json::json!({
-                "error": "path must be repo-relative and must not escape the repo root"
-            }));
-        }
-
-        let candidate = self.repo_root.join(&path);
-
-        let candidate_canon = match std::fs::canonicalize(&candidate) {
-            Ok(p) => p,
-            Err(_) => {
+        let candidate_canon = match resolve_repo_path(&self.repo_root, &self.repo_root_canon, &path) {
+            Ok(path) => path,
+            Err(error) => {
                 return to_json(serde_json::json!({
-                    "error": "file not found or not readable",
+                    "error": error,
                     "path": path
                 }));
             }
         };
 
-        if !candidate_canon.starts_with(&self.repo_root_canon) || !candidate_canon.is_file() {
+        if !candidate_canon.is_file() {
             return to_json(serde_json::json!({
-                "error": "path escapes repo root or is not a regular file",
+                "error": "path is not a regular file",
                 "path": path
             }));
         }
@@ -137,6 +340,119 @@ impl CfdRsMemory {
             })),
         }
     }
+
+    #[tool(
+        description = "Read a specific line range from a repo file with truncation and repo-boundary \
+                       enforcement."
+    )]
+    async fn read_file_lines(
+        &self,
+        Parameters(ReadFileLinesRequest {
+            path,
+            start_line,
+            end_line,
+            max_chars,
+        }): Parameters<ReadFileLinesRequest>,
+    ) -> String {
+        let max_chars = max_chars.unwrap_or(4000).clamp(200, 16000) as usize;
+
+        if start_line == 0 || end_line < start_line {
+            return to_json(serde_json::json!({
+                "error": "line range must be 1-based and end_line must be >= start_line",
+                "path": path
+            }));
+        }
+
+        let candidate_canon = match resolve_repo_path(&self.repo_root, &self.repo_root_canon, &path) {
+            Ok(path) => path,
+            Err(error) => {
+                return to_json(serde_json::json!({
+                    "error": error,
+                    "path": path
+                }));
+            }
+        };
+
+        if !candidate_canon.is_file() {
+            return to_json(serde_json::json!({
+                "error": "path is not a regular file",
+                "path": path
+            }));
+        }
+
+        match fs::read_to_string(&candidate_canon).await {
+            Ok(text) => match slice_lines(text.as_str(), start_line as usize, end_line as usize, max_chars) {
+                Ok((content, total_line_count, truncated)) => to_json(serde_json::json!({
+                    "path": path,
+                    "start_line": start_line,
+                    "end_line": usize::min(end_line as usize, total_line_count),
+                    "total_line_count": total_line_count,
+                    "truncated": truncated,
+                    "content": content
+                })),
+                Err(error) => to_json(serde_json::json!({
+                    "error": error,
+                    "path": path
+                })),
+            },
+            Err(_) => to_json(serde_json::json!({
+                "error": "file not readable as UTF-8 text",
+                "path": path
+            })),
+        }
+    }
+
+    #[tool(description = "Return metadata for a repo path, including line count for readable text files.")]
+    async fn file_metadata(
+        &self,
+        Parameters(FileMetadataRequest { path }): Parameters<FileMetadataRequest>,
+    ) -> String {
+        let candidate_canon = match resolve_repo_path(&self.repo_root, &self.repo_root_canon, &path) {
+            Ok(path) => path,
+            Err(error) => {
+                return to_json(serde_json::json!({
+                    "error": error,
+                    "path": path
+                }));
+            }
+        };
+
+        let metadata = match fs::metadata(&candidate_canon).await {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                return to_json(serde_json::json!({
+                    "error": "path not readable",
+                    "path": path
+                }));
+            }
+        };
+
+        let kind = if metadata.is_dir() {
+            "directory"
+        } else if metadata.is_file() {
+            "file"
+        } else {
+            "other"
+        };
+
+        let line_count = if metadata.is_file() && is_text_file(&candidate_canon) {
+            fs::read_to_string(&candidate_canon)
+                .await
+                .ok()
+                .map(|text| text.lines().count())
+        } else {
+            None
+        };
+
+        let metadata = FileMetadata {
+            path,
+            kind,
+            size_bytes: metadata.len(),
+            line_count,
+        };
+
+        to_json(metadata)
+    }
 }
 
 #[tool_handler]
@@ -144,8 +460,9 @@ impl ServerHandler for CfdRsMemory {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::default();
         info.instructions = Some(
-            "Read-only repository memory server. Use its tools to retrieve small grounded slices before \
-             making claims."
+            "Read-only repository memory server. Prefer staged retrieval: route first, list or search the \
+             smallest path set, inspect metadata or snippets, then read only the needed lines or chunk \
+             before making claims."
                 .into(),
         );
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
@@ -200,6 +517,82 @@ async fn search_roots(repo_root: &Path, roots: &[PathBuf], query: &str, max_resu
     hits.truncate(max_results);
 
     to_json(hits)
+}
+
+async fn collect_paths(
+    repo_root: &Path,
+    base_path: &Path,
+    recursive: bool,
+    extensions: Option<&BTreeSet<String>>,
+    max_results: usize,
+) -> Vec<PathEntry> {
+    let Ok(base_meta) = fs::symlink_metadata(base_path).await else {
+        return Vec::new();
+    };
+
+    if !base_meta.is_dir() {
+        return Vec::new();
+    }
+
+    let mut entries = Vec::new();
+    let mut stack = vec![base_path.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let Ok(mut read_dir) = fs::read_dir(&dir).await else {
+            continue;
+        };
+
+        let mut children = Vec::new();
+        while let Ok(Some(entry)) = read_dir.next_entry().await {
+            let entry_path = entry.path();
+
+            let Ok(entry_meta) = fs::symlink_metadata(&entry_path).await else {
+                continue;
+            };
+
+            if entry_meta.file_type().is_symlink() {
+                continue;
+            }
+
+            children.push((entry_path, entry_meta));
+        }
+
+        children.sort_by(|left, right| left.0.cmp(&right.0));
+
+        for (entry_path, entry_meta) in children {
+            if entry_meta.is_dir() {
+                entries.push(PathEntry {
+                    path: make_relative(repo_root, &entry_path),
+                    kind: "directory",
+                    size_bytes: None,
+                });
+
+                if recursive {
+                    stack.push(entry_path);
+                }
+            } else if entry_meta.is_file() {
+                if !path_matches_extensions(&entry_path, extensions) {
+                    continue;
+                }
+
+                entries.push(PathEntry {
+                    path: make_relative(repo_root, &entry_path),
+                    kind: "file",
+                    size_bytes: Some(entry_meta.len()),
+                });
+            }
+
+            if entries.len() >= max_results {
+                return entries;
+            }
+        }
+
+        if !recursive {
+            break;
+        }
+    }
+
+    entries
 }
 
 async fn collect_text_files(path: &Path, out: &mut BTreeSet<PathBuf>) {
@@ -261,6 +654,34 @@ fn is_text_file(path: &Path) -> bool {
     )
 }
 
+fn normalize_extensions(extensions: Option<&[String]>) -> Option<BTreeSet<String>> {
+    let mut normalized = BTreeSet::new();
+
+    for extension in extensions.unwrap_or(&[]) {
+        let extension = extension.trim().trim_start_matches('.').to_ascii_lowercase();
+        if !extension.is_empty() {
+            normalized.insert(extension);
+        }
+    }
+
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+fn path_matches_extensions(path: &Path, extensions: Option<&BTreeSet<String>>) -> bool {
+    let Some(extensions) = extensions else {
+        return true;
+    };
+
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extensions.contains(&extension.to_ascii_lowercase()))
+        .unwrap_or(false)
+}
+
 fn normalize_terms(query: &str) -> Vec<String> {
     query
         .split_whitespace()
@@ -303,6 +724,47 @@ fn make_relative(root: &Path, path: &Path) -> String {
         .unwrap_or_else(|_| path.display().to_string())
 }
 
+fn resolve_repo_path(repo_root: &Path, repo_root_canon: &Path, path: &str) -> Result<PathBuf, &'static str> {
+    if invalid_repo_relative_path(path) {
+        return Err("path must be repo-relative and must not escape the repo root");
+    }
+
+    let candidate = repo_root.join(path);
+    let candidate_canon =
+        std::fs::canonicalize(&candidate).map_err(|_| "file or directory not found or not readable")?;
+
+    if !candidate_canon.starts_with(repo_root_canon) {
+        return Err("path escapes repo root");
+    }
+
+    Ok(candidate_canon)
+}
+
+fn slice_lines(
+    text: &str,
+    start_line: usize,
+    end_line: usize,
+    max_chars: usize,
+) -> Result<(String, usize, bool), &'static str> {
+    let all_lines = text.lines().collect::<Vec<_>>();
+    let total_line_count = all_lines.len();
+
+    if total_line_count == 0 {
+        return Ok((String::new(), 0, false));
+    }
+
+    if start_line > total_line_count {
+        return Err("start_line is out of bounds for this file");
+    }
+
+    let end_line = usize::min(end_line, total_line_count);
+    let content = all_lines[start_line - 1..end_line].join("\n");
+    let truncated = content.chars().count() > max_chars;
+    let content = content.chars().take(max_chars).collect();
+
+    Ok((content, total_line_count, truncated))
+}
+
 fn invalid_repo_relative_path(path: &str) -> bool {
     let p = Path::new(path);
 
@@ -318,4 +780,527 @@ fn invalid_repo_relative_path(path: &str) -> bool {
 fn to_json<T: Serialize>(value: T) -> String {
     serde_json::to_string_pretty(&value)
         .unwrap_or_else(|_| "{\"error\":\"serialization failed\"}".to_string())
+}
+
+fn supported_bundle_names() -> Vec<&'static str> {
+    vec![
+        "scope-lane",
+        "repo-state",
+        "active-surface",
+        "first-slice-parity",
+        "runtime-deps",
+        "behavior-baseline",
+    ]
+}
+
+fn context_bundle(bundle: &str) -> Option<ContextBundle> {
+    match bundle {
+        "scope-lane" => Some(ContextBundle {
+            bundle: "scope-lane",
+            summary: "Use this bundle for rewrite boundaries, current lane, and non-negotiable scope.",
+            entries: vec![
+                BundleEntry {
+                    path: "REWRITE_CHARTER.md".to_string(),
+                    reason: "Shortest source of non-negotiables, lane decisions, and scope boundaries.",
+                },
+                BundleEntry {
+                    path: "docs/compatibility-scope.md".to_string(),
+                    reason: "Defines what compatibility means and what it does not imply.",
+                },
+                BundleEntry {
+                    path: "docs/promotion-gates.md".to_string(),
+                    reason: "Gives the current phase model when phase boundaries matter to scope.",
+                },
+            ],
+        }),
+        "repo-state" => Some(ContextBundle {
+            bundle: "repo-state",
+            summary: "Use this bundle for what exists now in the workspace without loading the entire old \
+                      status narrative.",
+            entries: vec![
+                BundleEntry {
+                    path: "STATUS.md".to_string(),
+                    reason: "Short status index and summary.",
+                },
+                BundleEntry {
+                    path: "docs/status/rewrite-foundation.md".to_string(),
+                    reason: "Current lane, workspace shape, and governance baseline.",
+                },
+                BundleEntry {
+                    path: "docs/status/active-surface.md".to_string(),
+                    reason: "Current executable surface and deferred scope.",
+                },
+            ],
+        }),
+        "active-surface" => Some(ContextBundle {
+            bundle: "active-surface",
+            summary: "Use this bundle for the currently admitted implementation surface and nearby deferred \
+                      slices.",
+            entries: vec![
+                BundleEntry {
+                    path: "STATUS.md".to_string(),
+                    reason: "Short status index for current state entry.",
+                },
+                BundleEntry {
+                    path: "docs/status/active-surface.md".to_string(),
+                    reason: "Current Phase 3.3 surface and deferred Big Phase 3 slices.",
+                },
+                BundleEntry {
+                    path: "docs/promotion-gates.md".to_string(),
+                    reason: "Promotion boundaries when deciding whether a behavior belongs to the active \
+                             slice.",
+                },
+            ],
+        }),
+        "first-slice-parity" => Some(ContextBundle {
+            bundle: "first-slice-parity",
+            summary: "Use this bundle for first-slice implementation history and parity-backed closure \
+                      state.",
+            entries: vec![
+                BundleEntry {
+                    path: "docs/first-slice-freeze.md".to_string(),
+                    reason: "Frozen accepted first-slice scope.",
+                },
+                BundleEntry {
+                    path: "docs/status/first-slice-parity.md".to_string(),
+                    reason: "Current first-slice implementation and parity status by subphase.",
+                },
+                BundleEntry {
+                    path: "tools/first_slice_parity.py".to_string(),
+                    reason: "Parity harness entry point when implementation details matter.",
+                },
+            ],
+        }),
+        "runtime-deps" => Some(ContextBundle {
+            bundle: "runtime-deps",
+            summary: "Use this bundle for dependency admission, allocator rules, and runtime structure \
+                      constraints.",
+            entries: vec![
+                BundleEntry {
+                    path: "docs/dependency-policy.md".to_string(),
+                    reason: "Dependency admission and workspace dependency truth.",
+                },
+                BundleEntry {
+                    path: "docs/allocator-runtime-baseline.md".to_string(),
+                    reason: "Allocator and runtime baseline.",
+                },
+                BundleEntry {
+                    path: "docs/go-rust-semantic-mapping.md".to_string(),
+                    reason: "Concurrency and lifecycle doctrine when runtime shape matters.",
+                },
+            ],
+        }),
+        "behavior-baseline" => Some(ContextBundle {
+            bundle: "behavior-baseline",
+            summary: "Use this bundle for behavior and parity questions against the frozen Go baseline.",
+            entries: vec![
+                BundleEntry {
+                    path: "baseline-2026.2.0/design-audit/REPO_SOURCE_INDEX.md".to_string(),
+                    reason: "Topic-to-source map into the frozen Go tree.",
+                },
+                BundleEntry {
+                    path: "baseline-2026.2.0/design-audit/REPO_REFERENCE.md".to_string(),
+                    reason: "Broad repository reference for behavioral and contract questions.",
+                },
+                BundleEntry {
+                    path: "baseline-2026.2.0/old-impl".to_string(),
+                    reason: "Frozen behavioral source of truth; read the specific package or test after \
+                             routing.",
+                },
+            ],
+        }),
+        _ => None,
+    }
+}
+
+fn context_brief(bundle: &str) -> Option<ContextBrief> {
+    let bundle = context_bundle(bundle)?;
+    let mut paths = bundle.entries.into_iter().map(|entry| entry.path);
+    let first_path = paths.next()?;
+    let next_paths = paths.collect();
+
+    Some(ContextBrief {
+        bundle: bundle.bundle,
+        summary: bundle.summary,
+        first_path,
+        next_paths,
+    })
+}
+
+fn supported_snapshot_names() -> Vec<&'static str> {
+    vec![
+        "governing-files",
+        "scope-lane",
+        "repo-state",
+        "active-phase",
+        "runtime-deps",
+        "behavior-baseline",
+        "lane-decisions",
+    ]
+}
+
+fn context_snapshot(snapshot: &str) -> Option<ContextSnapshot> {
+    match snapshot {
+        "governing-files" => Some(ContextSnapshot {
+            snapshot: "governing-files",
+            summary: "Compact answer for which repository file owns the main governance topic categories.",
+            facts: vec![
+                SnapshotFact {
+                    label: "scope_and_lane",
+                    value: "Use REWRITE_CHARTER.md for non-negotiables, active lane, and scope boundaries; \
+                            use docs/compatibility-scope.md when the meaning of compatibility needs detail.",
+                },
+                SnapshotFact {
+                    label: "current_state_and_phase",
+                    value: "Use STATUS.md as the short current-state index, docs/status/* for focused \
+                            current-state detail, and docs/promotion-gates.md for active phase and \
+                            promotion boundaries.",
+                },
+                SnapshotFact {
+                    label: "dependencies_and_runtime",
+                    value: "Use docs/dependency-policy.md for dependency admission and workspace dependency \
+                            truth, and docs/allocator-runtime-baseline.md plus \
+                            docs/go-rust-semantic-mapping.md for runtime and lifecycle doctrine.",
+                },
+                SnapshotFact {
+                    label: "behavior_and_parity",
+                    value: "Use baseline-2026.2.0/old-impl first for behavior truth, then \
+                            baseline-2026.2.0/design-audit for topic maps and broader parity reference.",
+                },
+            ],
+            source_paths: vec![
+                "REWRITE_CHARTER.md".to_string(),
+                "STATUS.md".to_string(),
+                "docs/promotion-gates.md".to_string(),
+                "docs/dependency-policy.md".to_string(),
+                "baseline-2026.2.0/old-impl".to_string(),
+            ],
+        }),
+        "scope-lane" => Some(ContextSnapshot {
+            snapshot: "scope-lane",
+            summary: "Compact answer for rewrite boundaries, compatibility lane, and governing scope files.",
+            facts: vec![
+                SnapshotFact {
+                    label: "scope_owner",
+                    value: "REWRITE_CHARTER.md owns non-negotiables, lane decisions, and scope boundaries.",
+                },
+                SnapshotFact {
+                    label: "compatibility_meaning",
+                    value: "Compatibility is bounded by the frozen rewrite lane and must not be widened by \
+                            implication from later slices or broader platform assumptions.",
+                },
+                SnapshotFact {
+                    label: "phase_boundary_owner",
+                    value: "Promotion and current phase truth belong to docs/promotion-gates.md rather than \
+                            branch names, draft plans, or workflow notes.",
+                },
+            ],
+            source_paths: vec![
+                "REWRITE_CHARTER.md".to_string(),
+                "docs/compatibility-scope.md".to_string(),
+                "docs/promotion-gates.md".to_string(),
+            ],
+        }),
+        "repo-state" => Some(ContextSnapshot {
+            snapshot: "repo-state",
+            summary: "Compact answer for what exists now versus what remains explicitly unimplemented.",
+            facts: vec![
+                SnapshotFact {
+                    label: "workspace_state",
+                    value: "The workspace is real but partial, not a blank scaffold and not a \
+                            parity-complete rewrite.",
+                },
+                SnapshotFact {
+                    label: "implemented_now",
+                    value: "Accepted first-slice config, credentials, and ingress behavior exists in \
+                            crates/cloudflared-config, and a narrow Phase 3.3 QUIC tunnel core exists in \
+                            crates/cloudflared-cli.",
+                },
+                SnapshotFact {
+                    label: "explicitly_missing",
+                    value: "Pingora integration, later wire or protocol slices, security or compliance \
+                            operational behavior, and broader platform scope are not implemented yet.",
+                },
+            ],
+            source_paths: vec![
+                "STATUS.md".to_string(),
+                "docs/status/rewrite-foundation.md".to_string(),
+                "docs/status/active-surface.md".to_string(),
+            ],
+        }),
+        "active-phase" => Some(ContextSnapshot {
+            snapshot: "active-phase",
+            summary: "Compact answer for the current implementation phase and what it must not imply.",
+            facts: vec![
+                SnapshotFact {
+                    label: "current_big_phase",
+                    value: "Big Phase 3 is current.",
+                },
+                SnapshotFact {
+                    label: "active_task",
+                    value: "Phase 3.3 owns the QUIC tunnel core for the frozen Linux production-alpha lane.",
+                },
+                SnapshotFact {
+                    label: "deferred_next_slices",
+                    value: "Phase 3.4 Pingora integration, Phase 3.5 wire or protocol, Phase 3.6 security \
+                            or compliance operations, and Phase 3.7 standard-format integration remain \
+                            deferred.",
+                },
+                SnapshotFact {
+                    label: "must_not_imply",
+                    value: "Current Phase 3.3 work must not imply that Pingora, later wire behavior, \
+                            compliance operations, or broader packaging and deployment tooling already \
+                            exist.",
+                },
+            ],
+            source_paths: vec![
+                "STATUS.md".to_string(),
+                "docs/status/active-surface.md".to_string(),
+                "docs/promotion-gates.md".to_string(),
+            ],
+        }),
+        "runtime-deps" => Some(ContextSnapshot {
+            snapshot: "runtime-deps",
+            summary: "Compact answer for dependency admission, workspace dependency truth, and runtime \
+                      baseline constraints.",
+            facts: vec![
+                SnapshotFact {
+                    label: "dependency_default",
+                    value: "Normal workspace-managed third-party dependency truth should normally live in \
+                            [workspace.dependencies], with crate-local declarations reserved for explicit \
+                            isolation cases.",
+                },
+                SnapshotFact {
+                    label: "admission_rule",
+                    value: "Dependencies are admitted only for active owning slices and must not silently \
+                            redesign externally visible behavior or preload later-slice scope.",
+                },
+                SnapshotFact {
+                    label: "runtime_guardrail",
+                    value: "Runtime and allocator shape remain governed by the accepted baseline; later \
+                            async, transport, or observability dependencies do not become defaults before \
+                            their owning slices start.",
+                },
+            ],
+            source_paths: vec![
+                "docs/dependency-policy.md".to_string(),
+                "docs/allocator-runtime-baseline.md".to_string(),
+                "docs/go-rust-semantic-mapping.md".to_string(),
+            ],
+        }),
+        "behavior-baseline" => Some(ContextSnapshot {
+            snapshot: "behavior-baseline",
+            summary: "Compact answer for where behavior and parity truth must be sourced before making \
+                      claims about rewrite correctness.",
+            facts: vec![
+                SnapshotFact {
+                    label: "first_truth_source",
+                    value: "Behavior and parity questions start with baseline-2026.2.0/old-impl code and \
+                            tests, not the Rust rewrite shape.",
+                },
+                SnapshotFact {
+                    label: "second_truth_source",
+                    value: "Use baseline-2026.2.0/design-audit after the frozen source tree when a topic \
+                            map, reference index, or broader audit summary is needed.",
+                },
+                SnapshotFact {
+                    label: "claim_guardrail",
+                    value: "Do not claim parity from Rust code alone; route to the frozen baseline first \
+                            and widen only after the baseline path is known.",
+                },
+            ],
+            source_paths: vec![
+                "baseline-2026.2.0/old-impl".to_string(),
+                "baseline-2026.2.0/design-audit/REPO_SOURCE_INDEX.md".to_string(),
+                "baseline-2026.2.0/design-audit/REPO_REFERENCE.md".to_string(),
+            ],
+        }),
+        "lane-decisions" => Some(ContextSnapshot {
+            snapshot: "lane-decisions",
+            summary: "Compact answer for the frozen alpha-lane decisions across transport, Pingora, FIPS, \
+                      and deployment.",
+            facts: vec![
+                SnapshotFact {
+                    label: "transport_lane",
+                    value: "The frozen alpha lane requires 0-RTT, uses quiche first, and chooses quiche \
+                            plus BoringSSL rather than quiche plus OpenSSL.",
+                },
+                SnapshotFact {
+                    label: "pingora_role",
+                    value: "Pingora is in the production-alpha critical path above the quiche transport \
+                            lane as the initial application-layer proxy path, not as the transport owner.",
+                },
+                SnapshotFact {
+                    label: "fips_boundary",
+                    value: "FIPS-in-alpha is a bounded governance commitment around the admitted crypto \
+                            surface and explicit build or link boundary, not proof of working \
+                            implementation or certification.",
+                },
+                SnapshotFact {
+                    label: "deployment_contract",
+                    value: "The deployment contract is Linux only on x86_64-unknown-linux-gnu with GNU or \
+                            glibc artifacts, a supervised host service model, and a bare-metal-first stance.",
+                },
+            ],
+            source_paths: vec![
+                "docs/adr/0002-transport-tls-crypto-lane.md".to_string(),
+                "docs/adr/0003-pingora-critical-path.md".to_string(),
+                "docs/adr/0004-fips-in-alpha-definition.md".to_string(),
+                "docs/adr/0005-deployment-contract.md".to_string(),
+            ],
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        context_brief, context_bundle, context_snapshot, invalid_repo_relative_path, normalize_extensions,
+        path_matches_extensions, slice_lines, supported_bundle_names, supported_snapshot_names,
+    };
+    use std::{collections::BTreeSet, path::Path};
+
+    #[test]
+    fn rejects_absolute_and_parent_paths() {
+        assert!(invalid_repo_relative_path("/tmp/file"));
+        assert!(invalid_repo_relative_path("../file"));
+        assert!(invalid_repo_relative_path("docs/../../file"));
+        assert!(!invalid_repo_relative_path("docs/file.md"));
+    }
+
+    #[test]
+    fn normalizes_extension_filters() {
+        let normalized = normalize_extensions(Some(&[".MD".to_string(), "rs".to_string(), "  ".to_string()]))
+            .expect("extensions should be present");
+
+        assert_eq!(normalized, BTreeSet::from(["md".to_string(), "rs".to_string()]));
+    }
+
+    #[test]
+    fn matches_extensions_case_insensitively() {
+        let extensions = BTreeSet::from(["md".to_string()]);
+
+        assert!(path_matches_extensions(
+            Path::new("docs/README.MD"),
+            Some(&extensions)
+        ));
+        assert!(!path_matches_extensions(
+            Path::new("src/main.rs"),
+            Some(&extensions)
+        ));
+    }
+
+    #[test]
+    fn slices_requested_line_range() {
+        let text = "one\ntwo\nthree\nfour\n";
+        let (content, total_line_count, truncated) =
+            slice_lines(text, 2, 3, 100).expect("line slice should succeed");
+
+        assert_eq!(content, "two\nthree");
+        assert_eq!(total_line_count, 4);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_line_start() {
+        let error = slice_lines("one\ntwo\n", 4, 4, 100).expect_err("slice should fail");
+
+        assert_eq!(error, "start_line is out of bounds for this file");
+    }
+
+    #[test]
+    fn exposes_known_context_bundle() {
+        let bundle = context_bundle("repo-state").expect("bundle should exist");
+
+        assert_eq!(bundle.bundle, "repo-state");
+        assert_eq!(bundle.entries.len(), 3);
+    }
+
+    #[test]
+    fn exposes_compact_context_brief() {
+        let brief = context_brief("repo-state").expect("brief should exist");
+
+        assert_eq!(brief.bundle, "repo-state");
+        assert_eq!(brief.first_path, "STATUS.md");
+        assert_eq!(brief.next_paths.len(), 2);
+    }
+
+    #[test]
+    fn exposes_repo_state_snapshot() {
+        let snapshot = context_snapshot("repo-state").expect("snapshot should exist");
+
+        assert_eq!(snapshot.snapshot, "repo-state");
+        assert_eq!(snapshot.facts.len(), 3);
+        assert!(snapshot.source_paths.contains(&"STATUS.md".to_string()));
+    }
+
+    #[test]
+    fn exposes_runtime_dependency_snapshot() {
+        let snapshot = context_snapshot("runtime-deps").expect("snapshot should exist");
+
+        assert_eq!(snapshot.snapshot, "runtime-deps");
+        assert_eq!(snapshot.facts.len(), 3);
+        assert!(
+            snapshot
+                .source_paths
+                .contains(&"docs/dependency-policy.md".to_string())
+        );
+    }
+
+    #[test]
+    fn exposes_behavior_baseline_snapshot() {
+        let snapshot = context_snapshot("behavior-baseline").expect("snapshot should exist");
+
+        assert_eq!(snapshot.snapshot, "behavior-baseline");
+        assert_eq!(snapshot.facts.len(), 3);
+        assert!(
+            snapshot
+                .source_paths
+                .contains(&"baseline-2026.2.0/old-impl".to_string())
+        );
+    }
+
+    #[test]
+    fn exposes_lane_decision_snapshot() {
+        let snapshot = context_snapshot("lane-decisions").expect("snapshot should exist");
+
+        assert_eq!(snapshot.snapshot, "lane-decisions");
+        assert_eq!(snapshot.facts.len(), 4);
+        assert!(
+            snapshot
+                .source_paths
+                .contains(&"docs/adr/0002-transport-tls-crypto-lane.md".to_string())
+        );
+    }
+
+    #[test]
+    fn exposes_governing_file_snapshot() {
+        let snapshot = context_snapshot("governing-files").expect("snapshot should exist");
+
+        assert_eq!(snapshot.snapshot, "governing-files");
+        assert_eq!(snapshot.facts.len(), 4);
+        assert!(snapshot.source_paths.contains(&"REWRITE_CHARTER.md".to_string()));
+    }
+
+    #[test]
+    fn advertises_supported_snapshot_names() {
+        let supported = supported_snapshot_names();
+
+        assert!(supported.contains(&"scope-lane"));
+        assert!(supported.contains(&"repo-state"));
+        assert!(supported.contains(&"active-phase"));
+        assert!(supported.contains(&"runtime-deps"));
+        assert!(supported.contains(&"behavior-baseline"));
+        assert!(supported.contains(&"lane-decisions"));
+        assert!(supported.contains(&"governing-files"));
+    }
+
+    #[test]
+    fn advertises_supported_bundle_names() {
+        let supported = supported_bundle_names();
+
+        assert!(supported.contains(&"scope-lane"));
+        assert!(supported.contains(&"behavior-baseline"));
+    }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the repository's documentation and agent/routing instructions to clarify context routing, governance file usage, and engineering standards. The changes establish a clear hierarchy and retrieval order for both human and AI contributors, aiming to minimize context drift, duplication, and unnecessary document loading. The update also introduces detailed instructions for editing Markdown and Rust, and adds new reference documents to guide code structure and review.

**Documentation and Routing Structure**

- Added `docs/ai-context-routing.md`, a central entry point for both AI and human contributors, detailing a staged and minimal file retrieval order for common repository tasks and clarifying anti-drift rules.
- Introduced `docs/README.md` as a documentation map, providing a high-level index of policy, scope, and phase documents, and emphasizing minimal context loading.
- Updated `.github/copilot-instructions.md` and `AGENTS.md` to direct cold reads and task routing through `docs/ai-context-routing.md`, and to discourage loading all governance files by default. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R5-R16) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R8-R16) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L75-R84) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R36-R52)

**Editing and Code Contribution Guidelines**

- Added `.github/instructions/markdown.instructions.md` with detailed rules for editing Markdown, including governance hierarchy, routing, anti-drift, and writing style.
- Expanded `.github/instructions/rust.instructions.md` to include workspace dependency review, local code style, engineering structure, and review preferences for Rust code.

**Engineering Standards and Status Documentation**

- Added `docs/engineering-standards.md` to define Rust code structure, ownership boundaries, abstraction thresholds, and module decomposition standards, supplementing the existing code style guide.
- Added `docs/status/active-surface.md` to document the current active implementation surface and explicitly list deferred scope areas for the current phase.

**Key Thematic Groups**

*Context Routing and Governance*
- Centralized context routing through `docs/ai-context-routing.md` for both AI and human contributors, establishing a staged, minimal retrieval order and clarifying file ownership for common question types. [[1]](diffhunk://#diff-f8ea65e86820cb8502a68957fa3a7b60e7844b8b8a625f02c76881e7fe1e99d0R1-R154) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R1-R59) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R5-R16) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R8-R16)
- Updated agent and copilot instructions to prioritize local MCP snapshot surfaces and discourage broad or redundant document loading. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R36-R52) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L75-R84)

*Editing Guidelines*
- Introduced repository-wide Markdown editing instructions to enforce governance hierarchy, anti-drift, and concise, task-oriented documentation.
- Enhanced Rust editing instructions with explicit guidance on dependency management, code style, engineering structure, and review preferences.

*Engineering and Status Reference*
- Added a comprehensive engineering standards document for Rust code, focusing on ownership, public surface discipline, dependency management, and module decomposition.
- Provided a new status file for the currently active implementation surface, clarifying what is in-scope and what is intentionally deferred.