### PR TITLE
rust-rewrite: phase 3.5 protocol boundary

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,14 +18,17 @@ What exists now:
 - a Phase 3.4 Pingora proxy seam with runtime lifecycle participation and a
   first admitted origin/proxy path (`http_status` routing) in
   `crates/cloudflared-cli/src/proxy.rs`
+- a Phase 3.5 wire/protocol boundary between transport and proxy in
+  `crates/cloudflared-cli/src/protocol.rs` with explicit transport-to-proxy
+  handoff through the runtime-managed protocol bridge
 - frozen Go baseline and design-audit references
 - governance and policy docs that freeze the Linux production-alpha lane
 
 What does not exist yet:
 
 - broader Pingora proxy completeness beyond the narrow admitted origin path
-- later wire/protocol slices
-- security/compliance operational behavior
+- registration RPC content (capnp) and incoming request stream handling
+- later security/compliance and standard-format integration slices
 - parity-complete broader subsystem coverage
 - broader platform scope beyond the frozen Linux lane
 

--- a/crates/cloudflared-cli/src/app.rs
+++ b/crates/cloudflared-cli/src/app.rs
@@ -51,7 +51,9 @@ fn execute_runtime_command(startup: StartupSurface) -> CliOutput {
 fn render_help() -> String {
     let mut text = String::new();
     text.push_str(&format!("{PROGRAM_NAME} {}\n", env!("CARGO_PKG_VERSION")));
-    text.push_str("Linux production-alpha QUIC tunnel core with Pingora proxy seam\n\n");
+    text.push_str(
+        "Linux production-alpha QUIC tunnel core with wire/protocol boundary and Pingora proxy seam\n\n",
+    );
     text.push_str("Usage:\n");
     text.push_str("  cloudflared [--config FILEPATH] validate\n");
     text.push_str("  cloudflared [--config FILEPATH] run\n");
@@ -62,10 +64,11 @@ fn render_help() -> String {
         "  validate  Resolve config, load YAML, normalize ingress, and report startup readiness.\n",
     );
     text.push_str(
-        "  run       Enter the runtime-owned QUIC transport core with a Pingora proxy \
+        "  run       Enter the runtime-owned QUIC transport core with wire/protocol \
+         boundary\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20and Pingora proxy \
          seam.\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20The admitted origin path is http_status \
-         only. Broader origin support,\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20wire/protocol \
-         behavior, and general proxy completeness remain later slices.\n",
+         only. Broader origin support\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20and general proxy \
+         completeness remain later slices.\n",
     );
     text.push_str("  version   Print the workspace version.\n");
     text.push_str("  help      Print this help text.\n\n");
@@ -83,8 +86,9 @@ fn render_help() -> String {
     text.push_str("  HOME  Expands the leading ~ in default config search directories.\n\n");
     text.push_str("Deferred beyond current phase:\n");
     text.push_str(
-        "  Broader origin support, wire/protocol boundary, security/compliance operational \
-         boundary,\n\x20\x20standard-format crate integration, packaging, and deployment tooling\n",
+        "  Broader origin support, registration RPC, incoming stream handling,\n\x20\x20security/compliance \
+         operational boundary, standard-format crate integration,\n\x20\x20packaging, and deployment \
+         tooling\n",
     );
     text
 }

--- a/crates/cloudflared-cli/src/main.rs
+++ b/crates/cloudflared-cli/src/main.rs
@@ -3,6 +3,7 @@
 mod app;
 mod cli;
 mod output;
+mod protocol;
 mod proxy;
 mod runtime;
 mod startup;

--- a/crates/cloudflared-cli/src/protocol.rs
+++ b/crates/cloudflared-cli/src/protocol.rs
@@ -1,0 +1,131 @@
+//! Phase 3.5: Wire/protocol boundary between transport and proxy.
+//!
+//! Owns the protocol-level boundary that bridges the QUIC transport
+//! session to the Pingora proxy layer. Transport owns QUIC establishment.
+//! Proxy owns Pingora request dispatch. This module owns the explicit
+//! handoff between them.
+//!
+//! The admitted alpha path uses the cloudflare tunnel wire protocol:
+//! - client-initiated bidi stream 0 is the control/registration stream
+//! - later slices will carry HTTP requests as edge-initiated QUIC streams
+//! - registration RPC content (capnp) remains deferred to later slices
+
+use tokio::sync::mpsc;
+
+/// QUIC stream ID for the tunnel control/registration stream.
+///
+/// The cloudflare tunnel wire protocol uses the first client-initiated
+/// bidirectional stream for tunnel registration.
+pub(crate) const CONTROL_STREAM_ID: u64 = 0;
+
+/// Events that cross the wire/protocol boundary from transport to proxy.
+///
+/// This is the explicit handoff surface. Transport sends these events
+/// after crossing protocol boundaries. The proxy layer receives them
+/// to coordinate its readiness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProtocolEvent {
+    /// The transport has opened the control stream and reached the
+    /// protocol registration boundary.
+    ///
+    /// Later slices will carry real registration RPC and incoming
+    /// request streams through this boundary.
+    Registered { peer: String },
+}
+
+/// Create the explicit protocol bridge between transport and proxy.
+///
+/// Returns the transport-owned sender and the proxy-owned receiver.
+/// The runtime creates this bridge and hands the endpoints to the
+/// services it supervises.
+pub(crate) fn protocol_bridge() -> (ProtocolSender, ProtocolReceiver) {
+    let (tx, rx) = mpsc::channel(4);
+    (ProtocolSender(tx), ProtocolReceiver(rx))
+}
+
+/// Transport-owned end of the protocol bridge.
+///
+/// Cloneable so the runtime service factory can provide a sender
+/// to each transport service instance across restarts.
+#[derive(Debug, Clone)]
+pub(crate) struct ProtocolSender(mpsc::Sender<ProtocolEvent>);
+
+impl ProtocolSender {
+    /// Send a protocol event across the wire/protocol boundary.
+    pub(crate) async fn send(&self, event: ProtocolEvent) {
+        // Best-effort: if the receiver has been dropped, the event
+        // is silently lost. The runtime owns shutdown ordering.
+        let _ = self.0.send(event).await;
+    }
+}
+
+/// Proxy-owned end of the protocol bridge.
+#[derive(Debug)]
+pub(crate) struct ProtocolReceiver(mpsc::Receiver<ProtocolEvent>);
+
+impl ProtocolReceiver {
+    /// Receive the next protocol event from the transport layer.
+    ///
+    /// Returns `None` when all senders have been dropped.
+    pub(crate) async fn recv(&mut self) -> Option<ProtocolEvent> {
+        self.0.recv().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bridge_delivers_registered_event() {
+        let (sender, mut receiver) = protocol_bridge();
+
+        sender
+            .send(ProtocolEvent::Registered {
+                peer: "127.0.0.1:7844".to_owned(),
+            })
+            .await;
+
+        assert_eq!(
+            receiver.recv().await,
+            Some(ProtocolEvent::Registered {
+                peer: "127.0.0.1:7844".to_owned(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_returns_none_after_all_senders_dropped() {
+        let (sender, mut receiver) = protocol_bridge();
+        drop(sender);
+
+        assert_eq!(receiver.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn sender_clone_keeps_bridge_alive() {
+        let (sender, mut receiver) = protocol_bridge();
+        let sender_clone = sender.clone();
+        drop(sender);
+
+        sender_clone
+            .send(ProtocolEvent::Registered {
+                peer: "10.0.0.1:7844".to_owned(),
+            })
+            .await;
+
+        assert_eq!(
+            receiver.recv().await,
+            Some(ProtocolEvent::Registered {
+                peer: "10.0.0.1:7844".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn control_stream_id_is_first_client_bidi() {
+        // QUIC stream ID 0 is client-initiated bidirectional,
+        // matching the cloudflare tunnel protocol expectation.
+        assert_eq!(CONTROL_STREAM_ID % 4, 0);
+    }
+}

--- a/crates/cloudflared-cli/src/proxy.rs
+++ b/crates/cloudflared-cli/src/proxy.rs
@@ -1,5 +1,5 @@
-//! Phase 3.4a–c: Pingora proxy-layer seam with lifecycle participation and
-//! first admitted origin/proxy path.
+//! Phase 3.4a–c + 3.5: Pingora proxy-layer seam with lifecycle participation,
+//! first admitted origin/proxy path, and wire/protocol bridge reception.
 //!
 //! This module is the owned entry point for Pingora in the production-alpha
 //! path. All direct Pingora types and API usage are confined here. The rest
@@ -11,6 +11,8 @@
 //! 3.4a admitted: dependency path and seam location.
 //! 3.4b admitted: runtime lifecycle participation (startup/shutdown).
 //! 3.4c admitted: first origin/proxy path (http_status ingress routing).
+//! 3.5 admitted: receives protocol registration events from the transport
+//!     layer through the explicit wire/protocol bridge.
 
 use cloudflared_config::{IngressRule, IngressService, find_matching_rule};
 use pingora_http::{RequestHeader, ResponseHeader};
@@ -18,6 +20,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
+use crate::protocol::{ProtocolEvent, ProtocolReceiver};
 use crate::runtime::{ChildTask, RuntimeCommand};
 
 pub(crate) const PROXY_SEAM_NAME: &str = "pingora-proxy-seam";
@@ -67,10 +70,12 @@ impl PingoraProxySeam {
     /// Spawn the proxy seam as a runtime-owned lifecycle participant.
     ///
     /// Reports the admitted origin/proxy path and ingress rule count at
-    /// startup, then holds position until shutdown.
+    /// startup. When a protocol bridge is provided, waits for
+    /// registration events from the transport layer before shutdown.
     pub(crate) fn spawn(
         self,
         command_tx: mpsc::Sender<RuntimeCommand>,
+        protocol_rx: Option<ProtocolReceiver>,
         shutdown: CancellationToken,
         child_tasks: &mut JoinSet<ChildTask>,
     ) {
@@ -86,7 +91,35 @@ impl PingoraProxySeam {
                 })
                 .await;
 
-            shutdown.cancelled().await;
+            if let Some(mut rx) = protocol_rx {
+                // Wait for protocol registration from the transport
+                // layer, or shutdown, whichever comes first.
+                // Biased: prefer processing a protocol event that
+                // arrived just before shutdown over missing it.
+                loop {
+                    tokio::select! {
+                        biased;
+                        event = rx.recv() => {
+                            match event {
+                                Some(ProtocolEvent::Registered { peer }) => {
+                                    let _ = command_tx
+                                        .send(RuntimeCommand::ServiceStatus {
+                                            service: PROXY_SEAM_NAME,
+                                            detail: format!(
+                                                "protocol-bridge: session registered, peer={peer}"
+                                            ),
+                                        })
+                                        .await;
+                                }
+                                None => break,
+                            }
+                        }
+                        _ = shutdown.cancelled() => break,
+                    }
+                }
+            } else {
+                shutdown.cancelled().await;
+            }
 
             let _ = command_tx
                 .send(RuntimeCommand::ServiceStatus {
@@ -249,7 +282,7 @@ mod tests {
         let mut child_tasks = JoinSet::new();
 
         let seam = PingoraProxySeam::new(vec![catch_all_rule(503)]);
-        seam.spawn(command_tx, shutdown.clone(), &mut child_tasks);
+        seam.spawn(command_tx, None, shutdown.clone(), &mut child_tasks);
 
         // Seam should report the admitted origin/proxy path on startup.
         let msg = command_rx.recv().await.expect("should receive origin status");
@@ -287,6 +320,105 @@ mod tests {
         {
             ChildTask::ProxySeam => {}
             other => panic!("expected ChildTask::ProxySeam, got: {other:?}"),
+        }
+    }
+
+    // -- Wire/protocol bridge (3.5) --
+
+    #[tokio::test]
+    async fn proxy_seam_receives_protocol_registration() {
+        let (command_tx, mut command_rx) = mpsc::channel(16);
+        let (protocol_sender, protocol_receiver) = crate::protocol::protocol_bridge();
+        let shutdown = CancellationToken::new();
+        let mut child_tasks = JoinSet::new();
+
+        let seam = PingoraProxySeam::new(vec![catch_all_rule(503)]);
+        seam.spawn(
+            command_tx,
+            Some(protocol_receiver),
+            shutdown.clone(),
+            &mut child_tasks,
+        );
+
+        // Startup status.
+        let msg = command_rx.recv().await.expect("should receive startup status");
+        assert!(matches!(msg, RuntimeCommand::ServiceStatus { .. }));
+
+        // Simulate transport sending registration event.
+        protocol_sender
+            .send(ProtocolEvent::Registered {
+                peer: "127.0.0.1:7844".to_owned(),
+            })
+            .await;
+
+        // Proxy should report the protocol bridge registration.
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive protocol bridge status");
+        match msg {
+            RuntimeCommand::ServiceStatus { service, detail } => {
+                assert_eq!(service, PROXY_SEAM_NAME);
+                assert!(
+                    detail.contains("protocol-bridge: session registered"),
+                    "expected protocol bridge registration, got: {detail}"
+                );
+                assert!(
+                    detail.contains("peer=127.0.0.1:7844"),
+                    "expected peer address, got: {detail}"
+                );
+            }
+            other => panic!("expected ServiceStatus for protocol bridge, got: {other:?}"),
+        }
+
+        shutdown.cancel();
+
+        let msg = command_rx.recv().await.expect("should receive shutdown status");
+        match msg {
+            RuntimeCommand::ServiceStatus { service, detail } => {
+                assert_eq!(service, PROXY_SEAM_NAME);
+                assert!(detail.contains("shutdown acknowledged"));
+            }
+            other => panic!("expected ServiceStatus for shutdown, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn proxy_seam_handles_bridge_closure_without_registration() {
+        let (command_tx, mut command_rx) = mpsc::channel(16);
+        let (protocol_sender, protocol_receiver) = crate::protocol::protocol_bridge();
+        let shutdown = CancellationToken::new();
+        let mut child_tasks = JoinSet::new();
+
+        let seam = PingoraProxySeam::new(vec![catch_all_rule(503)]);
+        seam.spawn(
+            command_tx,
+            Some(protocol_receiver),
+            shutdown.clone(),
+            &mut child_tasks,
+        );
+
+        // Startup status.
+        let _ = command_rx.recv().await;
+
+        // Drop sender without sending registration — simulates
+        // transport failure before reaching the protocol boundary.
+        drop(protocol_sender);
+
+        // Proxy should still exit cleanly after bridge closure.
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive shutdown status after bridge closure");
+        match msg {
+            RuntimeCommand::ServiceStatus { service, detail } => {
+                assert_eq!(service, PROXY_SEAM_NAME);
+                assert!(
+                    detail.contains("shutdown acknowledged"),
+                    "expected shutdown ack after bridge closure, got: {detail}"
+                );
+            }
+            other => panic!("expected ServiceStatus for shutdown, got: {other:?}"),
         }
     }
 }

--- a/crates/cloudflared-cli/src/runtime.rs
+++ b/crates/cloudflared-cli/src/runtime.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::protocol::{self, ProtocolReceiver};
 use crate::proxy::PingoraProxySeam;
 use crate::startup::config_source_label;
 use crate::transport::QuicTunnelServiceFactory;
@@ -226,13 +227,19 @@ struct ApplicationRuntime<F> {
     summary_lines: Vec<String>,
     lifecycle_state: LifecycleState,
     restart_attempts: u32,
+    protocol_receiver: Option<ProtocolReceiver>,
 }
 
 impl<F> ApplicationRuntime<F>
 where
     F: RuntimeServiceFactory,
 {
-    fn new(config: RuntimeConfig, factory: F, harness: RuntimeHarness) -> Self {
+    fn new(
+        config: RuntimeConfig,
+        factory: F,
+        harness: RuntimeHarness,
+        protocol_receiver: Option<ProtocolReceiver>,
+    ) -> Self {
         let (command_tx, command_rx) = mpsc::channel(16);
 
         Self {
@@ -247,6 +254,7 @@ where
             summary_lines: Vec::new(),
             lifecycle_state: LifecycleState::Starting,
             restart_attempts: 0,
+            protocol_receiver,
         }
     }
 
@@ -394,12 +402,14 @@ where
     fn spawn_proxy_seam(&mut self) {
         let ingress = self.config.normalized().ingress.clone();
         let seam = PingoraProxySeam::new(ingress);
+        let protocol_rx = self.protocol_receiver.take();
         self.summary_lines.push(format!(
             "proxy-seam: origin-proxy admitted, ingress-rules={}",
             seam.ingress_count()
         ));
         seam.spawn(
             self.command_tx.clone(),
+            protocol_rx,
             self.shutdown.child_token(),
             &mut self.child_tasks,
         );
@@ -539,10 +549,12 @@ where
 }
 
 pub(crate) fn run(config: RuntimeConfig) -> RuntimeExecution {
+    let (protocol_sender, protocol_receiver) = protocol::protocol_bridge();
     run_with_factory(
         config,
-        QuicTunnelServiceFactory::production(),
+        QuicTunnelServiceFactory::production(protocol_sender),
         RuntimeHarness::production(),
+        Some(protocol_receiver),
     )
 }
 
@@ -550,6 +562,7 @@ pub(crate) fn run_with_factory<F>(
     config: RuntimeConfig,
     factory: F,
     harness: RuntimeHarness,
+    protocol_receiver: Option<ProtocolReceiver>,
 ) -> RuntimeExecution
 where
     F: RuntimeServiceFactory,
@@ -559,7 +572,7 @@ where
         .build()
         .expect("tokio runtime should build for the admitted production-alpha shell");
 
-    runtime.block_on(ApplicationRuntime::new(config, factory, harness).run())
+    runtime.block_on(ApplicationRuntime::new(config, factory, harness, protocol_receiver).run())
 }
 
 #[cfg(test)]
@@ -700,6 +713,7 @@ mod tests {
             runtime_config(),
             TestFactory::new([TestBehavior::WaitForShutdown]),
             RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(25)),
+            None,
         );
 
         assert_eq!(execution.exit, RuntimeExit::Clean);
@@ -717,6 +731,7 @@ mod tests {
             runtime_config(),
             TestFactory::new([TestBehavior::WaitForShutdown]),
             RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(25)),
+            None,
         );
 
         assert_eq!(execution.exit, RuntimeExit::Clean);
@@ -733,6 +748,7 @@ mod tests {
             runtime_config(),
             TestFactory::new([TestBehavior::RetryableFailure, TestBehavior::WaitForShutdown]),
             RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(50)),
+            None,
         );
 
         assert_eq!(execution.exit, RuntimeExit::Clean);
@@ -758,6 +774,7 @@ mod tests {
             runtime_config(),
             TestFactory::new([TestBehavior::FatalFailure]),
             RuntimeHarness::for_tests(),
+            None,
         );
 
         assert!(matches!(execution.exit, RuntimeExit::Failed { .. }));
@@ -774,6 +791,7 @@ mod tests {
             runtime_config(),
             TestFactory::new([TestBehavior::WaitForShutdown]),
             RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(25)),
+            None,
         );
 
         assert_eq!(execution.exit, RuntimeExit::Clean);
@@ -791,6 +809,7 @@ mod tests {
             runtime_config(),
             TestFactory::new([TestBehavior::RetryableFailure, TestBehavior::WaitForShutdown]),
             RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(50)),
+            None,
         );
 
         assert_eq!(execution.exit, RuntimeExit::Clean);

--- a/crates/cloudflared-cli/src/transport/quic.rs
+++ b/crates/cloudflared-cli/src/transport/quic.rs
@@ -12,6 +12,7 @@ use tokio::time;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use crate::protocol::{CONTROL_STREAM_ID, ProtocolEvent, ProtocolSender};
 use crate::runtime::{
     ChildTask, RuntimeCommand, RuntimeConfig, RuntimeService, RuntimeServiceFactory, ServiceExit,
 };
@@ -24,23 +25,29 @@ const EDGE_QUIC_ALPN: &[&[u8]] = &[b"argotunnel"];
 const QUIC_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(5);
 const QUIC_IDLE_TIMEOUT_MS: u64 = 30_000;
 const MAX_DATAGRAM_SIZE: usize = 1350;
-const PHASE_35_DEFERRED_DETAIL: &str = "QUIC transport session is established, but tunnel registration and \
-                                        control-stream wire behavior remain deferred";
+const WIRE_PROTOCOL_DEFERRED_DETAIL: &str = "wire/protocol boundary crossed (control stream opened, proxy \
+                                             notified), but registration RPC and incoming stream handling \
+                                             remain deferred";
 
 #[derive(Debug, Clone)]
 pub(crate) struct QuicTunnelServiceFactory {
     test_target: Option<QuicEdgeTarget>,
+    protocol_sender: ProtocolSender,
 }
 
 impl QuicTunnelServiceFactory {
-    pub(crate) fn production() -> Self {
-        Self { test_target: None }
+    pub(crate) fn production(protocol_sender: ProtocolSender) -> Self {
+        Self {
+            test_target: None,
+            protocol_sender,
+        }
     }
 
     #[cfg(test)]
-    fn with_test_target(target: QuicEdgeTarget) -> Self {
+    fn with_test_target(protocol_sender: ProtocolSender, target: QuicEdgeTarget) -> Self {
         Self {
             test_target: Some(target),
+            protocol_sender,
         }
     }
 }
@@ -51,6 +58,7 @@ impl RuntimeServiceFactory for QuicTunnelServiceFactory {
             config,
             attempt,
             test_target: self.test_target.clone(),
+            protocol_sender: self.protocol_sender.clone(),
         })
     }
 }
@@ -59,6 +67,7 @@ struct QuicTunnelService {
     config: Arc<RuntimeConfig>,
     attempt: u32,
     test_target: Option<QuicEdgeTarget>,
+    protocol_sender: ProtocolSender,
 }
 
 impl RuntimeService for QuicTunnelService {
@@ -291,7 +300,48 @@ impl QuicTunnelService {
             .send(RuntimeCommand::ServiceReady { service: self.name() })
             .await;
 
-        let _ = connection.close(true, 0x00, b"deferred wire/protocol boundary");
+        // Phase 3.5: Cross the wire/protocol boundary.
+        // Open the control stream on the established QUIC session.
+        // This proves wire-level protocol behavior exists beyond
+        // transport establishment. Registration RPC content and
+        // incoming request stream handling remain deferred.
+        match connection.stream_send(CONTROL_STREAM_ID, &[], false) {
+            Ok(_) | Err(quiche::Error::Done) => {
+                send_status(
+                    command_tx,
+                    self.name(),
+                    format!("protocol-boundary: control-stream-{CONTROL_STREAM_ID} opened"),
+                )
+                .await;
+            }
+            Err(error) => {
+                return Ok(ServiceExit::RetryableFailure {
+                    service: self.name(),
+                    detail: format!("failed to open control stream at wire/protocol boundary: {error}"),
+                });
+            }
+        }
+
+        flush_egress(&socket, &mut connection, &mut send_buffer)
+            .await
+            .map_err(|error| format!("failed to flush control stream at wire/protocol boundary: {error}"))?;
+
+        // Notify the proxy layer through the explicit protocol bridge.
+        self.protocol_sender
+            .send(ProtocolEvent::Registered {
+                peer: target.connect_addr.to_string(),
+            })
+            .await;
+
+        send_status(
+            command_tx,
+            self.name(),
+            "protocol-boundary: registration event sent to proxy layer".to_owned(),
+        )
+        .await;
+
+        // Graceful close — the wire/protocol boundary has been crossed.
+        let _ = connection.close(true, 0x00, b"protocol boundary crossed");
         let _ = flush_egress(&socket, &mut connection, &mut send_buffer).await;
         send_status(
             command_tx,
@@ -302,10 +352,10 @@ impl QuicTunnelService {
 
         Ok(ServiceExit::Deferred {
             service: self.name(),
-            phase: "Big Phase 3.5",
+            phase: "Big Phase 3.6+",
             detail: format!(
                 "{} for tunnel {} against {}",
-                PHASE_35_DEFERRED_DETAIL, identity.tunnel_id, target.connect_addr
+                WIRE_PROTOCOL_DEFERRED_DETAIL, identity.tunnel_id, target.connect_addr
             ),
         })
     }
@@ -531,6 +581,7 @@ mod tests {
         EDGE_QUIC_ALPN, QuicEdgeTarget, QuicTunnelServiceFactory, build_quiche_config,
         default_ca_bundle_path, edge_host_label,
     };
+    use crate::protocol;
     use crate::runtime::{RuntimeExit, run_with_factory};
     use cloudflared_config::{ConfigSource, DiscoveryAction, DiscoveryOutcome, NormalizedConfig, RawConfig};
     use std::fs;
@@ -756,26 +807,33 @@ mod tests {
     }
 
     #[test]
-    fn runtime_establishes_real_quic_transport_before_wire_boundary() {
+    fn runtime_crosses_wire_protocol_boundary_after_quic_establish() {
         let root = temp_dir("quic-runtime");
         let server_addr = spawn_test_server(&root);
         let runtime_config = runtime_config(&root, server_addr);
+        let (protocol_sender, protocol_receiver) = protocol::protocol_bridge();
         let execution = run_with_factory(
             runtime_config,
-            QuicTunnelServiceFactory::with_test_target(QuicEdgeTarget {
-                connect_addr: server_addr,
-                host_label: "localhost".to_owned(),
-                server_name: "localhost".to_owned(),
-                verify_peer: false,
-                ca_bundle_path: None,
-            }),
+            QuicTunnelServiceFactory::with_test_target(
+                protocol_sender,
+                QuicEdgeTarget {
+                    connect_addr: server_addr,
+                    host_label: "localhost".to_owned(),
+                    server_name: "localhost".to_owned(),
+                    verify_peer: false,
+                    ca_bundle_path: None,
+                },
+            ),
             crate::runtime::RuntimeHarness::for_tests(),
+            Some(protocol_receiver),
         );
 
+        // 3.5: deferral moves from "Big Phase 3.5" to "Big Phase 3.6+"
+        // because the wire/protocol boundary is now crossed.
         assert!(matches!(
             execution.exit,
             RuntimeExit::Deferred {
-                phase: "Big Phase 3.5",
+                phase: "Big Phase 3.6+",
                 ..
             }
         ));
@@ -783,13 +841,29 @@ mod tests {
             execution
                 .summary_lines
                 .iter()
-                .any(|line| line.contains("transport-session-state: established"))
+                .any(|line| line.contains("transport-session-state: established")),
+            "should report QUIC session establishment"
         );
         assert!(
             execution
                 .summary_lines
                 .iter()
-                .any(|line| line.contains("quic-0rtt-policy:"))
+                .any(|line| line.contains("protocol-boundary: control-stream-0 opened")),
+            "should report control stream opened at wire/protocol boundary"
+        );
+        assert!(
+            execution
+                .summary_lines
+                .iter()
+                .any(|line| line.contains("protocol-boundary: registration event sent to proxy layer")),
+            "should report registration event sent through protocol bridge"
+        );
+        assert!(
+            execution
+                .summary_lines
+                .iter()
+                .any(|line| line.contains("quic-0rtt-policy:")),
+            "should report 0-RTT policy"
         );
 
         fs::remove_dir_all(root).expect("temp directory should be removable");

--- a/docs/promotion-gates.md
+++ b/docs/promotion-gates.md
@@ -367,5 +367,5 @@ At the current repo state:
 - Big Phase 3 is current
 - Phase 3.3 QUIC tunnel core is admitted
 - Phase 3.4 Pingora proxy seam (3.4a–c) is admitted
-- Phase 3.4d docs/tests/status reconciliation is active
-- Phases 3.5 through 3.7 are deferred within Big Phase 3
+- Phase 3.5 wire/protocol boundary is admitted
+- Phases 3.6 through 3.7 are deferred within Big Phase 3

--- a/docs/status/active-surface.md
+++ b/docs/status/active-surface.md
@@ -3,12 +3,12 @@
 This file captures the currently admitted executable surface and the immediate
 deferred scope around it.
 
-## Active Phase 3.4 Focus
+## Active Phase 3.5 Focus
 
 Phase 3.3 owns the QUIC tunnel core. Phase 3.4 adds the Pingora proxy seam
-above it.
+above it. Phase 3.5 adds the wire/protocol boundary between them.
 
-What exists now (3.3 + 3.4a–c):
+What exists now (3.3 + 3.4a–c + 3.5):
 
 - `run` enters a real quiche-based transport service under the runtime boundary
 - connection/session ownership and QUIC handshake state are explicit
@@ -20,13 +20,21 @@ What exists now (3.3 + 3.4a–c):
 - the first admitted origin/proxy path routes `http_status` ingress rules
   through the Pingora-owned seam
 - origin services not yet implemented return 502 honestly
-- the transport core still stops honestly after QUIC establishment where
-  later wire/protocol registration does not yet exist
+- the wire/protocol boundary is owned by
+  `crates/cloudflared-cli/src/protocol.rs`
+- after QUIC establishment, the transport opens the control stream
+  (client-initiated bidi stream 0) at the wire/protocol boundary
+- the transport sends a protocol registration event to the proxy layer
+  through an explicit protocol bridge
+- the proxy layer receives and acknowledges the registration event
+- the runtime creates and distributes the protocol bridge endpoints
+  to transport (sender) and proxy (receiver)
 
-What 3.4 does not imply:
+What 3.5 does not imply:
 
+- that registration RPC content (capnp) is implemented
+- that incoming request stream handling exists
 - that the admitted origin path is general proxy completeness
-- that wire/protocol behavior beyond the transport-owned boundary exists
 - that security/compliance operational behavior exists
 - that standard-format crate integration beyond active-slice need exists
 - that packaging, installers, updaters, or deployment tooling already exist
@@ -35,7 +43,6 @@ What 3.4 does not imply:
 
 The following later Big Phase 3 slices remain intentionally deferred:
 
-- 3.5 wire/protocol boundary
 - 3.6 security/compliance operational boundary
 - 3.7 standard-format crate integration boundary
 
@@ -46,19 +53,12 @@ The following remain intentionally out of the current executable-surface task:
 - broader platform parity beyond Linux
 - broader artifact scope beyond GNU `x86-64-v2` and `x86-64-v4`
 - broader Pingora proxy completeness beyond the narrow admitted origin path
-- wire/protocol, security/compliance, and standard-format integration work
+- registration RPC, incoming stream handling, and broader protocol work
   outside their later owning slices
 - packaging, deployment tooling, container support, and
   certification-proving work beyond the current numbered Big Phase 3 slice list
 
 ## Follow-On Constraints For Later Slices
-
-Phase 3.5 (wire/protocol boundary):
-
-- the proxy seam currently has no wire-level integration with the QUIC
-  transport; 3.5 must bridge the transport session to the proxy layer
-- the transport core still stops at QUIC establishment; 3.5 must carry
-  protocol registration through that boundary
 
 Phase 3.6 (security/compliance operational boundary):
 
@@ -76,3 +76,5 @@ Immediate narrowness caveat:
   types return 502 until later slices implement real origin connections
 - `PingoraProxySeam` is not a general Pingora proxy; it is a confined
   entry point for the first admitted path
+- the protocol bridge carries registration events only; incoming request
+  streams and registration RPC content remain deferred


### PR DESCRIPTION
This pull request introduces a new wire/protocol boundary between the QUIC transport and Pingora proxy layers, providing an explicit runtime-managed protocol bridge for event handoff. The proxy seam now receives protocol registration events from the transport layer, and the runtime is updated to manage this bridge. Documentation and help text are also updated to reflect these architectural changes.

**Wire/Protocol Boundary Integration:**

* Added a new `protocol.rs` module defining the wire/protocol boundary, including the `ProtocolEvent` enum, protocol bridge creation, and sender/receiver types for explicit transport-to-proxy event handoff.
* Updated the Pingora proxy seam (`proxy.rs`) to receive protocol registration events via the protocol bridge and report status accordingly; includes new tests for protocol bridge handling. [[1]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588L1-R2) [[2]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R14-R23) [[3]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588L70-R78) [[4]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R94-R122) [[5]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588L252-R285) [[6]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R325-R423)

**Runtime Management:**

* Modified the runtime (`runtime.rs`) to create and manage the protocol bridge, passing the receiver to the proxy seam and updating relevant method signatures and test cases. [[1]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210R5) [[2]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210R230-R242) [[3]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210R257) [[4]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210R405-R412) [[5]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210R552-R565) [[6]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210L562-R575) [[7]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210R716) [[8]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210R734) [[9]](diffhunk://#diff-b7aa32b983debf1c6cf9a75c0793f97866365ea48e0c14fb4ae7604a0f536210R751)

**Documentation and Help Text Updates:**

* Updated `STATUS.md` and CLI help text to describe the new wire/protocol boundary, registration RPC, and deferred features. [[1]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR21-R31) [[2]](diffhunk://#diff-c631fae940404e4e0645ba79d248bfd7c2b87bcbbddaad93fb0b21fe5ae2bbfdL54-R56) [[3]](diffhunk://#diff-c631fae940404e4e0645ba79d248bfd7c2b87bcbbddaad93fb0b21fe5ae2bbfdL65-R71) [[4]](diffhunk://#diff-c631fae940404e4e0645ba79d248bfd7c2b87bcbbddaad93fb0b21fe5ae2bbfdL86-R91)

**File Structure:**

* Registered the new `protocol` module in `main.rs`.

These changes establish a clear architectural boundary and event handoff between transport and proxy, enabling future protocol and registration extensions while improving observability and testability.