### PR TITLE
rust-rewrite: phase 4.2

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -31,6 +31,10 @@ What exists now:
   `crates/cloudflared-cli/` that emits live runtime reporting, owner-scoped
   transport/protocol/proxy state, narrow readiness truth, and minimal
   operability counters for the admitted alpha path
+- a Phase 4.2 performance validation surface in `crates/cloudflared-cli/`
+  that emits deterministic stage-transition timing evidence, cold vs resumed
+  path distinction, machine-readable performance evidence, and explicit
+  regression thresholds for the admitted alpha harness path
 - frozen Go baseline and design-audit references
 - governance and policy docs that freeze the Linux production-alpha lane
 
@@ -40,7 +44,8 @@ What does not exist yet:
 - registration RPC content (capnp) and incoming request stream handling
 - broader standard-format integration beyond the active origin-cert path and
   broader compliance proof work
-- broad admin APIs, performance proof, failure-mode proof, and deployment proof
+- broad admin APIs, broader performance proof beyond the admitted harness
+  path, failure-mode proof, and deployment proof
 - parity-complete broader subsystem coverage
 - broader platform scope beyond the frozen Linux lane
 

--- a/crates/cloudflared-cli/src/runtime/command_dispatch/handlers.rs
+++ b/crates/cloudflared-cli/src/runtime/command_dispatch/handlers.rs
@@ -11,6 +11,9 @@ where
     F: RuntimeServiceFactory,
 {
     pub(super) fn handle_service_ready(&mut self, service: &'static str) -> Option<RuntimeExit> {
+        let is_resumed = self.status.restart_attempts() > 0;
+        self.status.record_timing_service_ready(is_resumed);
+
         if self.status.lifecycle_state() == LifecycleState::Starting {
             self.status
                 .record_state(LifecycleState::Running, format!("service ready: {service}"));
@@ -34,6 +37,7 @@ where
         stage: TransportLifecycleStage,
         detail: String,
     ) -> Option<RuntimeExit> {
+        self.status.record_timing_transport_stage(stage);
         self.status.record_transport_stage(service, stage, detail);
         self.status
             .refresh_readiness(format!("transport reached {}", stage.as_str()));
@@ -45,6 +49,9 @@ where
         state: ProtocolBridgeState,
         detail: String,
     ) -> Option<RuntimeExit> {
+        if state == ProtocolBridgeState::RegistrationObserved {
+            self.status.record_timing_protocol_registration();
+        }
         self.status.record_protocol_state(state, detail);
         self.status
             .refresh_readiness(format!("protocol bridge reached {}", state.as_str()));
@@ -56,6 +63,9 @@ where
         state: ProxySeamState,
         detail: String,
     ) -> Option<RuntimeExit> {
+        if state == ProxySeamState::Admitted {
+            self.status.record_timing_proxy_admitted();
+        }
         self.status.record_proxy_state(state, detail);
         self.status
             .refresh_readiness(format!("proxy seam reached {}", state.as_str()));
@@ -88,6 +98,7 @@ where
         }
 
         let attempt = self.status.record_restart_attempt(service, &detail);
+        self.status.record_timing_restart();
         self.status.record_state(
             LifecycleState::Starting,
             format!("restarting {service} after retryable failure"),

--- a/crates/cloudflared-cli/src/runtime/mod.rs
+++ b/crates/cloudflared-cli/src/runtime/mod.rs
@@ -172,6 +172,8 @@ where
         }
 
         self.status.record_operability_summary();
+        self.status.record_timing_finished();
+        self.status.record_performance_evidence();
 
         RuntimeExecution {
             summary_lines: self.status.into_summary_lines(),

--- a/crates/cloudflared-cli/src/runtime/state/mod.rs
+++ b/crates/cloudflared-cli/src/runtime/state/mod.rs
@@ -1,5 +1,6 @@
 mod operability;
 mod readiness;
 mod status;
+mod timing;
 
 pub(super) use self::status::{LifecycleState, ReadinessState, RuntimeStatus};

--- a/crates/cloudflared-cli/src/runtime/state/readiness.rs
+++ b/crates/cloudflared-cli/src/runtime/state/readiness.rs
@@ -15,6 +15,9 @@ impl RuntimeStatus {
             self.protocol_state,
         );
         if next != self.readiness_state {
+            if next == ReadinessState::Ready {
+                self.record_timing_readiness_reached();
+            }
             self.record_readiness(next, reason);
         }
     }

--- a/crates/cloudflared-cli/src/runtime/state/status.rs
+++ b/crates/cloudflared-cli/src/runtime/state/status.rs
@@ -6,6 +6,7 @@ use crate::transport::TransportLifecycleStage;
 use tracing::{error, info, warn};
 
 use super::super::{READINESS_SCOPE, RuntimeConfig, RuntimePolicy, ShutdownReason};
+use super::timing::StageTiming;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::runtime) enum LifecycleState {
@@ -70,6 +71,7 @@ pub(in crate::runtime) struct RuntimeStatus {
     pub(in crate::runtime) transport_failures: u32,
     pub(in crate::runtime) failure_events: u32,
     pub(in crate::runtime) protocol_bridge_present: bool,
+    pub(in crate::runtime) timing: StageTiming,
 }
 
 impl RuntimeStatus {
@@ -87,6 +89,7 @@ impl RuntimeStatus {
             transport_failures: 0,
             failure_events: 0,
             protocol_bridge_present,
+            timing: StageTiming::new(),
         }
     }
 

--- a/crates/cloudflared-cli/src/runtime/state/timing.rs
+++ b/crates/cloudflared-cli/src/runtime/state/timing.rs
@@ -1,0 +1,316 @@
+//! Phase 4.2: Transport-stage timing evidence and regression thresholds.
+//!
+//! Tracks wall-clock elapsed time at each transport lifecycle stage
+//! transition relative to runtime start. Produces machine-readable
+//! performance evidence for the admitted alpha path.
+//!
+//! What this measures:
+//! - stage transition timing within the runtime command dispatch loop
+//! - cold-start (attempt 0) vs resumed (attempt > 0) path distinction
+//! - time from runtime start to each subsystem milestone
+//!
+//! What this does not measure:
+//! - real QUIC wire latency (deferred until real transport is testable)
+//! - 0-RTT session resumption handshake savings (transport is in-process)
+//! - end-to-end request latency (incoming stream handling is deferred)
+
+use std::time::{Duration, Instant};
+
+use super::RuntimeStatus;
+use crate::transport::TransportLifecycleStage;
+
+/// Regression thresholds for the admitted alpha harness path.
+///
+/// These are the maximum acceptable durations for stage transitions
+/// within the in-process test harness. Real transport thresholds will
+/// be defined when the transport layer is testable against a real edge.
+pub(in crate::runtime) struct RegressionThresholds;
+
+impl RegressionThresholds {
+    /// Maximum time from runtime start to proxy admission.
+    pub(in crate::runtime) const PROXY_ADMISSION_MAX: Duration = Duration::from_millis(500);
+    /// Maximum time from runtime start to readiness (full pipeline).
+    pub(in crate::runtime) const READINESS_MAX: Duration = Duration::from_secs(2);
+    /// Maximum restart overhead: time from restart decision to service ready.
+    pub(in crate::runtime) const RESTART_OVERHEAD_MAX: Duration = Duration::from_millis(500);
+    /// Maximum time from runtime start to service ready (cold path).
+    pub(in crate::runtime) const SERVICE_READY_MAX: Duration = Duration::from_millis(500);
+    /// Maximum total runtime duration for a harness-driven lifecycle.
+    pub(in crate::runtime) const TOTAL_RUNTIME_MAX: Duration = Duration::from_secs(5);
+}
+
+/// Stage-transition timing milestones relative to runtime start.
+pub(in crate::runtime) struct StageTiming {
+    runtime_start: Instant,
+    proxy_admitted: Option<Instant>,
+    service_ready: Option<Instant>,
+    transport_identity: Option<Instant>,
+    transport_dialing: Option<Instant>,
+    transport_established: Option<Instant>,
+    control_stream_opened: Option<Instant>,
+    protocol_registration: Option<Instant>,
+    readiness_reached: Option<Instant>,
+    last_restart: Option<Instant>,
+    resumed_service_ready: Option<Instant>,
+    runtime_finished: Option<Instant>,
+}
+
+impl StageTiming {
+    pub(in crate::runtime) fn new() -> Self {
+        Self {
+            runtime_start: Instant::now(),
+            proxy_admitted: None,
+            service_ready: None,
+            transport_identity: None,
+            transport_dialing: None,
+            transport_established: None,
+            control_stream_opened: None,
+            protocol_registration: None,
+            readiness_reached: None,
+            last_restart: None,
+            resumed_service_ready: None,
+            runtime_finished: None,
+        }
+    }
+
+    pub(in crate::runtime) fn record_proxy_admitted(&mut self) {
+        self.proxy_admitted.get_or_insert_with(Instant::now);
+    }
+
+    pub(in crate::runtime) fn record_service_ready(&mut self, is_resumed: bool) {
+        let now = Instant::now();
+        self.service_ready.get_or_insert(now);
+
+        if is_resumed {
+            self.resumed_service_ready = Some(now);
+        }
+    }
+
+    pub(in crate::runtime) fn record_transport_stage(&mut self, stage: TransportLifecycleStage) {
+        let now = Instant::now();
+        match stage {
+            TransportLifecycleStage::IdentityLoaded => {
+                self.transport_identity.get_or_insert(now);
+            }
+            TransportLifecycleStage::Dialing => {
+                self.transport_dialing.get_or_insert(now);
+            }
+            TransportLifecycleStage::Established => {
+                self.transport_established.get_or_insert(now);
+            }
+            TransportLifecycleStage::ControlStreamOpened => {
+                self.control_stream_opened.get_or_insert(now);
+            }
+            TransportLifecycleStage::ResolvingEdge
+            | TransportLifecycleStage::Handshaking
+            | TransportLifecycleStage::Teardown => {}
+        }
+    }
+
+    pub(in crate::runtime) fn record_protocol_registration(&mut self) {
+        self.protocol_registration.get_or_insert_with(Instant::now);
+    }
+
+    pub(in crate::runtime) fn record_readiness_reached(&mut self) {
+        self.readiness_reached.get_or_insert_with(Instant::now);
+    }
+
+    pub(in crate::runtime) fn record_restart(&mut self) {
+        self.last_restart = Some(Instant::now());
+    }
+
+    pub(in crate::runtime) fn record_finished(&mut self) {
+        self.runtime_finished = Some(Instant::now());
+    }
+
+    fn elapsed_ms(&self, milestone: Option<Instant>) -> Option<u64> {
+        milestone.map(|t| t.duration_since(self.runtime_start).as_millis() as u64)
+    }
+
+    fn restart_to_ready_ms(&self) -> Option<u64> {
+        match (self.last_restart, self.resumed_service_ready) {
+            (Some(restart), Some(ready)) if ready >= restart => {
+                Some(ready.duration_since(restart).as_millis() as u64)
+            }
+            _ => None,
+        }
+    }
+
+    fn total_runtime_ms(&self) -> Option<u64> {
+        self.runtime_finished
+            .map(|t| t.duration_since(self.runtime_start).as_millis() as u64)
+    }
+
+    /// Build the machine-readable performance evidence lines.
+    ///
+    /// Each line is a key=value pair suitable for structured log parsing,
+    /// CI gate evaluation, and regression threshold validation.
+    pub(in crate::runtime) fn evidence_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        let path_label = if self.last_restart.is_some() {
+            "resumed"
+        } else {
+            "cold"
+        };
+
+        lines.push(format!("perf-evidence-path: {path_label}"));
+
+        if let Some(ms) = self.elapsed_ms(self.proxy_admitted) {
+            lines.push(format!("perf-stage-ms[proxy-admitted]: {ms}"));
+        }
+
+        if let Some(ms) = self.elapsed_ms(self.service_ready) {
+            lines.push(format!("perf-stage-ms[service-ready]: {ms}"));
+        }
+
+        if let Some(ms) = self.elapsed_ms(self.transport_identity) {
+            lines.push(format!("perf-stage-ms[transport-identity]: {ms}"));
+        }
+
+        if let Some(ms) = self.elapsed_ms(self.transport_dialing) {
+            lines.push(format!("perf-stage-ms[transport-dialing]: {ms}"));
+        }
+
+        if let Some(ms) = self.elapsed_ms(self.transport_established) {
+            lines.push(format!("perf-stage-ms[transport-established]: {ms}"));
+        }
+
+        if let Some(ms) = self.elapsed_ms(self.control_stream_opened) {
+            lines.push(format!("perf-stage-ms[control-stream-opened]: {ms}"));
+        }
+
+        if let Some(ms) = self.elapsed_ms(self.protocol_registration) {
+            lines.push(format!("perf-stage-ms[protocol-registration]: {ms}"));
+        }
+
+        if let Some(ms) = self.elapsed_ms(self.readiness_reached) {
+            lines.push(format!("perf-stage-ms[readiness-reached]: {ms}"));
+        }
+
+        if let Some(ms) = self.restart_to_ready_ms() {
+            lines.push(format!("perf-restart-overhead-ms: {ms}"));
+        }
+
+        if let Some(ms) = self.total_runtime_ms() {
+            lines.push(format!("perf-total-runtime-ms: {ms}"));
+        }
+
+        lines
+    }
+
+    /// Validate timing against regression thresholds.
+    ///
+    /// Returns a list of threshold violations found. An empty list means
+    /// the timing meets all regression thresholds.
+    pub(in crate::runtime) fn threshold_violations(&self) -> Vec<String> {
+        let mut violations = Vec::new();
+
+        if let Some(proxy_admitted) = self.proxy_admitted {
+            let elapsed = proxy_admitted.duration_since(self.runtime_start);
+            if elapsed > RegressionThresholds::PROXY_ADMISSION_MAX {
+                violations.push(format!(
+                    "proxy-admission exceeded {}ms threshold: {}ms",
+                    RegressionThresholds::PROXY_ADMISSION_MAX.as_millis(),
+                    elapsed.as_millis()
+                ));
+            }
+        }
+
+        if let Some(service_ready) = self.service_ready {
+            let elapsed = service_ready.duration_since(self.runtime_start);
+            if elapsed > RegressionThresholds::SERVICE_READY_MAX {
+                violations.push(format!(
+                    "service-ready exceeded {}ms threshold: {}ms",
+                    RegressionThresholds::SERVICE_READY_MAX.as_millis(),
+                    elapsed.as_millis()
+                ));
+            }
+        }
+
+        if let Some(readiness_reached) = self.readiness_reached {
+            let elapsed = readiness_reached.duration_since(self.runtime_start);
+            if elapsed > RegressionThresholds::READINESS_MAX {
+                violations.push(format!(
+                    "readiness exceeded {}ms threshold: {}ms",
+                    RegressionThresholds::READINESS_MAX.as_millis(),
+                    elapsed.as_millis()
+                ));
+            }
+        }
+
+        if let (Some(restart), Some(ready)) = (self.last_restart, self.resumed_service_ready)
+            && ready >= restart
+        {
+            let elapsed = ready.duration_since(restart);
+            if elapsed > RegressionThresholds::RESTART_OVERHEAD_MAX {
+                violations.push(format!(
+                    "restart-overhead exceeded {}ms threshold: {}ms",
+                    RegressionThresholds::RESTART_OVERHEAD_MAX.as_millis(),
+                    elapsed.as_millis()
+                ));
+            }
+        }
+
+        if let Some(finished) = self.runtime_finished {
+            let elapsed = finished.duration_since(self.runtime_start);
+            if elapsed > RegressionThresholds::TOTAL_RUNTIME_MAX {
+                violations.push(format!(
+                    "total-runtime exceeded {}ms threshold: {}ms",
+                    RegressionThresholds::TOTAL_RUNTIME_MAX.as_millis(),
+                    elapsed.as_millis()
+                ));
+            }
+        }
+
+        violations
+    }
+}
+
+impl RuntimeStatus {
+    pub(in crate::runtime) fn record_timing_proxy_admitted(&mut self) {
+        self.timing.record_proxy_admitted();
+    }
+
+    pub(in crate::runtime) fn record_timing_service_ready(&mut self, is_resumed: bool) {
+        self.timing.record_service_ready(is_resumed);
+    }
+
+    pub(in crate::runtime) fn record_timing_transport_stage(&mut self, stage: TransportLifecycleStage) {
+        self.timing.record_transport_stage(stage);
+    }
+
+    pub(in crate::runtime) fn record_timing_protocol_registration(&mut self) {
+        self.timing.record_protocol_registration();
+    }
+
+    pub(in crate::runtime) fn record_timing_readiness_reached(&mut self) {
+        self.timing.record_readiness_reached();
+    }
+
+    pub(in crate::runtime) fn record_timing_restart(&mut self) {
+        self.timing.record_restart();
+    }
+
+    pub(in crate::runtime) fn record_timing_finished(&mut self) {
+        self.timing.record_finished();
+    }
+
+    /// Emit machine-readable performance evidence and threshold validation.
+    pub(in crate::runtime) fn record_performance_evidence(&mut self) {
+        let evidence_lines = self.timing.evidence_lines();
+        for line in &evidence_lines {
+            self.summary_lines.push(line.clone());
+        }
+
+        let violations = self.timing.threshold_violations();
+        if violations.is_empty() {
+            self.summary_lines.push("perf-threshold-gate: pass".to_owned());
+        } else {
+            self.summary_lines
+                .push(format!("perf-threshold-gate: fail ({})", violations.len()));
+            for v in &violations {
+                self.summary_lines.push(format!("perf-threshold-violation: {v}"));
+            }
+        }
+    }
+}

--- a/crates/cloudflared-cli/src/runtime/tests/mod.rs
+++ b/crates/cloudflared-cli/src/runtime/tests/mod.rs
@@ -3,3 +3,4 @@ mod fixtures;
 mod harness;
 mod lifecycle_primary;
 mod lifecycle_proxy;
+mod performance;

--- a/crates/cloudflared-cli/src/runtime/tests/performance.rs
+++ b/crates/cloudflared-cli/src/runtime/tests/performance.rs
@@ -1,0 +1,167 @@
+//! Phase 4.2: Performance validation tests.
+//!
+//! Validates cold vs resumed path timing evidence, machine-readable
+//! performance output, and regression threshold gates for the admitted
+//! alpha harness path.
+
+use std::time::Duration;
+
+use crate::runtime::{RuntimeExit, RuntimeHarness, run_with_factory};
+
+use super::fixtures::{runtime_config, summary_contains};
+use super::harness::{TestBehavior, TestFactory};
+
+// -- Cold path evidence --
+
+#[test]
+fn cold_path_emits_performance_evidence() {
+    let execution = run_with_factory(
+        runtime_config(),
+        TestFactory::new([TestBehavior::WaitForShutdown]),
+        RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(25)),
+        None,
+    );
+
+    assert_eq!(execution.exit, RuntimeExit::Clean);
+    assert!(summary_contains(&execution, "perf-evidence-path: cold"));
+    assert!(summary_contains(&execution, "perf-stage-ms[service-ready]:"));
+    assert!(summary_contains(&execution, "perf-stage-ms[proxy-admitted]:"));
+    assert!(summary_contains(&execution, "perf-total-runtime-ms:"));
+}
+
+#[test]
+fn cold_path_passes_regression_threshold_gate() {
+    let execution = run_with_factory(
+        runtime_config(),
+        TestFactory::new([TestBehavior::WaitForShutdown]),
+        RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(25)),
+        None,
+    );
+
+    assert_eq!(execution.exit, RuntimeExit::Clean);
+    assert!(
+        summary_contains(&execution, "perf-threshold-gate: pass"),
+        "cold path should pass regression thresholds, summary: {:?}",
+        execution.summary_lines
+    );
+    assert!(
+        !summary_contains(&execution, "perf-threshold-violation:"),
+        "cold path should have no threshold violations"
+    );
+}
+
+// -- Resumed path evidence --
+
+#[test]
+fn resumed_path_emits_performance_evidence_after_restart() {
+    let execution = run_with_factory(
+        runtime_config(),
+        TestFactory::new([TestBehavior::RetryableFailure, TestBehavior::WaitForShutdown]),
+        RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(50)),
+        None,
+    );
+
+    assert_eq!(execution.exit, RuntimeExit::Clean);
+    assert!(summary_contains(&execution, "perf-evidence-path: resumed"));
+    assert!(summary_contains(&execution, "perf-restart-overhead-ms:"));
+    assert!(summary_contains(&execution, "perf-stage-ms[service-ready]:"));
+}
+
+#[test]
+fn resumed_path_passes_regression_threshold_gate() {
+    let execution = run_with_factory(
+        runtime_config(),
+        TestFactory::new([TestBehavior::RetryableFailure, TestBehavior::WaitForShutdown]),
+        RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(50)),
+        None,
+    );
+
+    assert_eq!(execution.exit, RuntimeExit::Clean);
+    assert!(
+        summary_contains(&execution, "perf-threshold-gate: pass"),
+        "resumed path should pass regression thresholds, summary: {:?}",
+        execution.summary_lines
+    );
+}
+
+// -- Failed path still emits evidence --
+
+#[test]
+fn failed_path_emits_performance_evidence() {
+    let execution = run_with_factory(
+        runtime_config(),
+        TestFactory::new([TestBehavior::FatalFailure]),
+        RuntimeHarness::for_tests(),
+        None,
+    );
+
+    assert!(matches!(execution.exit, RuntimeExit::Failed { .. }));
+    assert!(summary_contains(&execution, "perf-evidence-path: cold"));
+    assert!(summary_contains(&execution, "perf-total-runtime-ms:"));
+    assert!(summary_contains(&execution, "perf-threshold-gate:"));
+}
+
+// -- Machine-readable format validation --
+
+#[test]
+fn performance_evidence_lines_have_structured_format() {
+    let execution = run_with_factory(
+        runtime_config(),
+        TestFactory::new([TestBehavior::WaitForShutdown]),
+        RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(25)),
+        None,
+    );
+
+    assert_eq!(execution.exit, RuntimeExit::Clean);
+
+    let perf_lines: Vec<&String> = execution
+        .summary_lines
+        .iter()
+        .filter(|line| line.starts_with("perf-"))
+        .collect();
+
+    assert!(
+        perf_lines.len() >= 4,
+        "expected at least 4 perf evidence lines, found {}: {:?}",
+        perf_lines.len(),
+        perf_lines
+    );
+
+    for line in &perf_lines {
+        assert!(
+            line.contains(':'),
+            "perf evidence line should be key: value format: {line}"
+        );
+    }
+}
+
+// -- Timing values are reasonable --
+
+#[test]
+fn stage_timing_values_are_nonnegative() {
+    let execution = run_with_factory(
+        runtime_config(),
+        TestFactory::new([TestBehavior::WaitForShutdown]),
+        RuntimeHarness::for_tests().with_shutdown_after(Duration::from_millis(25)),
+        None,
+    );
+
+    assert_eq!(execution.exit, RuntimeExit::Clean);
+
+    for line in &execution.summary_lines {
+        if line.starts_with("perf-stage-ms[") || line.starts_with("perf-total-runtime-ms:") {
+            let value_part = line
+                .split(':')
+                .next_back()
+                .expect("should have value after colon");
+            let ms: u64 = value_part
+                .trim()
+                .parse()
+                .unwrap_or_else(|_| panic!("perf timing value should be a non-negative integer: {line}"));
+            assert!(
+                ms < 5000,
+                "perf timing value should be under 5000ms: {line} = {ms}ms"
+            );
+        }
+    }
+}

