### PR TITLE
rust-rewrite: phase 3.7 standard format crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
 name = "cloudflared-config"
 version = "2026.2.0-alpha.202603"
 dependencies = [
+ "pem",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -669,6 +670,16 @@ name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ version = "2026.2.0-alpha.202603"
 # monorepo dependencies
 cloudflared-config = { path = "crates/cloudflared-config" }
 # crates.io dependencies
+pem = "3.0.6"
 pingora-http = "0.8"
 mimalloc = { version = "0.1.48", default-features = false, features = [
   "extended",

--- a/STATUS.md
+++ b/STATUS.md
@@ -24,6 +24,9 @@ What exists now:
 - a Phase 3.6 security/compliance operational boundary that reports the bounded
   crypto surface (quiche + BoringSSL lane only) and enforces Linux GNU/glibc
   deployment-contract assumptions at runtime startup
+- a Phase 3.7 standard-format crate integration boundary that admits
+  workspace-managed PEM handling for the active origin-cert runtime path
+  through owned credential adapters in `crates/cloudflared-config/`
 - frozen Go baseline and design-audit references
 - governance and policy docs that freeze the Linux production-alpha lane
 
@@ -31,7 +34,8 @@ What does not exist yet:
 
 - broader Pingora proxy completeness beyond the narrow admitted origin path
 - registration RPC content (capnp) and incoming request stream handling
-- later standard-format integration slices and broader compliance proof work
+- broader standard-format integration beyond the active origin-cert path and
+  broader compliance proof work
 - parity-complete broader subsystem coverage
 - broader platform scope beyond the frozen Linux lane
 

--- a/crates/cloudflared-cli/src/app.rs
+++ b/crates/cloudflared-cli/src/app.rs
@@ -86,8 +86,8 @@ fn render_help() -> String {
     text.push_str("  HOME  Expands the leading ~ in default config search directories.\n\n");
     text.push_str("Deferred beyond current phase:\n");
     text.push_str(
-        "  Broader origin support, registration RPC, incoming stream handling,\n\x20\x20standard-format \
-         crate integration, packaging, and deployment tooling\n",
+        "  Broader origin support, registration RPC, incoming stream handling,\n\x20\x20certificate/key \
+         container handling beyond the active path, packaging, and deployment tooling\n",
     );
     text
 }

--- a/crates/cloudflared-cli/src/transport/quic.rs
+++ b/crates/cloudflared-cli/src/transport/quic.rs
@@ -352,7 +352,7 @@ impl QuicTunnelService {
 
         Ok(ServiceExit::Deferred {
             service: self.name(),
-            phase: "Big Phase 3.7+",
+            phase: "later runtime/protocol slices",
             detail: format!(
                 "{} for tunnel {} against {}",
                 WIRE_PROTOCOL_DEFERRED_DETAIL, identity.tunnel_id, target.connect_addr
@@ -578,7 +578,7 @@ fn origin_cert_path(credentials: &cloudflared_config::CredentialSurface) -> Opti
 #[cfg(test)]
 mod tests {
     use super::{
-        EDGE_QUIC_ALPN, QuicEdgeTarget, QuicTunnelServiceFactory, build_quiche_config,
+        EDGE_QUIC_ALPN, QuicEdgeTarget, QuicTunnelServiceFactory, TransportIdentity, build_quiche_config,
         default_ca_bundle_path, edge_host_label,
     };
     use crate::protocol;
@@ -671,6 +671,47 @@ mod tests {
             action: DiscoveryAction::UseExisting,
             source: ConfigSource::ExplicitPath(root.join("runtime-test.yaml")),
             path: root.join("runtime-test.yaml"),
+            created_paths: Vec::new(),
+            written_config: None,
+        };
+
+        crate::runtime::RuntimeConfig::new(discovery, normalized)
+    }
+
+    fn runtime_config_with_origin_cert(root: &Path) -> crate::runtime::RuntimeConfig {
+        let origin_cert_path = root.join("cert.pem");
+        let origin_cert = cloudflared_config::OriginCertToken {
+            zone_id: "zone".to_owned(),
+            account_id: "account".to_owned(),
+            api_token: "token".to_owned(),
+            endpoint: Some("FED".to_owned()),
+        };
+        fs::write(
+            &origin_cert_path,
+            origin_cert
+                .encode_pem()
+                .expect("origin cert fixture should encode"),
+        )
+        .expect("origin cert fixture should be written");
+
+        let raw = RawConfig::from_yaml_str(
+            "runtime-origin-cert.yaml",
+            &format!(
+                "tunnel: 11111111-1111-1111-1111-111111111111\norigincert: {}\ningress:\n  - service: \
+                 http_status:503\n",
+                origin_cert_path.display()
+            ),
+        )
+        .expect("runtime transport config should parse");
+        let normalized = NormalizedConfig::from_raw(
+            ConfigSource::ExplicitPath(root.join("runtime-origin-cert.yaml")),
+            raw,
+        )
+        .expect("runtime transport config should normalize");
+        let discovery = DiscoveryOutcome {
+            action: DiscoveryAction::UseExisting,
+            source: ConfigSource::ExplicitPath(root.join("runtime-origin-cert.yaml")),
+            path: root.join("runtime-origin-cert.yaml"),
             created_paths: Vec::new(),
             written_config: None,
         };
@@ -807,6 +848,20 @@ mod tests {
     }
 
     #[test]
+    fn transport_identity_reads_origin_cert_through_owned_pem_boundary() {
+        let root = temp_dir("origin-cert-runtime");
+        let runtime_config = runtime_config_with_origin_cert(&root);
+
+        let identity = TransportIdentity::from_runtime_config(&runtime_config)
+            .expect("origin cert should resolve runtime identity");
+
+        assert_eq!(identity.identity_source, "origin-cert");
+        assert_eq!(identity.endpoint_hint.as_deref(), Some("fed"));
+
+        fs::remove_dir_all(root).expect("temp directory should be removable");
+    }
+
+    #[test]
     fn runtime_crosses_wire_protocol_boundary_after_quic_establish() {
         let root = temp_dir("quic-runtime");
         let server_addr = spawn_test_server(&root);
@@ -828,12 +883,12 @@ mod tests {
             Some(protocol_receiver),
         );
 
-        // 3.6: deferral now moves from "Big Phase 3.6" to "Big Phase 3.7+"
-        // because the wire/protocol boundary is now crossed.
+        // The runtime now stops honestly at the post-transport protocol boundary
+        // without tying that deferred work to a stale numbered phase label.
         assert!(matches!(
             execution.exit,
             RuntimeExit::Deferred {
-                phase: "Big Phase 3.7+",
+                phase: "later runtime/protocol slices",
                 ..
             }
         ));

--- a/crates/cloudflared-config/Cargo.toml
+++ b/crates/cloudflared-config/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+pem.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/cloudflared-config/src/credentials.rs
+++ b/crates/cloudflared-config/src/credentials.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use pem::{Pem, encode, parse_many};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -114,8 +115,8 @@ impl OriginCertToken {
         }
 
         let mut token = None;
-        for block in parse_pem_blocks(blocks) {
-            match block.block_type.as_str() {
+        for block in origin_cert_pem::parse_blocks(blocks)? {
+            match block.block_type() {
                 "PRIVATE KEY" | "CERTIFICATE" => {}
                 "ARGO TUNNEL TOKEN" => {
                     if token.as_ref().is_some_and(|current: &OriginCertToken| {
@@ -124,7 +125,7 @@ impl OriginCertToken {
                         return Err(ConfigError::OriginCertMultipleTokens);
                     }
 
-                    if let Ok(decoded) = Self::from_json_bytes(&block.bytes) {
+                    if let Ok(decoded) = Self::from_json_bytes(block.contents()) {
                         token = Some(decoded);
                     }
                 }
@@ -149,14 +150,7 @@ impl OriginCertToken {
         let json = serde_json::to_vec(self)
             .map_err(|source| ConfigError::json_serialize("origin cert token", source))?;
 
-        let mut pem = String::from("-----BEGIN ARGO TUNNEL TOKEN-----\n");
-        let encoded = encode_base64(&json);
-        for chunk in encoded.as_bytes().chunks(64) {
-            pem.push_str(std::str::from_utf8(chunk).expect("base64 output should be utf-8"));
-            pem.push('\n');
-        }
-        pem.push_str("-----END ARGO TUNNEL TOKEN-----\n");
-        Ok(pem.into_bytes())
+        Ok(origin_cert_pem::encode_token(json).into_bytes())
     }
 
     pub fn is_fed_endpoint(&self) -> bool {
@@ -185,115 +179,32 @@ impl OriginCertUser {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct PemBlock {
-    block_type: String,
-    bytes: Vec<u8>,
-}
+mod origin_cert_pem {
+    use super::{ConfigError, Pem, encode, parse_many};
+    use crate::error::Result;
 
-fn parse_pem_blocks(blocks: &[u8]) -> Vec<PemBlock> {
-    let mut parsed = Vec::new();
-    let text = String::from_utf8_lossy(blocks);
-    let mut remaining = text.as_ref();
+    const ARGO_TUNNEL_TOKEN_BLOCK: &str = "ARGO TUNNEL TOKEN";
 
-    while let Some(begin_offset) = remaining.find("-----BEGIN ") {
-        remaining = &remaining[begin_offset + "-----BEGIN ".len()..];
-        let Some(type_end) = remaining.find("-----") else {
-            break;
-        };
+    pub(super) struct OriginCertPemBlock(Pem);
 
-        let block_type = remaining[..type_end].to_owned();
-        remaining = &remaining[type_end + "-----".len()..];
-        remaining = remaining.strip_prefix("\r\n").unwrap_or(remaining);
-        remaining = remaining.strip_prefix('\n').unwrap_or(remaining);
-
-        let end_marker = format!("-----END {block_type}-----");
-        let Some(end_offset) = remaining.find(&end_marker) else {
-            break;
-        };
-
-        let body = &remaining[..end_offset];
-        parsed.push(PemBlock {
-            block_type,
-            bytes: decode_base64(body).unwrap_or_default(),
-        });
-        remaining = &remaining[end_offset + end_marker.len()..];
-    }
-
-    parsed
-}
-
-fn decode_base64(input: &str) -> Option<Vec<u8>> {
-    let filtered: Vec<u8> = input.bytes().filter(|byte| !byte.is_ascii_whitespace()).collect();
-    if filtered.is_empty() {
-        return Some(Vec::new());
-    }
-    if !filtered.len().is_multiple_of(4) {
-        return None;
-    }
-
-    let mut output = Vec::with_capacity(filtered.len() / 4 * 3);
-    for chunk in filtered.chunks(4) {
-        let mut values = [0u8; 4];
-        let mut padding = 0usize;
-
-        for (index, byte) in chunk.iter().copied().enumerate() {
-            if byte == b'=' {
-                values[index] = 0;
-                padding += 1;
-            } else {
-                values[index] = base64_value(byte)?;
-            }
+    impl OriginCertPemBlock {
+        pub(super) fn block_type(&self) -> &str {
+            self.0.tag()
         }
 
-        output.push((values[0] << 2) | (values[1] >> 4));
-        if padding < 2 {
-            output.push((values[1] << 4) | (values[2] >> 2));
-        }
-        if padding == 0 {
-            output.push((values[2] << 6) | values[3]);
+        pub(super) fn contents(&self) -> &[u8] {
+            self.0.contents()
         }
     }
 
-    Some(output)
-}
-
-fn encode_base64(input: &[u8]) -> String {
-    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-    let mut output = String::with_capacity(input.len().div_ceil(3) * 4);
-    for chunk in input.chunks(3) {
-        let first = chunk[0];
-        let second = *chunk.get(1).unwrap_or(&0);
-        let third = *chunk.get(2).unwrap_or(&0);
-
-        output.push(ALPHABET[(first >> 2) as usize] as char);
-        output.push(ALPHABET[(((first & 0x03) << 4) | (second >> 4)) as usize] as char);
-
-        if chunk.len() > 1 {
-            output.push(ALPHABET[(((second & 0x0f) << 2) | (third >> 6)) as usize] as char);
-        } else {
-            output.push('=');
-        }
-
-        if chunk.len() > 2 {
-            output.push(ALPHABET[(third & 0x3f) as usize] as char);
-        } else {
-            output.push('=');
-        }
+    pub(super) fn parse_blocks(blocks: &[u8]) -> Result<Vec<OriginCertPemBlock>> {
+        parse_many(blocks)
+            .map(|blocks| blocks.into_iter().map(OriginCertPemBlock).collect())
+            .map_err(|source| ConfigError::origin_cert_invalid_pem(source.to_string()))
     }
 
-    output
-}
-
-fn base64_value(byte: u8) -> Option<u8> {
-    match byte {
-        b'A'..=b'Z' => Some(byte - b'A'),
-        b'a'..=b'z' => Some(byte - b'a' + 26),
-        b'0'..=b'9' => Some(byte - b'0' + 52),
-        b'+' => Some(62),
-        b'/' => Some(63),
-        _ => None,
+    pub(super) fn encode_token(json: Vec<u8>) -> String {
+        encode(&Pem::new(ARGO_TUNNEL_TOKEN_BLOCK, json))
     }
 }
 
@@ -391,6 +302,18 @@ mod tests {
         let error = OriginCertToken::from_pem_blocks(&pem).expect_err("multiple tokens should fail");
         assert_eq!(error.to_string(), "found multiple tokens in the certificate");
         assert_eq!(error.category(), "origin-cert-multiple-tokens");
+    }
+
+    #[test]
+    fn malformed_origin_cert_pem_is_rejected_explicitly() {
+        let pem = concat!(
+            "-----BEGIN ARGO TUNNEL TOKEN-----\n",
+            "not base64$$$\n",
+            "-----END ARGO TUNNEL TOKEN-----\n"
+        );
+
+        let error = OriginCertToken::from_pem_blocks(pem.as_bytes()).expect_err("malformed pem should fail");
+        assert_eq!(error.category(), "origin-cert-invalid-pem");
     }
 
     #[test]

--- a/crates/cloudflared-config/src/error.rs
+++ b/crates/cloudflared-config/src/error.rs
@@ -70,6 +70,9 @@ pub enum ConfigError {
     #[error("cannot decode empty certificate")]
     OriginCertEmpty,
 
+    #[error("invalid PEM encoding in the certificate")]
+    OriginCertInvalidPem,
+
     #[error("unknown block {block_type} in the certificate")]
     OriginCertUnknownBlock { block_type: String },
 
@@ -181,6 +184,10 @@ impl ConfigError {
         }
     }
 
+    pub fn origin_cert_invalid_pem(_detail: impl Into<String>) -> Self {
+        Self::OriginCertInvalidPem
+    }
+
     pub fn origin_cert_needs_refresh(path: impl Into<PathBuf>) -> Self {
         Self::OriginCertNeedsRefresh { path: path.into() }
     }
@@ -215,6 +222,7 @@ impl ConfigError {
             Self::CreateFile { .. } => "create-file",
             Self::WriteFile { .. } => "write-file",
             Self::OriginCertEmpty => "origin-cert-empty",
+            Self::OriginCertInvalidPem => "origin-cert-invalid-pem",
             Self::OriginCertUnknownBlock { .. } => "origin-cert-unknown-block",
             Self::OriginCertMultipleTokens => "origin-cert-multiple-tokens",
             Self::OriginCertMissingToken => "origin-cert-missing-token",

--- a/docs/promotion-gates.md
+++ b/docs/promotion-gates.md
@@ -368,4 +368,5 @@ At the current repo state:
 - Phase 3.3 QUIC tunnel core is admitted
 - Phase 3.4 Pingora proxy seam (3.4a–c) is admitted
 - Phase 3.5 wire/protocol boundary is admitted
-- Phases 3.6 through 3.7 are deferred within Big Phase 3
+- Phase 3.6 security/compliance operational boundary is admitted
+- Phase 3.7 standard-format crate integration boundary is admitted

--- a/docs/status/active-surface.md
+++ b/docs/status/active-surface.md
@@ -3,14 +3,15 @@
 This file captures the currently admitted executable surface and the immediate
 deferred scope around it.
 
-## Active Phase 3.6 Focus
+## Active Phase 3.7 Focus
 
 Phase 3.3 owns the QUIC tunnel core. Phase 3.4 adds the Pingora proxy seam
 above it. Phase 3.5 adds the wire/protocol boundary between them. Phase 3.6
 adds a narrow security/compliance operational boundary around the admitted
-quiche + BoringSSL lane.
+quiche + BoringSSL lane. Phase 3.7 admits the minimum standard-format crate
+boundary required by the active runtime path.
 
-What exists now (3.3 + 3.4a–c + 3.5 + 3.6):
+What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7):
 
 - `run` enters a real quiche-based transport service under the runtime boundary
 - connection/session ownership and QUIC handshake state are explicit
@@ -36,6 +37,11 @@ What exists now (3.3 + 3.4a–c + 3.5 + 3.6):
 - runtime startup now enforces Linux GNU/glibc deployment-contract assumptions
   for the admitted lane and fails honestly when required host assumptions are
   missing
+- the active origin-cert runtime path now uses a workspace-managed mature PEM
+  crate through owned credential adapters in
+  `crates/cloudflared-config/src/credentials.rs`
+- direct third-party PEM handling remains confined to that owned credential
+  boundary rather than leaking across runtime, transport, proxy, or app code
 
 What the current surface does not imply:
 
@@ -44,14 +50,13 @@ What the current surface does not imply:
 - that the admitted origin path is general proxy completeness
 - that the bounded security/compliance operational boundary constitutes
   certification, whole-program compliance, or validated FIPS implementation
-- that standard-format crate integration beyond active-slice need exists
+- that broader standard-format crate integration beyond active-slice need
+  exists
 - that packaging, installers, updaters, or deployment tooling already exist
 
 ## Deferred Within Big Phase 3
 
-The following later Big Phase 3 slices remain intentionally deferred:
-
-- 3.7 standard-format crate integration boundary
+No later Big Phase 3 slice is admitted here beyond the active 3.7 minimum.
 
 ## Deferred Beyond Big Phase 3
 
@@ -77,8 +82,12 @@ Phase 3.6 (security/compliance operational boundary):
 
 Phase 3.7 (standard-format crate integration boundary):
 
-- no standard-format crate integration beyond the active-slice minimum
-  has been admitted
+- the admitted standard-format boundary is limited to PEM container handling
+  needed by the active origin-cert runtime path
+- the PEM crate enters through owned credential adapters in
+  `crates/cloudflared-config/src/credentials.rs`
+- broader certificate/key container handling, broader format coverage, and
+  later protocol/runtime parsing work remain deferred
 
 Immediate narrowness caveat:
 

--- a/docs/status/rewrite-foundation.md
+++ b/docs/status/rewrite-foundation.md
@@ -21,8 +21,11 @@ compares green. It also now contains a narrow Phase 3.3 QUIC tunnel core in
 establishment, and runtime config handoff. Phase 3.4 adds a Pingora proxy seam
 with runtime lifecycle participation and a first admitted origin/proxy path
 (`http_status` routing) confined to `crates/cloudflared-cli/src/proxy.rs`. The
-admitted origin path is intentionally narrow. Broader wire/protocol behavior
-and general proxy completeness remain later slices. Most broader
+admitted origin path is intentionally narrow. Phase 3.7 now admits a minimal
+standard-format crate boundary for the active origin-cert PEM path through the
+owned credential seam in `crates/cloudflared-config/src/credentials.rs`.
+Broader wire/protocol behavior and general proxy completeness remain later
+slices. Most broader
 production-alpha subsystem behavior is still unported.
 
 The scaffold is intentionally real but minimal:
@@ -86,7 +89,8 @@ The following top-level rewrite decisions are part of the active scaffold:
   - Phase 3.3 QUIC tunnel core is admitted
   - Phase 3.4 Pingora proxy seam (3.4a–c) is admitted
   - Phase 3.5 wire/protocol boundary is admitted
-  - active task: 3.6 security/compliance operational boundary
+  - Phase 3.6 security/compliance operational boundary is admitted
+  - Phase 3.7 standard-format crate integration boundary is admitted
 - Big Phase 4 is later:
   - harden, validate, measure, and prove the alpha in real use
 - Big Phase 5 is later:


### PR DESCRIPTION
This pull request introduces a Phase 3.7 standard-format crate integration boundary, focusing on workspace-managed PEM handling for the active origin-cert runtime path. The main changes replace custom PEM parsing and encoding with the mature `pem` crate, confining direct third-party PEM handling to owned credential adapters in `crates/cloudflared-config`. Documentation is updated to reflect this boundary admission and clarify deferred scope. Additionally, error handling for PEM parsing is improved, and new tests ensure robust origin-cert credential handling.

Integration of standard-format PEM handling:

* Replaced custom PEM parsing and encoding logic in `crates/cloudflared-config/src/credentials.rs` with workspace-managed usage of the `pem` crate, encapsulated in the new `origin_cert_pem` module.
* Updated `Cargo.toml` files to add `pem` as a dependency for both the workspace and `cloudflared-config` crate. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R22) [[2]](diffhunk://#diff-2c72f6e38062c51ef2356972b0719828e5e08bbe5ded3a853eea8c79e678c27eR10)
* Modified origin-cert credential adapters to use the new PEM parsing and encoding methods, improving maintainability and correctness. [[1]](diffhunk://#diff-cd3f98a72e2e2ad5b891b9dbeb744d0d62ee7720e0ef8b738a809002559551bcL117-R119) [[2]](diffhunk://#diff-cd3f98a72e2e2ad5b891b9dbeb744d0d62ee7720e0ef8b738a809002559551bcL127-R128) [[3]](diffhunk://#diff-cd3f98a72e2e2ad5b891b9dbeb744d0d62ee7720e0ef8b738a809002559551bcL152-R153)

Error handling and testing improvements:

* Added explicit error handling for invalid PEM encoding in origin-cert credentials, including new error variants and test coverage. [[1]](diffhunk://#diff-07032db707bd99e3aecb048dbfa88b4b69b6e3cc74a321720310cfe6923b1290R73-R75) [[2]](diffhunk://#diff-07032db707bd99e3aecb048dbfa88b4b69b6e3cc74a321720310cfe6923b1290R187-R190) [[3]](diffhunk://#diff-07032db707bd99e3aecb048dbfa88b4b69b6e3cc74a321720310cfe6923b1290R225) [[4]](diffhunk://#diff-cd3f98a72e2e2ad5b891b9dbeb744d0d62ee7720e0ef8b738a809002559551bcR307-R318)
* Introduced a new test in `crates/cloudflared-cli/src/transport/quic.rs` to verify that transport identity correctly reads origin-cert credentials through the owned PEM boundary. [[1]](diffhunk://#diff-e268698b8e303db15de3ac0c9ac7aa2c3c699abdc9f5ed5a9c696b35fc596277R681-R721) [[2]](diffhunk://#diff-e268698b8e303db15de3ac0c9ac7aa2c3c699abdc9f5ed5a9c696b35fc596277R850-R863)

Documentation updates for Phase 3.7 boundary:

* Updated `docs/status/active-surface.md`, `docs/promotion-gates.md`, and `STATUS.md` to document the admission of the Phase 3.7 standard-format crate integration boundary, clarify the scope of PEM handling, and describe deferred work. [[1]](diffhunk://#diff-99fd2abe9c38951320279e46a6b232b165b9bb776d36f661d3e52dd7bb5e0eacL6-R14) [[2]](diffhunk://#diff-99fd2abe9c38951320279e46a6b232b165b9bb776d36f661d3e52dd7bb5e0eacR40-R44) [[3]](diffhunk://#diff-99fd2abe9c38951320279e46a6b232b165b9bb776d36f661d3e52dd7bb5e0eacL47-R59) [[4]](diffhunk://#diff-99fd2abe9c38951320279e46a6b232b165b9bb776d36f661d3e52dd7bb5e0eacL80-R90) [[5]](diffhunk://#diff-c9698ed11e65faac9ef3e37a685c3f7d95ae2dc6ff773d84e581382132a58094L371-R372) [[6]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR27-R38) [[7]](diffhunk://#diff-c631fae940404e4e0645ba79d248bfd7c2b87bcbbddaad93fb0b21fe5ae2bbfdL89-R90)

Other minor changes:

* Updated deferral phase labels and test imports in `crates/cloudflared-cli/src/transport/quic.rs` for clarity and accuracy. [[1]](diffhunk://#diff-e268698b8e303db15de3ac0c9ac7aa2c3c699abdc9f5ed5a9c696b35fc596277L355-R355) [[2]](diffhunk://#diff-e268698b8e303db15de3ac0c9ac7aa2c3c699abdc9f5ed5a9c696b35fc596277L581-R581) [[3]](diffhunk://#diff-e268698b8e303db15de3ac0c9ac7aa2c3c699abdc9f5ed5a9c696b35fc596277L831-R891)