### PR TITLE
rust-rewrite: phase 4.1 observability & operability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,8 @@ dependencies = [
  "quiche",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -569,6 +571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +947,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1136,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ tokio = { version = "1.50.0", features = [
   "time",
 ] }
 tokio-util = { version = "0.7.16", features = ["rt"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", default-features = false, features = ["fmt"] }
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.22.0", default-features = false, features = ["serde", "std", "v4", "v7"] }
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -27,6 +27,10 @@ What exists now:
 - a Phase 3.7 standard-format crate integration boundary that admits
   workspace-managed PEM handling for the active origin-cert runtime path
   through owned credential adapters in `crates/cloudflared-config/`
+- a Phase 4.1 observability and operability surface in
+  `crates/cloudflared-cli/` that emits live runtime reporting, owner-scoped
+  transport/protocol/proxy state, narrow readiness truth, and minimal
+  operability counters for the admitted alpha path
 - frozen Go baseline and design-audit references
 - governance and policy docs that freeze the Linux production-alpha lane
 
@@ -36,6 +40,7 @@ What does not exist yet:
 - registration RPC content (capnp) and incoming request stream handling
 - broader standard-format integration beyond the active origin-cert path and
   broader compliance proof work
+- broad admin APIs, performance proof, failure-mode proof, and deployment proof
 - parity-complete broader subsystem coverage
 - broader platform scope beyond the frozen Linux lane
 

--- a/crates/cloudflared-cli/Cargo.toml
+++ b/crates/cloudflared-cli/Cargo.toml
@@ -16,6 +16,8 @@ pingora-http.workspace = true
 quiche.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [[bin]]

--- a/crates/cloudflared-cli/src/app.rs
+++ b/crates/cloudflared-cli/src/app.rs
@@ -36,6 +36,7 @@ fn execute_startup_command(cli: Cli, mode: CliMode) -> CliOutput {
 }
 
 fn execute_runtime_command(startup: StartupSurface) -> CliOutput {
+    runtime::install_runtime_logging();
     let report = runtime::run(runtime::RuntimeConfig::new(
         startup.discovery.clone(),
         startup.normalized.clone(),
@@ -52,7 +53,8 @@ fn render_help() -> String {
     let mut text = String::new();
     text.push_str(&format!("{PROGRAM_NAME} {}\n", env!("CARGO_PKG_VERSION")));
     text.push_str(
-        "Linux production-alpha QUIC tunnel core with wire/protocol boundary and Pingora proxy seam\n\n",
+        "Linux production-alpha QUIC tunnel core with wire/protocol boundary, Pingora proxy seam, and \
+         narrow operability reporting\n\n",
     );
     text.push_str("Usage:\n");
     text.push_str("  cloudflared [--config FILEPATH] validate\n");
@@ -66,9 +68,11 @@ fn render_help() -> String {
     text.push_str(
         "  run       Enter the runtime-owned QUIC transport core with wire/protocol \
          boundary\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20and Pingora proxy \
-         seam.\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20The admitted origin path is http_status \
-         only. Broader origin support\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20and general proxy \
-         completeness remain later slices.\n",
+         seam.\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20Emits narrow lifecycle, readiness, and \
+         failure visibility for the\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20admitted alpha role. \
+         The admitted origin path is http_status \
+         only.\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20Broader origin support and general proxy \
+         completeness remain later\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20slices.\n",
     );
     text.push_str("  version   Print the workspace version.\n");
     text.push_str("  help      Print this help text.\n\n");
@@ -84,6 +88,12 @@ fn render_help() -> String {
     );
     text.push_str("Admitted environment:\n");
     text.push_str("  HOME  Expands the leading ~ in default config search directories.\n\n");
+    text.push_str("Admitted operability surface:\n");
+    text.push_str(
+        "  run output  Reports runtime lifecycle, owner-scoped transport/protocol/proxy \
+         state,\n\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20narrow readiness, and localized failure \
+         visibility for the admitted path.\n\n",
+    );
     text.push_str("Deferred beyond current phase:\n");
     text.push_str(
         "  Broader origin support, registration RPC, incoming stream handling,\n\x20\x20certificate/key \

--- a/crates/cloudflared-cli/src/protocol.rs
+++ b/crates/cloudflared-cli/src/protocol.rs
@@ -1,4 +1,4 @@
-//! Phase 3.5: Wire/protocol boundary between transport and proxy.
+//! Phase 3.5 + 4.1: Wire/protocol boundary between transport and proxy.
 //!
 //! Owns the protocol-level boundary that bridges the QUIC transport
 //! session to the Pingora proxy layer. Transport owns QUIC establishment.
@@ -18,11 +18,33 @@ use tokio::sync::mpsc;
 /// bidirectional stream for tunnel registration.
 pub(crate) const CONTROL_STREAM_ID: u64 = 0;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProtocolBridgeState {
+    BridgeUnavailable,
+    BridgeCreated,
+    RegistrationSent,
+    RegistrationObserved,
+    BridgeClosed,
+}
+
+impl ProtocolBridgeState {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::BridgeUnavailable => "bridge-unavailable",
+            Self::BridgeCreated => "bridge-created",
+            Self::RegistrationSent => "registration-sent",
+            Self::RegistrationObserved => "registration-observed",
+            Self::BridgeClosed => "bridge-closed",
+        }
+    }
+}
+
 /// Events that cross the wire/protocol boundary from transport to proxy.
 ///
 /// This is the explicit handoff surface. Transport sends these events
 /// after crossing protocol boundaries. The proxy layer receives them
-/// to coordinate its readiness.
+/// for its owned lifecycle reporting, while the runtime derives the
+/// top-level readiness view from owner-scoped state updates.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ProtocolEvent {
     /// The transport has opened the control stream and reached the
@@ -52,10 +74,15 @@ pub(crate) struct ProtocolSender(mpsc::Sender<ProtocolEvent>);
 
 impl ProtocolSender {
     /// Send a protocol event across the wire/protocol boundary.
-    pub(crate) async fn send(&self, event: ProtocolEvent) {
-        // Best-effort: if the receiver has been dropped, the event
-        // is silently lost. The runtime owns shutdown ordering.
-        let _ = self.0.send(event).await;
+    ///
+    /// Returns an error when the proxy-owned receiver is no longer
+    /// available so the transport can report that failure boundary
+    /// explicitly instead of losing the signal silently.
+    pub(crate) async fn send(&self, event: ProtocolEvent) -> Result<(), String> {
+        self.0
+            .send(event)
+            .await
+            .map_err(|_| String::from("proxy-side protocol bridge receiver is no longer available"))
     }
 }
 
@@ -84,7 +111,8 @@ mod tests {
             .send(ProtocolEvent::Registered {
                 peer: "127.0.0.1:7844".to_owned(),
             })
-            .await;
+            .await
+            .expect("bridge sender should deliver event while receiver is alive");
 
         assert_eq!(
             receiver.recv().await,
@@ -112,7 +140,8 @@ mod tests {
             .send(ProtocolEvent::Registered {
                 peer: "10.0.0.1:7844".to_owned(),
             })
-            .await;
+            .await
+            .expect("bridge sender clone should deliver event while receiver is alive");
 
         assert_eq!(
             receiver.recv().await,

--- a/crates/cloudflared-cli/src/proxy.rs
+++ b/crates/cloudflared-cli/src/proxy.rs
@@ -1,5 +1,6 @@
-//! Phase 3.4a–c + 3.5: Pingora proxy-layer seam with lifecycle participation,
-//! first admitted origin/proxy path, and wire/protocol bridge reception.
+//! Phase 3.4a–c + 3.5 + 4.1: Pingora proxy-layer seam with lifecycle
+//! participation, first admitted origin/proxy path, wire/protocol bridge
+//! reception, and owner-scoped operability reporting.
 //!
 //! This module is the owned entry point for Pingora in the production-alpha
 //! path. All direct Pingora types and API usage are confined here. The rest
@@ -13,6 +14,9 @@
 //! 3.4c admitted: first origin/proxy path (http_status ingress routing).
 //! 3.5 admitted: receives protocol registration events from the transport
 //!     layer through the explicit wire/protocol bridge.
+//! 4.1 admitted: reports proxy admission, observed registration, bridge
+//!     closure, and shutdown acknowledgement through the runtime-owned
+//!     operability surface.
 
 use cloudflared_config::{IngressRule, IngressService, find_matching_rule};
 use pingora_http::{RequestHeader, ResponseHeader};
@@ -20,10 +24,27 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
-use crate::protocol::{ProtocolEvent, ProtocolReceiver};
+use crate::protocol::{ProtocolBridgeState, ProtocolEvent, ProtocolReceiver};
 use crate::runtime::{ChildTask, RuntimeCommand};
 
 pub(crate) const PROXY_SEAM_NAME: &str = "pingora-proxy-seam";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProxySeamState {
+    Admitted,
+    RegistrationObserved,
+    ShutdownAcknowledged,
+}
+
+impl ProxySeamState {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Admitted => "admitted",
+            Self::RegistrationObserved => "registration-observed",
+            Self::ShutdownAcknowledged => "shutdown-acknowledged",
+        }
+    }
+}
 
 /// Owned boundary for the Pingora proxy layer.
 ///
@@ -71,7 +92,8 @@ impl PingoraProxySeam {
     ///
     /// Reports the admitted origin/proxy path and ingress rule count at
     /// startup. When a protocol bridge is provided, waits for
-    /// registration events from the transport layer before shutdown.
+    /// registration events from the transport layer and reports owned
+    /// proxy/protocol visibility before shutdown.
     pub(crate) fn spawn(
         self,
         command_tx: mpsc::Sender<RuntimeCommand>,
@@ -83,6 +105,12 @@ impl PingoraProxySeam {
 
         child_tasks.spawn(async move {
             let _ = command_tx
+                .send(RuntimeCommand::ProxyState {
+                    state: ProxySeamState::Admitted,
+                    detail: format!("ingress-rules={ingress_count}"),
+                })
+                .await;
+            let _ = command_tx
                 .send(RuntimeCommand::ServiceStatus {
                     service: PROXY_SEAM_NAME,
                     detail: format!(
@@ -92,6 +120,8 @@ impl PingoraProxySeam {
                 .await;
 
             if let Some(mut rx) = protocol_rx {
+                let mut registration_observed = false;
+
                 // Wait for protocol registration from the transport
                 // layer, or shutdown, whichever comes first.
                 // Biased: prefer processing a protocol event that
@@ -102,6 +132,19 @@ impl PingoraProxySeam {
                         event = rx.recv() => {
                             match event {
                                 Some(ProtocolEvent::Registered { peer }) => {
+                                    registration_observed = true;
+                                    let _ = command_tx
+                                        .send(RuntimeCommand::ProtocolState {
+                                            state: ProtocolBridgeState::RegistrationObserved,
+                                            detail: format!("proxy observed transport registration from {peer}"),
+                                        })
+                                        .await;
+                                    let _ = command_tx
+                                        .send(RuntimeCommand::ProxyState {
+                                            state: ProxySeamState::RegistrationObserved,
+                                            detail: format!("peer={peer}"),
+                                        })
+                                        .await;
                                     let _ = command_tx
                                         .send(RuntimeCommand::ServiceStatus {
                                             service: PROXY_SEAM_NAME,
@@ -111,7 +154,26 @@ impl PingoraProxySeam {
                                         })
                                         .await;
                                 }
-                                None => break,
+                                None => {
+                                    let detail = if registration_observed {
+                                        String::from("proxy bridge closed after transport registration")
+                                    } else {
+                                        String::from("proxy bridge closed before transport registration")
+                                    };
+                                    let _ = command_tx
+                                        .send(RuntimeCommand::ProtocolState {
+                                            state: ProtocolBridgeState::BridgeClosed,
+                                            detail: detail.clone(),
+                                        })
+                                        .await;
+                                    let _ = command_tx
+                                        .send(RuntimeCommand::ServiceStatus {
+                                            service: PROXY_SEAM_NAME,
+                                            detail: format!("protocol-bridge: {detail}"),
+                                        })
+                                        .await;
+                                    break;
+                                }
                             }
                         }
                         _ = shutdown.cancelled() => break,
@@ -121,6 +183,12 @@ impl PingoraProxySeam {
                 shutdown.cancelled().await;
             }
 
+            let _ = command_tx
+                .send(RuntimeCommand::ProxyState {
+                    state: ProxySeamState::ShutdownAcknowledged,
+                    detail: String::from("proxy seam acknowledged runtime shutdown"),
+                })
+                .await;
             let _ = command_tx
                 .send(RuntimeCommand::ServiceStatus {
                     service: PROXY_SEAM_NAME,
@@ -284,6 +352,15 @@ mod tests {
         let seam = PingoraProxySeam::new(vec![catch_all_rule(503)]);
         seam.spawn(command_tx, None, shutdown.clone(), &mut child_tasks);
 
+        let msg = command_rx.recv().await.expect("should receive proxy state");
+        match msg {
+            RuntimeCommand::ProxyState { state, detail } => {
+                assert_eq!(state, ProxySeamState::Admitted);
+                assert!(detail.contains("ingress-rules=1"));
+            }
+            other => panic!("expected ProxyState for admission, got: {other:?}"),
+        }
+
         // Seam should report the admitted origin/proxy path on startup.
         let msg = command_rx.recv().await.expect("should receive origin status");
         match msg {
@@ -302,6 +379,18 @@ mod tests {
         }
 
         shutdown.cancel();
+
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive shutdown proxy state");
+        match msg {
+            RuntimeCommand::ProxyState { state, detail } => {
+                assert_eq!(state, ProxySeamState::ShutdownAcknowledged);
+                assert!(detail.contains("shutdown"));
+            }
+            other => panic!("expected ProxyState for shutdown, got: {other:?}"),
+        }
 
         let msg = command_rx.recv().await.expect("should receive shutdown status");
         match msg {
@@ -342,6 +431,15 @@ mod tests {
 
         // Startup status.
         let msg = command_rx.recv().await.expect("should receive startup status");
+        assert!(matches!(
+            msg,
+            RuntimeCommand::ProxyState {
+                state: ProxySeamState::Admitted,
+                ..
+            }
+        ));
+
+        let msg = command_rx.recv().await.expect("should receive origin status");
         assert!(matches!(msg, RuntimeCommand::ServiceStatus { .. }));
 
         // Simulate transport sending registration event.
@@ -349,7 +447,32 @@ mod tests {
             .send(ProtocolEvent::Registered {
                 peer: "127.0.0.1:7844".to_owned(),
             })
-            .await;
+            .await
+            .expect("protocol bridge should stay available during registration test");
+
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive protocol state update");
+        match msg {
+            RuntimeCommand::ProtocolState { state, detail } => {
+                assert_eq!(state, ProtocolBridgeState::RegistrationObserved);
+                assert!(detail.contains("127.0.0.1:7844"));
+            }
+            other => panic!("expected ProtocolState for registration, got: {other:?}"),
+        }
+
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive proxy registration state");
+        match msg {
+            RuntimeCommand::ProxyState { state, detail } => {
+                assert_eq!(state, ProxySeamState::RegistrationObserved);
+                assert!(detail.contains("127.0.0.1:7844"));
+            }
+            other => panic!("expected ProxyState for registration, got: {other:?}"),
+        }
 
         // Proxy should report the protocol bridge registration.
         let msg = command_rx
@@ -372,6 +495,18 @@ mod tests {
         }
 
         shutdown.cancel();
+
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive shutdown proxy state");
+        assert!(matches!(
+            msg,
+            RuntimeCommand::ProxyState {
+                state: ProxySeamState::ShutdownAcknowledged,
+                ..
+            }
+        ));
 
         let msg = command_rx.recv().await.expect("should receive shutdown status");
         match msg {
@@ -400,12 +535,50 @@ mod tests {
 
         // Startup status.
         let _ = command_rx.recv().await;
+        let _ = command_rx.recv().await;
 
         // Drop sender without sending registration — simulates
         // transport failure before reaching the protocol boundary.
         drop(protocol_sender);
 
-        // Proxy should still exit cleanly after bridge closure.
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive bridge-closed state");
+        match msg {
+            RuntimeCommand::ProtocolState { state, detail } => {
+                assert_eq!(state, ProtocolBridgeState::BridgeClosed);
+                assert!(detail.contains("before transport registration"));
+            }
+            other => panic!("expected ProtocolState for bridge closure, got: {other:?}"),
+        }
+
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive bridge-closure status after closure");
+        match msg {
+            RuntimeCommand::ServiceStatus { service, detail } => {
+                assert_eq!(service, PROXY_SEAM_NAME);
+                assert!(detail.contains("proxy bridge closed before transport registration"));
+            }
+            other => panic!("expected ServiceStatus for bridge closure, got: {other:?}"),
+        }
+
+        shutdown.cancel();
+
+        let msg = command_rx
+            .recv()
+            .await
+            .expect("should receive shutdown proxy state after bridge closure");
+        assert!(matches!(
+            msg,
+            RuntimeCommand::ProxyState {
+                state: ProxySeamState::ShutdownAcknowledged,
+                ..
+            }
+        ));
+
         let msg = command_rx
             .recv()
             .await

--- a/crates/cloudflared-cli/src/runtime.rs
+++ b/crates/cloudflared-cli/src/runtime.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{env, fs};
 
-use crate::protocol::{self, ProtocolReceiver};
-use crate::proxy::PingoraProxySeam;
+use crate::protocol::{self, ProtocolBridgeState, ProtocolReceiver};
+use crate::proxy::{PingoraProxySeam, ProxySeamState};
 use crate::startup::config_source_label;
-use crate::transport::QuicTunnelServiceFactory;
+use crate::transport::{QuicTunnelServiceFactory, TransportLifecycleStage};
 
 use cloudflared_config::{ConfigSource, DiscoveryOutcome, NormalizedConfig};
 use tokio::runtime::Builder;
@@ -14,6 +14,8 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+use tracing_subscriber::fmt;
 
 #[cfg(target_family = "unix")]
 use tokio::signal::unix::{SignalKind, signal};
@@ -21,11 +23,14 @@ use tokio::signal::unix::{SignalKind, signal};
 const PRIMARY_SERVICE_NAME: &str = "quic-tunnel-core";
 const FROZEN_TARGET_TRIPLE: &str = "x86_64-unknown-linux-gnu";
 const TRANSPORT_CRYPTO_LANE: &str = "quiche+boringssl";
+const READINESS_SCOPE: &str = "narrow-alpha-control-plane-only";
 const GLIBC_RUNTIME_MARKERS: &[&str] = &[
     "/lib64/ld-linux-x86-64.so.2",
     "/lib/x86_64-linux-gnu/libc.so.6",
     "/usr/lib64/libc.so.6",
 ];
+
+static RUNTIME_LOGGING: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeConfig {
@@ -104,6 +109,18 @@ impl RuntimeExit {
     }
 }
 
+pub(crate) fn install_runtime_logging() {
+    RUNTIME_LOGGING.get_or_init(|| {
+        let subscriber = fmt()
+            .with_writer(std::io::stderr)
+            .without_time()
+            .with_target(false)
+            .compact()
+            .finish();
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LifecycleState {
     Starting,
@@ -125,13 +142,58 @@ impl LifecycleState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReadinessState {
+    Starting,
+    WaitingForProxyAdmission,
+    WaitingForTransport,
+    WaitingForProtocolBridge,
+    Ready,
+    Stopping,
+    Failed,
+}
+
+impl ReadinessState {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::WaitingForProxyAdmission => "waiting-for-proxy-admission",
+            Self::WaitingForTransport => "waiting-for-transport",
+            Self::WaitingForProtocolBridge => "waiting-for-protocol-bridge",
+            Self::Ready => "ready",
+            Self::Stopping => "stopping",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum RuntimeCommand {
-    ServiceReady { service: &'static str },
-    ServiceStatus { service: &'static str, detail: String },
+    ServiceReady {
+        service: &'static str,
+    },
+    ServiceStatus {
+        service: &'static str,
+        detail: String,
+    },
+    TransportStage {
+        service: &'static str,
+        stage: TransportLifecycleStage,
+        detail: String,
+    },
+    ProtocolState {
+        state: ProtocolBridgeState,
+        detail: String,
+    },
+    ProxyState {
+        state: ProxySeamState,
+        detail: String,
+    },
     ServiceExited(ServiceExit),
     ShutdownRequested(ShutdownReason),
-    ControlPlaneFailure { detail: String },
+    ControlPlaneFailure {
+        detail: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,8 +297,16 @@ struct ApplicationRuntime<F> {
     shutdown: CancellationToken,
     summary_lines: Vec<String>,
     lifecycle_state: LifecycleState,
+    readiness_state: ReadinessState,
     restart_attempts: u32,
     protocol_receiver: Option<ProtocolReceiver>,
+    transport_stage: Option<TransportLifecycleStage>,
+    protocol_state: ProtocolBridgeState,
+    proxy_state: Option<ProxySeamState>,
+    proxy_admissions: u32,
+    protocol_registrations: u32,
+    transport_failures: u32,
+    failure_events: u32,
 }
 
 impl<F> ApplicationRuntime<F>
@@ -262,8 +332,20 @@ where
             shutdown: CancellationToken::new(),
             summary_lines: Vec::new(),
             lifecycle_state: LifecycleState::Starting,
+            readiness_state: ReadinessState::Starting,
             restart_attempts: 0,
+            transport_stage: None,
+            protocol_state: if protocol_receiver.is_some() {
+                ProtocolBridgeState::BridgeCreated
+            } else {
+                ProtocolBridgeState::BridgeUnavailable
+            },
             protocol_receiver,
+            proxy_state: None,
+            proxy_admissions: 0,
+            protocol_registrations: 0,
+            transport_failures: 0,
+            failure_events: 0,
         }
     }
 
@@ -290,18 +372,30 @@ where
             self.policy.restart_backoff.as_millis(),
             self.policy.shutdown_grace_period.as_millis()
         ));
+        self.summary_lines
+            .push(format!("readiness-scope: {READINESS_SCOPE}"));
 
         if let Err(detail) = self.record_security_compliance_boundary() {
             return self.finish(RuntimeExit::Failed { detail }).await;
         }
 
         self.record_state(LifecycleState::Starting, "startup sequencing entered");
+        self.record_readiness(ReadinessState::Starting, "runtime startup sequencing entered");
+        self.record_protocol_state(
+            self.protocol_state,
+            if matches!(self.protocol_state, ProtocolBridgeState::BridgeCreated) {
+                "runtime created protocol bridge endpoints"
+            } else {
+                "protocol bridge omitted by runtime harness"
+            },
+        );
 
         self.spawn_signal_bridge();
         self.spawn_harness_shutdown();
-        // 3.4b+c: proxy seam enters lifecycle before the primary transport
-        // service, receives ingress rules from the runtime, and provides the
-        // first admitted origin/proxy path (http_status routing).
+        // 3.4b+c + 4.1: proxy seam enters lifecycle before the primary
+        // transport service, receives ingress rules from the runtime,
+        // provides the first admitted origin/proxy path, and reports
+        // owner-scoped proxy/protocol operability state back to runtime.
         self.spawn_proxy_seam();
         self.spawn_primary_service(0);
 
@@ -394,27 +488,63 @@ where
                 if self.lifecycle_state == LifecycleState::Starting {
                     self.record_state(LifecycleState::Running, format!("service ready: {service}"));
                 }
+                self.refresh_readiness(format!("{service} reported ready"));
                 None
             }
             RuntimeCommand::ServiceStatus { service, detail } => {
                 self.summary_lines
                     .push(format!("service-status[{service}]: {detail}"));
+                info!("service-status service={service} detail={detail}");
+                None
+            }
+            RuntimeCommand::TransportStage {
+                service,
+                stage,
+                detail,
+            } => {
+                self.transport_stage = Some(stage);
+                self.summary_lines
+                    .push(format!("transport-stage[{service}]: {}", stage.as_str()));
+                self.summary_lines
+                    .push(format!("transport-detail[{service}]: {detail}"));
+                info!(
+                    "transport-stage service={service} stage={} detail={detail}",
+                    stage.as_str()
+                );
+                self.refresh_readiness(format!("transport reached {}", stage.as_str()));
+                None
+            }
+            RuntimeCommand::ProtocolState { state, detail } => {
+                self.record_protocol_state(state, detail);
+                self.refresh_readiness(format!("protocol bridge reached {}", state.as_str()));
+                None
+            }
+            RuntimeCommand::ProxyState { state, detail } => {
+                self.record_proxy_state(state, detail);
+                self.refresh_readiness(format!("proxy seam reached {}", state.as_str()));
                 None
             }
             RuntimeCommand::ServiceExited(ServiceExit::Completed { service }) => Some(RuntimeExit::Failed {
                 detail: format!("{service} exited without a runtime shutdown request"),
             }),
             RuntimeCommand::ServiceExited(ServiceExit::RetryableFailure { service, detail }) => {
+                self.record_failure_boundary(service, "retryable", &detail);
+                self.transport_failures += 1;
                 if self.restart_attempts < self.policy.max_restart_attempts {
                     self.restart_attempts += 1;
                     self.summary_lines.push(format!(
                         "supervision-restart-attempt: {} service={} detail={detail}",
                         self.restart_attempts, service
                     ));
+                    warn!(
+                        "runtime-restart service={service} attempt={} detail={detail}",
+                        self.restart_attempts
+                    );
                     self.record_state(
                         LifecycleState::Starting,
                         format!("restarting {service} after retryable failure"),
                     );
+                    self.refresh_readiness(format!("runtime restarting {service} after retryable failure"));
                     time::sleep(self.policy.restart_backoff).await;
                     self.spawn_primary_service(self.restart_attempts);
                     None
@@ -433,9 +563,13 @@ where
                 detail,
             }) => Some(RuntimeExit::Deferred {
                 phase,
-                detail: format!("{service}: {detail}"),
+                detail: {
+                    self.record_failure_boundary(service, "deferred", &detail);
+                    format!("{service}: {detail}")
+                },
             }),
             RuntimeCommand::ServiceExited(ServiceExit::Fatal { service, detail }) => {
+                self.record_failure_boundary(service, "fatal", &detail);
                 Some(RuntimeExit::Failed {
                     detail: format!("{service}: {detail}"),
                 })
@@ -443,9 +577,13 @@ where
             RuntimeCommand::ShutdownRequested(reason) => {
                 self.summary_lines
                     .push(format!("shutdown-reason: {}", reason.as_str()));
+                info!("runtime-shutdown-request reason={}", reason.as_str());
                 Some(RuntimeExit::Clean)
             }
-            RuntimeCommand::ControlPlaneFailure { detail } => Some(RuntimeExit::Failed { detail }),
+            RuntimeCommand::ControlPlaneFailure { detail } => {
+                self.record_failure_boundary("runtime-control-plane", "fatal", &detail);
+                Some(RuntimeExit::Failed { detail })
+            }
         }
     }
 
@@ -456,6 +594,7 @@ where
             RuntimeExit::Failed { detail } => format!("runtime failure: {detail}"),
         };
         self.record_state(LifecycleState::Stopping, stopping_reason);
+        self.record_readiness(ReadinessState::Stopping, "runtime shutdown sequencing entered");
 
         if matches!(exit, RuntimeExit::Deferred { .. }) {
             self.summary_lines.push(format!(
@@ -468,17 +607,155 @@ where
         self.drain_child_tasks().await;
 
         match exit {
-            RuntimeExit::Clean => self.record_state(LifecycleState::Stopped, "runtime stopped cleanly"),
-            RuntimeExit::Deferred { .. } | RuntimeExit::Failed { .. } => self.record_state(
-                LifecycleState::Failed,
-                "runtime stopped with a deferred or failed service boundary",
-            ),
+            RuntimeExit::Clean => {
+                self.record_state(LifecycleState::Stopped, "runtime stopped cleanly");
+                self.record_readiness(ReadinessState::Stopping, "runtime stopped after clean shutdown");
+            }
+            RuntimeExit::Deferred { .. } | RuntimeExit::Failed { .. } => {
+                self.record_state(
+                    LifecycleState::Failed,
+                    "runtime stopped with a deferred or failed service boundary",
+                );
+                self.record_readiness(
+                    ReadinessState::Failed,
+                    "runtime stopped after deferred or failed service boundary",
+                );
+            }
         }
+
+        self.record_operability_summary();
 
         RuntimeExecution {
             summary_lines: self.summary_lines,
             exit,
         }
+    }
+
+    fn record_proxy_state(&mut self, state: ProxySeamState, detail: String) {
+        self.proxy_state = Some(state);
+        if state == ProxySeamState::Admitted {
+            self.proxy_admissions += 1;
+        }
+
+        self.summary_lines
+            .push(format!("proxy-state: {}", state.as_str()));
+        self.summary_lines.push(format!("proxy-detail: {detail}"));
+        info!("proxy-state state={} detail={detail}", state.as_str());
+    }
+
+    fn record_protocol_state(&mut self, state: ProtocolBridgeState, detail: impl Into<String>) {
+        self.protocol_state = state;
+        if state == ProtocolBridgeState::RegistrationObserved {
+            self.protocol_registrations += 1;
+        }
+
+        let detail = detail.into();
+        self.summary_lines
+            .push(format!("protocol-state: {}", state.as_str()));
+        self.summary_lines.push(format!("protocol-detail: {detail}"));
+        info!("protocol-state state={} detail={detail}", state.as_str());
+    }
+
+    fn record_failure_boundary(&mut self, owner: &'static str, class: &'static str, detail: &str) {
+        self.failure_events += 1;
+        self.summary_lines.push(format!(
+            "failure-visibility: owner={owner} class={class} detail={detail}"
+        ));
+        error!("failure-boundary owner={owner} class={class} detail={detail}");
+    }
+
+    fn refresh_readiness(&mut self, reason: impl Into<String>) {
+        let next = if self.lifecycle_state == LifecycleState::Failed {
+            ReadinessState::Failed
+        } else if matches!(
+            self.lifecycle_state,
+            LifecycleState::Stopping | LifecycleState::Stopped
+        ) {
+            ReadinessState::Stopping
+        } else if !matches!(
+            self.proxy_state,
+            Some(
+                ProxySeamState::Admitted
+                    | ProxySeamState::RegistrationObserved
+                    | ProxySeamState::ShutdownAcknowledged
+            )
+        ) {
+            ReadinessState::WaitingForProxyAdmission
+        } else if !matches!(
+            self.transport_stage,
+            Some(
+                TransportLifecycleStage::Established
+                    | TransportLifecycleStage::ControlStreamOpened
+                    | TransportLifecycleStage::Teardown
+            )
+        ) {
+            ReadinessState::WaitingForTransport
+        } else if self.protocol_state != ProtocolBridgeState::RegistrationObserved {
+            ReadinessState::WaitingForProtocolBridge
+        } else {
+            ReadinessState::Ready
+        };
+
+        if next != self.readiness_state {
+            self.record_readiness(next, reason);
+        }
+    }
+
+    fn record_readiness(&mut self, state: ReadinessState, reason: impl Into<String>) {
+        let reason = reason.into();
+        self.readiness_state = state;
+        self.summary_lines
+            .push(format!("readiness-state: {}", state.as_str()));
+        self.summary_lines.push(format!("readiness-reason: {reason}"));
+        info!(
+            "readiness-transition state={} scope={READINESS_SCOPE} reason={reason}",
+            state.as_str()
+        );
+    }
+
+    fn record_operability_summary(&mut self) {
+        let transport_stage = self
+            .transport_stage
+            .map(|stage| stage.as_str())
+            .unwrap_or("not-reported");
+        let proxy_state = self
+            .proxy_state
+            .map(|state| state.as_str())
+            .unwrap_or("not-reported");
+
+        self.summary_lines.push(format!(
+            "operability-status: lifecycle={} readiness={} transport-stage={} protocol-state={} \
+             proxy-state={}",
+            self.lifecycle_state.as_str(),
+            self.readiness_state.as_str(),
+            transport_stage,
+            self.protocol_state.as_str(),
+            proxy_state
+        ));
+        self.summary_lines.push(format!(
+            "operability-metrics: restart-attempts={} proxy-admissions={} protocol-registrations={} \
+             transport-failures={} failure-events={}",
+            self.restart_attempts,
+            self.proxy_admissions,
+            self.protocol_registrations,
+            self.transport_failures,
+            self.failure_events
+        ));
+        info!(
+            "operability-summary lifecycle={} readiness={} transport-stage={} protocol-state={} \
+             proxy-state={} restart-attempts={} proxy-admissions={} protocol-registrations={} \
+             transport-failures={} failure-events={}",
+            self.lifecycle_state.as_str(),
+            self.readiness_state.as_str(),
+            transport_stage,
+            self.protocol_state.as_str(),
+            proxy_state,
+            self.restart_attempts,
+            self.proxy_admissions,
+            self.protocol_registrations,
+            self.transport_failures,
+            self.failure_events
+        );
     }
 
     fn spawn_proxy_seam(&mut self) {
@@ -623,10 +900,11 @@ where
 
     fn record_state(&mut self, state: LifecycleState, reason: impl Into<String>) {
         self.lifecycle_state = state;
+        let reason = reason.into();
         self.summary_lines
             .push(format!("lifecycle-state: {}", state.as_str()));
-        self.summary_lines
-            .push(format!("lifecycle-reason: {}", reason.into()));
+        self.summary_lines.push(format!("lifecycle-reason: {reason}"));
+        info!("lifecycle-transition state={} reason={reason}", state.as_str());
     }
 }
 
@@ -815,6 +1093,7 @@ mod tests {
             &execution,
             "runtime-config-path: /tmp/runtime-test.yml"
         ));
+        assert!(summary_contains(&execution, "protocol-state: bridge-unavailable"));
     }
 
     #[test]
@@ -832,6 +1111,7 @@ mod tests {
         assert!(summary_contains(&execution, "shutdown-reason: harness"));
         assert!(summary_contains(&execution, "lifecycle-state: stopping"));
         assert!(summary_contains(&execution, "lifecycle-state: stopped"));
+        assert!(summary_contains(&execution, "readiness-state: stopping"));
     }
 
     #[test]
@@ -849,6 +1129,10 @@ mod tests {
             &execution,
             "restarting test-service after retryable failure"
         ));
+        assert!(summary_contains(
+            &execution,
+            "operability-metrics: restart-attempts=1"
+        ));
     }
 
     #[test]
@@ -858,6 +1142,10 @@ mod tests {
         assert!(matches!(execution.exit, RuntimeExit::Failed { .. }));
         assert!(summary_contains(&execution, "primary-service=quic-tunnel-core"));
         assert!(summary_contains(&execution, "lifecycle-state: failed"));
+        assert!(summary_contains(
+            &execution,
+            "operability-status: lifecycle=failed readiness=failed"
+        ));
     }
 
     #[test]
@@ -881,6 +1169,10 @@ mod tests {
         assert!(summary_contains(
             &execution,
             "security-host-contract: linux-x86_64-gnu-glibc markers present"
+        ));
+        assert!(summary_contains(
+            &execution,
+            "readiness-scope: narrow-alpha-control-plane-only"
         ));
     }
 
@@ -906,6 +1198,10 @@ mod tests {
             &execution,
             "runtime failure: test-service: fatal lifecycle boundary triggered"
         ));
+        assert!(summary_contains(
+            &execution,
+            "failure-visibility: owner=test-service class=fatal"
+        ));
         assert!(!summary_contains(&execution, "supervision-restart-attempt:"));
     }
 
@@ -924,6 +1220,7 @@ mod tests {
             &execution,
             "service-status[pingora-proxy-seam]: origin-proxy-admitted"
         ));
+        assert!(summary_contains(&execution, "proxy-state: admitted"));
         assert!(summary_contains(&execution, "child-task-stopped: proxy-seam"));
     }
 
@@ -941,5 +1238,18 @@ mod tests {
         assert!(summary_contains(&execution, "proxy-seam: origin-proxy admitted"));
         assert!(summary_contains(&execution, "supervision-restart-attempt: 1"));
         assert!(summary_contains(&execution, "child-task-stopped: proxy-seam"));
+    }
+
+    #[test]
+    fn runtime_reports_operability_snapshot_when_transport_inputs_are_missing() {
+        let execution = super::run(runtime_config());
+
+        assert!(matches!(execution.exit, RuntimeExit::Failed { .. }));
+        assert!(summary_contains(&execution, "protocol-state: bridge-created"));
+        assert!(summary_contains(&execution, "proxy-state: admitted"));
+        assert!(summary_contains(
+            &execution,
+            "operability-metrics: restart-attempts=0 proxy-admissions=1"
+        ));
     }
 }

--- a/crates/cloudflared-cli/src/startup.rs
+++ b/crates/cloudflared-cli/src/startup.rs
@@ -56,6 +56,7 @@ fn render_startup_lines(startup: &StartupSurface) -> Vec<String> {
         ),
         format!("config-path: {}", startup.discovery.path.display()),
         format!("ingress-rules: {}", startup.normalized.ingress.len()),
+        String::from("startup-readiness: admitted-for-runtime-handoff"),
     ];
 
     if startup.discovery.action == DiscoveryAction::CreateDefaultConfig {

--- a/crates/cloudflared-cli/src/transport/mod.rs
+++ b/crates/cloudflared-cli/src/transport/mod.rs
@@ -1,3 +1,28 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransportLifecycleStage {
+    IdentityLoaded,
+    ResolvingEdge,
+    Dialing,
+    Handshaking,
+    Established,
+    ControlStreamOpened,
+    Teardown,
+}
+
+impl TransportLifecycleStage {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::IdentityLoaded => "identity-loaded",
+            Self::ResolvingEdge => "resolving-edge",
+            Self::Dialing => "dialing",
+            Self::Handshaking => "handshaking",
+            Self::Established => "established",
+            Self::ControlStreamOpened => "control-stream-opened",
+            Self::Teardown => "teardown",
+        }
+    }
+}
+
 mod quic;
 
 pub(crate) use quic::QuicTunnelServiceFactory;

--- a/crates/cloudflared-cli/src/transport/quic.rs
+++ b/crates/cloudflared-cli/src/transport/quic.rs
@@ -12,6 +12,8 @@ use tokio::time;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use super::TransportLifecycleStage;
+use crate::protocol::ProtocolBridgeState;
 use crate::protocol::{CONTROL_STREAM_ID, ProtocolEvent, ProtocolSender};
 use crate::runtime::{
     ChildTask, RuntimeCommand, RuntimeConfig, RuntimeService, RuntimeServiceFactory, ServiceExit,
@@ -103,6 +105,14 @@ impl QuicTunnelService {
             }
         };
 
+        send_transport_stage(
+            &command_tx,
+            service_name,
+            TransportLifecycleStage::IdentityLoaded,
+            format!("identity-source={}", identity.identity_source),
+        )
+        .await;
+
         send_status(
             &command_tx,
             service_name,
@@ -133,6 +143,16 @@ impl QuicTunnelService {
             "quic-pqc-compatibility: preserved through quiche + boringssl lane".to_owned(),
         )
         .await;
+        send_transport_stage(
+            &command_tx,
+            service_name,
+            TransportLifecycleStage::ResolvingEdge,
+            format!(
+                "endpoint-hint={}",
+                identity.endpoint_hint.as_deref().unwrap_or(EDGE_DEFAULT_REGION)
+            ),
+        )
+        .await;
 
         let target = match self.test_target.as_ref() {
             Some(target) => target.clone(),
@@ -156,6 +176,13 @@ impl QuicTunnelService {
                 target.connect_addr,
                 identity.endpoint_hint.as_deref().unwrap_or(EDGE_DEFAULT_REGION)
             ),
+        )
+        .await;
+        send_transport_stage(
+            &command_tx,
+            service_name,
+            TransportLifecycleStage::Dialing,
+            format!("edge={}", target.connect_addr),
         )
         .await;
         send_status(
@@ -233,6 +260,13 @@ impl QuicTunnelService {
             format!("transport-session-state: handshaking local={local_addr}"),
         )
         .await;
+        send_transport_stage(
+            command_tx,
+            self.name(),
+            TransportLifecycleStage::Handshaking,
+            format!("local={local_addr} remote={}", target.connect_addr),
+        )
+        .await;
 
         loop {
             if connection.is_established() {
@@ -296,11 +330,23 @@ impl QuicTunnelService {
             ),
         )
         .await;
+        send_transport_stage(
+            command_tx,
+            self.name(),
+            TransportLifecycleStage::Established,
+            format!(
+                "peer={} resumed-shape={}",
+                target.connect_addr,
+                identity.resumption.shape_label()
+            ),
+        )
+        .await;
         let _ = command_tx
             .send(RuntimeCommand::ServiceReady { service: self.name() })
             .await;
 
-        // Phase 3.5: Cross the wire/protocol boundary.
+        // Phase 3.5 + 4.1: Cross the wire/protocol boundary and report
+        // the transport-owned stage transition explicitly.
         // Open the control stream on the established QUIC session.
         // This proves wire-level protocol behavior exists beyond
         // transport establishment. Registration RPC content and
@@ -311,6 +357,13 @@ impl QuicTunnelService {
                     command_tx,
                     self.name(),
                     format!("protocol-boundary: control-stream-{CONTROL_STREAM_ID} opened"),
+                )
+                .await;
+                send_transport_stage(
+                    command_tx,
+                    self.name(),
+                    TransportLifecycleStage::ControlStreamOpened,
+                    format!("stream-id={CONTROL_STREAM_ID}"),
                 )
                 .await;
             }
@@ -327,9 +380,24 @@ impl QuicTunnelService {
             .map_err(|error| format!("failed to flush control stream at wire/protocol boundary: {error}"))?;
 
         // Notify the proxy layer through the explicit protocol bridge.
+        // The runtime consumes the resulting owner-scoped updates to
+        // derive its narrow readiness and failure-visibility surface.
         self.protocol_sender
             .send(ProtocolEvent::Registered {
                 peer: target.connect_addr.to_string(),
+            })
+            .await
+            .map_err(|detail| {
+                format!("failed to report transport registration across protocol bridge: {detail}")
+            })?;
+
+        let _ = command_tx
+            .send(RuntimeCommand::ProtocolState {
+                state: ProtocolBridgeState::RegistrationSent,
+                detail: format!(
+                    "transport sent registration event for peer {}",
+                    target.connect_addr
+                ),
             })
             .await;
 
@@ -343,6 +411,13 @@ impl QuicTunnelService {
         // Graceful close — the wire/protocol boundary has been crossed.
         let _ = connection.close(true, 0x00, b"protocol boundary crossed");
         let _ = flush_egress(&socket, &mut connection, &mut send_buffer).await;
+        send_transport_stage(
+            command_tx,
+            self.name(),
+            TransportLifecycleStage::Teardown,
+            format!("peer={}", target.connect_addr),
+        )
+        .await;
         send_status(
             command_tx,
             self.name(),
@@ -563,6 +638,21 @@ async fn flush_egress(
 async fn send_status(command_tx: &mpsc::Sender<RuntimeCommand>, service: &'static str, detail: String) {
     let _ = command_tx
         .send(RuntimeCommand::ServiceStatus { service, detail })
+        .await;
+}
+
+async fn send_transport_stage(
+    command_tx: &mpsc::Sender<RuntimeCommand>,
+    service: &'static str,
+    stage: TransportLifecycleStage,
+    detail: String,
+) {
+    let _ = command_tx
+        .send(RuntimeCommand::TransportStage {
+            service,
+            stage,
+            detail,
+        })
         .await;
 }
 

--- a/crates/cloudflared-cli/tests/cli_surface.rs
+++ b/crates/cloudflared-cli/tests/cli_surface.rs
@@ -40,9 +40,12 @@ fn help_lists_admitted_surface() {
     assert!(output.status.success());
     assert!(stdout.contains("Pingora proxy seam"));
     assert!(stdout.contains("wire/protocol boundary"));
+    assert!(stdout.contains("narrow operability reporting"));
     assert!(stdout.contains("cloudflared [--config FILEPATH] validate"));
     assert!(stdout.contains("cloudflared [--config FILEPATH] run"));
     assert!(stdout.contains("HOME"));
+    assert!(stdout.contains("lifecycle, readiness, and failure visibility"));
+    assert!(stdout.contains("Admitted operability surface"));
     assert!(stdout.contains("http_status only"));
     assert!(stdout.contains("Broader origin support"));
     assert!(stdout.contains("registration RPC"));
@@ -76,6 +79,7 @@ fn validate_reports_admitted_startup_surface() {
     assert!(stdout.contains("config-source: explicit"));
     assert!(stdout.contains(&format!("config-path: {}", config.display())));
     assert!(stdout.contains("ingress-rules: 2"));
+    assert!(stdout.contains("startup-readiness: admitted-for-runtime-handoff"));
     assert!(stdout.contains("warnings: none"));
 
     fs::remove_dir_all(root).expect("temp directory should be removable");
@@ -93,8 +97,10 @@ fn run_exits_nonzero_when_quic_transport_inputs_are_missing() {
     assert_eq!(output.status.code(), Some(1));
     assert!(stdout.contains("Resolved admitted alpha startup surface"));
     assert!(stdout.contains("config-source: explicit"));
+    assert!(stdout.contains("startup-readiness: admitted-for-runtime-handoff"));
     assert!(stdout.contains("runtime-owner: initialized"));
     assert!(stdout.contains("config-ownership: runtime-owned"));
+    assert!(stdout.contains("readiness-scope: narrow-alpha-control-plane-only"));
     assert!(stdout.contains("security-boundary: runtime-crypto-surface=transport-tls-only"));
     assert!(
         stdout
@@ -105,6 +111,12 @@ fn run_exits_nonzero_when_quic_transport_inputs_are_missing() {
         stdout.contains("proxy-seam: origin-proxy admitted"),
         "run output should report the admitted Pingora proxy seam"
     );
+    assert!(stdout.contains("proxy-state: admitted"));
+    assert!(stdout.contains("protocol-state: bridge-created"));
+    assert!(stdout.contains("operability-status: lifecycle=failed readiness=failed"));
+    assert!(stdout.contains("operability-metrics: restart-attempts=0 proxy-admissions=1"));
+    assert!(stderr.contains("readiness-transition state=waiting-for-transport"));
+    assert!(stderr.contains("failure-boundary owner=quic-tunnel-core class=fatal"));
     assert!(stderr.contains("quic tunnel core requires credentials-file or origincert"));
 
     fs::remove_dir_all(root).expect("temp directory should be removable");

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -83,11 +83,13 @@ That means:
 
 The current manifests admit only the dependencies needed by the binary runtime
 baseline, the active first-slice config implementation, the active QUIC tunnel
-core, and the existing workspace tool surface:
+core, the admitted Pingora and observability seams, and the existing workspace
+tool surface:
 
-- `mimalloc`, `tokio`, `tokio-util`, and `quiche` in `cloudflared-cli`
-- shared workspace truth for `serde`, `serde_json`, `serde_yaml`, `thiserror`,
-  `url`, and `uuid`
+- `mimalloc`, `tokio`, `tokio-util`, `quiche`, `pingora-http`, `tracing`, and
+  `tracing-subscriber` in `cloudflared-cli`
+- shared workspace truth for `pem`, `serde`, `serde_json`, `serde_yaml`,
+  `thiserror`, `url`, and `uuid`
 - `rmcp`, `schemars`, and `tokio` in `tools/mcp-cfd-rs`
 
 Reason:
@@ -100,6 +102,14 @@ Reason:
   `cloudflared-cli` may use `quiche` on the locked quiche + BoringSSL lane for
   real transport ownership and handshake/session state under the runtime
   boundary
+- Phase 3.4 has now started, so the admitted Pingora seam in
+  `cloudflared-cli` may use `pingora-http` inside its owned proxy boundary for
+  the first narrow origin path
+- Phase 3.7 has now started, so the active origin-cert path may use the mature
+  `pem` crate through owned credential adapters in `cloudflared-config`
+- Phase 4.1 has now started, so the admitted runtime observability surface in
+  `cloudflared-cli` may use `tracing` and `tracing-subscriber` for live,
+  owner-scoped reporting at the binary boundary
 - config, credential, and ingress normalization work is active in
   `cloudflared-config`, so its admitted slice dependencies now exist honestly in
   manifests

--- a/docs/promotion-gates.md
+++ b/docs/promotion-gates.md
@@ -332,6 +332,29 @@ The minimum runnable alpha exists on the frozen Linux production-alpha lane.
 
 Harden, validate, measure, and prove the alpha in real use.
 
+### Phase 4.1 — Observability And Operability
+
+#### Purpose
+
+Make the admitted alpha operable and inspectable in real use without widening
+scope into performance proof, failure-mode proof, or deployment proof.
+
+#### Required conditions
+
+- runtime-owned lifecycle and readiness truth are visible while `run` executes
+- transport, protocol, and proxy report their own state transitions through
+  explicit owned seams
+- startup, restart, shutdown, and failure boundaries are inspectable without
+  implying broader subsystem completeness
+- minimal counters exist for the current alpha path without turning this phase
+  into a broad telemetry platform
+
+#### Exit condition
+
+Phase 4.1 is complete when the current alpha can be run, inspected, and
+debugged honestly through narrow logs, readiness, and minimal operability
+reporting.
+
 ### Exit condition
 
 The promoted alpha scope is validated well enough to be credible in real use.
@@ -364,9 +387,11 @@ At the current repo state:
 
 - Big Phase 1 is done
 - Big Phase 2 is closed and frozen
-- Big Phase 3 is current
+- Big Phase 3 runnable-alpha admission remains intact
 - Phase 3.3 QUIC tunnel core is admitted
 - Phase 3.4 Pingora proxy seam (3.4a–c) is admitted
 - Phase 3.5 wire/protocol boundary is admitted
 - Phase 3.6 security/compliance operational boundary is admitted
 - Phase 3.7 standard-format crate integration boundary is admitted
+- Phase 4.1 observability and operability is admitted
+- 4.2 performance proof, 4.3 failure-mode proof, and 4.4 deployment proof are later

--- a/docs/status/active-surface.md
+++ b/docs/status/active-surface.md
@@ -3,15 +3,17 @@
 This file captures the currently admitted executable surface and the immediate
 deferred scope around it.
 
-## Active Phase 3.7 Focus
+## Active Phase 3.7 + 4.1 Focus
 
 Phase 3.3 owns the QUIC tunnel core. Phase 3.4 adds the Pingora proxy seam
 above it. Phase 3.5 adds the wire/protocol boundary between them. Phase 3.6
 adds a narrow security/compliance operational boundary around the admitted
 quiche + BoringSSL lane. Phase 3.7 admits the minimum standard-format crate
-boundary required by the active runtime path.
+boundary required by the active runtime path. Phase 4.1 adds the minimum
+observability and operability surface required to run and inspect that alpha
+honestly.
 
-What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7):
+What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7 + 4.1):
 
 - `run` enters a real quiche-based transport service under the runtime boundary
 - connection/session ownership and QUIC handshake state are explicit
@@ -42,6 +44,13 @@ What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7):
   `crates/cloudflared-config/src/credentials.rs`
 - direct third-party PEM handling remains confined to that owned credential
   boundary rather than leaking across runtime, transport, proxy, or app code
+- runtime-owned observability now reports lifecycle transitions, owner-scoped
+  transport/protocol/proxy state, and failure boundaries live while `run`
+  executes
+- the runtime now derives and reports a narrow readiness state for the current
+  alpha role rather than implying broader request-serving readiness
+- the runtime now emits a minimal final operability snapshot with restart,
+  proxy-admission, protocol-registration, and failure counters
 
 What the current surface does not imply:
 
@@ -52,6 +61,8 @@ What the current surface does not imply:
   certification, whole-program compliance, or validated FIPS implementation
 - that broader standard-format crate integration beyond active-slice need
   exists
+- that the narrow readiness signal implies broad admin, deployment, or
+  production-proof surfaces
 - that packaging, installers, updaters, or deployment tooling already exist
 
 ## Deferred Within Big Phase 3
@@ -69,6 +80,8 @@ The following remain intentionally out of the current executable-surface task:
   outside their later owning slices
 - packaging, deployment tooling, container support, and
   certification-proving work beyond the current numbered Big Phase 3 slice list
+- performance proof, failure-mode proof, and broader deployment/management
+  work beyond the admitted 4.1 observability surface
 
 ## Follow-On Constraints For Later Slices
 

--- a/docs/status/rewrite-foundation.md
+++ b/docs/status/rewrite-foundation.md
@@ -84,15 +84,18 @@ The following top-level rewrite decisions are part of the active scaffold:
 - Big Phase 2 is closed and frozen:
   - purpose was to freeze the Linux production-alpha lane
   - tasks 2.0 through 2.6 are complete at the governance level
-- Big Phase 3 is current:
-  - purpose: build the minimum runnable alpha on the frozen lane
+- Big Phase 3 runnable-alpha admission remains the active base:
+  - purpose was to build the minimum runnable alpha on the frozen lane
   - Phase 3.3 QUIC tunnel core is admitted
   - Phase 3.4 Pingora proxy seam (3.4a–c) is admitted
   - Phase 3.5 wire/protocol boundary is admitted
   - Phase 3.6 security/compliance operational boundary is admitted
   - Phase 3.7 standard-format crate integration boundary is admitted
-- Big Phase 4 is later:
-  - harden, validate, measure, and prove the alpha in real use
+- Big Phase 4 has started narrowly:
+  - Phase 4.1 observability and operability is admitted around the existing
+    runnable-alpha surface
+  - 4.2 performance proof, 4.3 failure-mode proof, and 4.4 deployment proof
+    remain later
 - Big Phase 5 is later:
   - widen intentionally only after the alpha is credible
 
@@ -116,13 +119,15 @@ The following top-level rewrite decisions are part of the active scaffold:
 - `baseline-2026.2.0/old-impl/` contains the frozen Go source of truth
 - `baseline-2026.2.0/design-audit/` contains the extracted spec set
 - `docs/` contains rewrite-program decisions and semantic guidance
-- `crates/` contains only minimal Rust crate skeletons
+- `crates/` contains the admitted Rust implementation crates plus the
+  remaining future-slice skeleton crates
 
 Current crate intent:
 
 - `crates/cloudflared-cli`: narrow admitted alpha entry surface for help,
   version, config-backed startup validation, the current runtime/lifecycle
-  owner, the current QUIC transport core, and the Pingora proxy seam
+  owner, the current QUIC transport core, the Pingora proxy seam, and the
+  admitted 4.1 observability/operability reporting surface
 - `crates/cloudflared-config`: owning crate for the accepted first-slice
   domain skeleton and future config, credentials, and ingress normalization
   behavior


### PR DESCRIPTION
This pull request introduces Phase 4.1 observability and operability features to the `cloudflared-cli` crate, expanding runtime reporting and owner-scoped state visibility. The main changes include new runtime state reporting, enhanced protocol and proxy state tracking, improved error handling for protocol events, and updated documentation and help text. These updates make it easier to monitor tunnel lifecycle, readiness, and localized failures during alpha operation.

**Observability and Operability Enhancements:**

* Added `tracing` and `tracing-subscriber` dependencies for runtime logging and observability in `Cargo.toml` and workspace manifests. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R46-R47) [[2]](diffhunk://#diff-133c0813bd826cf45e96ae84ca8436438fde00fc7b2f75a6fa85eeaf8e25cd72R19-R20)
* Introduced runtime logging initialization in `execute_runtime_command`, enabling live reporting.
* Updated `render_help` to describe new operability surface and reporting features in CLI help output. [[1]](diffhunk://#diff-c631fae940404e4e0645ba79d248bfd7c2b87bcbbddaad93fb0b21fe5ae2bbfdL55-R57) [[2]](diffhunk://#diff-c631fae940404e4e0645ba79d248bfd7c2b87bcbbddaad93fb0b21fe5ae2bbfdL69-R75) [[3]](diffhunk://#diff-c631fae940404e4e0645ba79d248bfd7c2b87bcbbddaad93fb0b21fe5ae2bbfdR91-R96)

**Protocol and Proxy State Tracking:**

* Added `ProtocolBridgeState` and `ProxySeamState` enums to track and report protocol bridge and proxy seam lifecycle states, including registration, closure, and shutdown acknowledgement. [[1]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cR21-R47) [[2]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R17-R48)
* Modified `PingoraProxySeam::spawn` to emit detailed state updates via `RuntimeCommand`, reporting admission, registration observation, bridge closure, and shutdown acknowledgement. [[1]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588L74-R96) [[2]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R107-R112) [[3]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R123-R124) [[4]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R135-R147) [[5]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588L114-R176) [[6]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R186-R191)

**Error Handling Improvements:**

* Updated `ProtocolSender::send` to return a `Result`, allowing explicit error reporting when the protocol bridge receiver is unavailable, instead of silently dropping events.

**Documentation and Status Updates:**

* Updated `STATUS.md` to reflect the new Phase 4.1 observability and operability surface, and clarified deferred features and future work. [[1]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR30-R33) [[2]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR43)
* Revised module documentation in `protocol.rs` and `proxy.rs` to include Phase 4.1 features and reporting. [[1]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cL1-R1) [[2]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588L1-R3)

**Test Coverage for New Features:**

* Extended tests in `proxy.rs` and `protocol.rs` to verify new state reporting, error handling, and operability signals, ensuring correct lifecycle and readiness visibility. [[1]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R355-R363) [[2]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R383-R394) [[3]](diffhunk://#diff-3cf340d180e9bbbacb581bf67df6330e9a9f04dd6bc4ee2e0e76830234731588R434-R475) [[4]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cL87-R115) [[5]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cL115-R144)

These improvements collectively provide richer runtime visibility for the admitted alpha path, making it easier to monitor tunnel status, track readiness, and diagnose localized failures.