--- a/docs/promotion-gates.md
+++ b/docs/promotion-gates.md
@@ -355,6 +355,32 @@ Phase 4.1 is complete when the current alpha can be run, inspected, and
 debugged honestly through narrow logs, readiness, and minimal operability
 reporting.
 
+### Phase 4.2 — Performance Validation
+
+#### Purpose
+
+Validate the admitted alpha path with deterministic stage-transition timing
+evidence, cold vs resumed path distinction, and explicit regression thresholds
+without implying full transport or end-to-end performance proof.
+
+#### Required conditions
+
+- transport lifecycle stage transitions are timed relative to runtime start
+- cold-start (attempt 0) vs resumed (attempt > 0) paths are distinguished in
+  evidence output
+- machine-readable performance evidence is emitted at runtime finish
+- explicit regression thresholds exist for the admitted harness path
+- threshold violations are reported as a pass/fail gate in summary output
+- evidence is honest about what is measured (in-process harness timing) vs
+  what remains deferred (real QUIC wire latency, 0-RTT session resumption
+  savings, end-to-end request latency)
+
+#### Exit condition
+
+Phase 4.2 is complete when the admitted alpha path emits deterministic
+performance evidence with regression thresholds that can gate CI and detect
+stage-transition regressions.
+
 ### Exit condition
 
 The promoted alpha scope is validated well enough to be credible in real use.
