### PR TITLE
rust-rewrite: phase 3.5 regression coverage

### DIFF
--- a/crates/cloudflared-cli/tests/cli_surface.rs
+++ b/crates/cloudflared-cli/tests/cli_surface.rs
@@ -39,11 +39,14 @@ fn help_lists_admitted_surface() {
 
     assert!(output.status.success());
     assert!(stdout.contains("Pingora proxy seam"));
+    assert!(stdout.contains("wire/protocol boundary"));
     assert!(stdout.contains("cloudflared [--config FILEPATH] validate"));
     assert!(stdout.contains("cloudflared [--config FILEPATH] run"));
     assert!(stdout.contains("HOME"));
     assert!(stdout.contains("http_status only"));
     assert!(stdout.contains("Broader origin support"));
+    assert!(stdout.contains("registration RPC"));
+    assert!(stdout.contains("incoming stream handling"));
     assert!(!stdout.contains("cloudflared tunnel"));
 }
 


### PR DESCRIPTION
This pull request adds additional assertions to the `help_lists_admitted_surface` test in `crates/cloudflared-cli/tests/cli_surface.rs`. The new assertions verify that specific phrases related to protocol boundaries and registration are present in the CLI help output, improving test coverage for the admitted surface.

Test coverage improvements:

* Added assertions to check for the presence of "wire/protocol boundary", "registration RPC", and "incoming stream handling" in the CLI help output in `help_lists_admitted_surface`.