@@ -394,4 +420,5 @@ At the current repo state:
 - Phase 3.6 security/compliance operational boundary is admitted
 - Phase 3.7 standard-format crate integration boundary is admitted
 - Phase 4.1 observability and operability is admitted
-- 4.2 performance proof, 4.3 failure-mode proof, and 4.4 deployment proof are later
+- Phase 4.2 performance validation is admitted
+- 4.3 failure-mode proof and 4.4 deployment proof are later

--- a/docs/status/active-surface.md
+++ b/docs/status/active-surface.md
@@ -3,17 +3,19 @@
 This file captures the currently admitted executable surface and the immediate
 deferred scope around it.
 
-## Active Phase 4.1 Surface
+## Active Phase 4.2 Surface
 
 Phase 3.3 owns the QUIC tunnel core. Phase 3.4 adds the Pingora proxy seam
 above it. Phase 3.5 adds the wire/protocol boundary between them. Phase 3.6
 adds a narrow security/compliance operational boundary around the admitted
 quiche + BoringSSL lane. Phase 3.7 admits the minimum standard-format crate
-boundary required by the active runtime path. Phase 4.1 is the current
-admitted slice on top of that base and adds the minimum observability and
-operability surface required to run and inspect that alpha honestly.
+boundary required by the active runtime path. Phase 4.1 adds the minimum
+observability and operability surface required to run and inspect that alpha
+honestly. Phase 4.2 is the current admitted slice and adds deterministic
+performance validation with stage-transition timing evidence, cold vs resumed
+path distinction, and explicit regression thresholds.
 
-What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7 + 4.1):
+What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7 + 4.1 + 4.2):
 
 - `run` enters a real quiche-based transport service under the runtime boundary
 - connection/session ownership and QUIC handshake state are explicit
@@ -51,6 +53,15 @@ What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7 + 4.1):
   alpha role rather than implying broader request-serving readiness
 - the runtime now emits a minimal final operability snapshot with restart,
   proxy-admission, protocol-registration, and failure counters
+- transport lifecycle stage transitions are now timed relative to runtime start
+  with wall-clock millisecond-resolution evidence
+- cold-start (attempt 0) vs resumed (attempt > 0) transport paths are
+  distinguished in performance evidence output
+- machine-readable performance evidence lines (`perf-*`) are emitted at
+  runtime finish for structured log parsing and CI gate evaluation
+- explicit regression thresholds gate proxy-admission, service-ready,
+  readiness, restart-overhead, and total-runtime timing
+- threshold violations are reported as a pass/fail gate in summary output
 
 What the current surface does not imply:
 
@@ -63,6 +74,8 @@ What the current surface does not imply:
   exists
 - that the narrow readiness signal implies broad admin, deployment, or
   production-proof surfaces
+- that performance evidence implies real QUIC wire latency measurement,
+  0-RTT session resumption savings, or end-to-end request latency
 - that packaging, installers, updaters, or deployment tooling already exist
 
 ## Deferred Within Big Phase 3
@@ -81,7 +94,7 @@ The following remain intentionally out of the current executable-surface task:
 - packaging, deployment tooling, container support, and
   certification-proving work beyond the current numbered Big Phase 3 slice list
 - performance proof, failure-mode proof, and broader deployment/management
-  work beyond the admitted 4.1 observability surface
+  work beyond the admitted 4.2 performance validation surface
 
 ## Follow-On Constraints For Later Slices
 


### PR DESCRIPTION
This pull request introduces a comprehensive performance validation surface for the admitted alpha path in `crates/cloudflared-cli/`, enabling deterministic stage-transition timing evidence, cold vs resumed path distinction, machine-readable performance evidence, and explicit regression thresholds. The main changes are grouped into performance instrumentation and documentation updates.

Performance instrumentation and evidence:

* Added a new `timing` module (`crates/cloudflared-cli/src/runtime/state/timing.rs`) that tracks wall-clock elapsed time for each transport lifecycle stage, records milestones, and validates against regression thresholds; it also emits machine-readable performance evidence and threshold violations for CI and regression testing.
* Integrated timing instrumentation into the runtime command dispatch handlers, recording timing for service readiness, transport stages, protocol registration, proxy admission, restart, readiness, and runtime finish. [[1]](diffhunk://#diff-e828cfea518adf7f6d265170102783d39d8efd68952c0be4913a9b6aee517208R14-R16) [[2]](diffhunk://#diff-e828cfea518adf7f6d265170102783d39d8efd68952c0be4913a9b6aee517208R40) [[3]](diffhunk://#diff-e828cfea518adf7f6d265170102783d39d8efd68952c0be4913a9b6aee517208R52-R54) [[4]](diffhunk://#diff-e828cfea518adf7f6d265170102783d39d8efd68952c0be4913a9b6aee517208R66-R68) [[5]](diffhunk://#diff-e828cfea518adf7f6d265170102783d39d8efd68952c0be4913a9b6aee517208R101) [[6]](diffhunk://#diff-0db6065970223c28a7fddd8ab95a8430f2148f32e17ecbae7bc1a7a875317f08R18-R20) [[7]](diffhunk://#diff-c7d6430ef102ac435b6e3c054f8a031d8a2bb497b46ce2f9d7c22e791e626ea4R175-R176)
* Extended `RuntimeStatus` to include a `timing` field and methods for recording and emitting performance evidence and threshold validation results. [[1]](diffhunk://#diff-ba97dd8fe1dac540542a1be6f8b90b966c354b558bf790b6d64b28a201698e01R9) [[2]](diffhunk://#diff-ba97dd8fe1dac540542a1be6f8b90b966c354b558bf790b6d64b28a201698e01R74) [[3]](diffhunk://#diff-ba97dd8fe1dac540542a1be6f8b90b966c354b558bf790b6d64b28a201698e01R92)

Documentation and test surface:

* Updated `STATUS.md` to clarify the existence of Phase 4.2 performance validation and to scope performance proof to the admitted harness path. [[1]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR34-R37) [[2]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eL43-R48)
* Added a new `performance` test module to support performance evidence validation.

These changes provide a robust foundation for performance regression gating and evidence generation in the alpha harness path, supporting future expansion to real transport and broader subsystem coverage.