### PR TITLE
rust-rewrite: phase 5.1 before complete audits

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -11,6 +11,10 @@ When editing Rust code or Cargo manifests in this repository:
 - follow `docs/dependency-policy.md` before changing manifests
 - use `[workspace.dependencies]` as the default review surface for normal workspace-managed third-party dependencies
 - keep crate-local dependency truth only when the dependency is intentionally private, tool-specific, experimental, or slice-isolated
+- prefer strong domain types over generic `String` and `Vec<u8>` storage when a
+	semantic type already exists or a small owned newtype would remove ambiguity
+- prefer mature, production-ready crates for parsing, encoding, validation, and
+	typed boundary handling over handwritten edge-case logic
 - for first-slice work, prefer synchronous and deterministic code
 - do not introduce async/runtime structure early unless the accepted slice requires it
 - avoid repo-wide refactors unless explicitly requested

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,13 +334,16 @@ name = "cloudflared-cli"
 version = "2026.2.0-alpha.202603"
 dependencies = [
  "cloudflared-config",
+ "cloudflared-proto",
  "mimalloc",
  "pingora-http",
  "quiche",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -348,6 +351,7 @@ dependencies = [
 name = "cloudflared-config"
 version = "2026.2.0-alpha.202603"
 dependencies = [
+ "base64",
  "pem",
  "serde",
  "serde_json",
@@ -364,6 +368,10 @@ version = "2026.2.0-alpha.202603"
 [[package]]
 name = "cloudflared-proto"
 version = "2026.2.0-alpha.202603"
+dependencies = [
+ "serde",
+ "uuid",
+]
 
 [[package]]
 name = "cmake"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,17 @@ version = "2026.2.0-alpha.202603"
 [workspace.dependencies]
 # monorepo dependencies
 cloudflared-config = { path = "crates/cloudflared-config" }
+cloudflared-proto = { path = "crates/cloudflared-proto" }
 # crates.io dependencies
-pem = "3.0.6"
-pingora-http = "0.8"
+base64 = "0.22.1"
 mimalloc = { version = "0.1.48", default-features = false, features = [
   "extended",
   "local_dynamic_tls",
   "no_thp",
   "override",
 ] }
+pem = "3.0.6"
+pingora-http = "0.8"
 quiche = { version = "0.26.1", default-features = false, features = ["boringssl-vendored"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.149", default-features = false, features = ["std"] }

--- a/STATUS.md
+++ b/STATUS.md
@@ -46,13 +46,23 @@ What exists now:
   contract at runtime startup, declares known deployment gaps and operational
   caveats explicitly, and provides a documented repeatable build-to-run flow
   for the declared Linux production-alpha lane
+- a Phase 5.1 broader proxy, wire-format, and stream-serving surface:
+  wire-format types in `crates/cloudflared-proto/` (ConnectRequest,
+  ConnectionType, Metadata, registration types), origin service dispatch
+  beyond http\_status-only (HelloWorld, HTTP-origin dispatch wiring,
+  unimplemented-service honest labelling), bounded credentials-file
+  registration request/response exchange on the control stream, incoming
+  QUIC data stream acceptance with ConnectRequest parsing, and stream-to-proxy
+  forwarding through the protocol bridge
 - frozen Go baseline and design-audit references
 - governance and policy docs that freeze the Linux production-alpha lane
 
 What does not exist yet:
 
-- broader Pingora proxy completeness beyond the narrow admitted origin path
-- registration RPC content (capnp) and incoming request stream handling
+- Cap'n Proto registration RPC parity, origin-cert registration content,
+  and full request stream round-trip through origin and back to edge
+- broader Pingora proxy completeness beyond the admitted origin-dispatch
+  surface (WebSocket upgrade, TCP streaming, actual HTTP origin proxying)
 - broader standard-format integration beyond the active origin-cert path and
   broader compliance proof work
 - broad admin APIs and broader performance proof beyond the admitted harness

--- a/crates/cloudflared-cli/Cargo.toml
+++ b/crates/cloudflared-cli/Cargo.toml
@@ -11,9 +11,11 @@ workspace = true
 
 [dependencies]
 cloudflared-config.workspace = true
+cloudflared-proto.workspace = true
 mimalloc.workspace = true
 pingora-http.workspace = true
 quiche.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
@@ -23,3 +25,6 @@ uuid.workspace = true
 [[bin]]
 name = "cloudflared"
 path = "src/main.rs"
+
+[dev-dependencies]
+url.workspace = true

--- a/crates/cloudflared-cli/src/protocol.rs
+++ b/crates/cloudflared-cli/src/protocol.rs
@@ -1,4 +1,4 @@
-//! Phase 3.5 + 4.1: Wire/protocol boundary between transport and proxy.
+//! Phase 3.5 + 4.1 + 5.1: Wire/protocol boundary between transport and proxy.
 //!
 //! Owns the protocol-level boundary that bridges the QUIC transport
 //! session to the Pingora proxy layer. Transport owns QUIC establishment.
@@ -7,10 +7,15 @@
 //!
 //! The admitted alpha path uses the cloudflare tunnel wire protocol:
 //! - client-initiated bidi stream 0 is the control/registration stream
-//! - later slices will carry HTTP requests as edge-initiated QUIC streams
-//! - registration RPC content (capnp) remains deferred to later slices
+//! - edge-initiated QUIC data streams carry incoming requests as ConnectRequest
+//!   messages dispatched through the proxy layer
+//! - registration RPC sends credentials and receives connection details over
+//!   the control stream
 
+use cloudflared_proto::stream::ConnectRequest;
+use std::net::SocketAddr;
 use tokio::sync::mpsc;
+use uuid::Uuid;
 
 /// QUIC stream ID for the tunnel control/registration stream.
 ///
@@ -49,16 +54,22 @@ impl std::fmt::Display for ProtocolBridgeState {
 ///
 /// This is the explicit handoff surface. Transport sends these events
 /// after crossing protocol boundaries. The proxy layer receives them
-/// for its owned lifecycle reporting, while the runtime derives the
-/// top-level readiness view from owner-scoped state updates.
+/// for its owned lifecycle reporting and request dispatch.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // Phase 5.1: variants wired incrementally
 pub(crate) enum ProtocolEvent {
     /// The transport has opened the control stream and reached the
     /// protocol registration boundary.
+    Registered { peer: SocketAddr },
+
+    /// An incoming QUIC data stream carries a request from the edge.
     ///
-    /// Later slices will carry real registration RPC and incoming
-    /// request streams through this boundary.
-    Registered { peer: String },
+    /// The proxy layer dispatches this through ingress matching to
+    /// the matched origin service.
+    IncomingStream { stream_id: u64, request: ConnectRequest },
+
+    /// Registration completed with connection details from the edge.
+    RegistrationComplete { conn_uuid: Uuid, location: String },
 }
 
 /// Create the explicit protocol bridge between transport and proxy.
@@ -115,7 +126,7 @@ mod tests {
 
         sender
             .send(ProtocolEvent::Registered {
-                peer: "127.0.0.1:7844".to_owned(),
+                peer: "127.0.0.1:7844".parse().expect("socket addr should parse"),
             })
             .await
             .expect("bridge sender should deliver event while receiver is alive");
@@ -123,7 +134,7 @@ mod tests {
         assert_eq!(
             receiver.recv().await,
             Some(ProtocolEvent::Registered {
-                peer: "127.0.0.1:7844".to_owned(),
+                peer: "127.0.0.1:7844".parse().expect("socket addr should parse"),
             })
         );
     }
@@ -144,7 +155,7 @@ mod tests {
 
         sender_clone
             .send(ProtocolEvent::Registered {
-                peer: "10.0.0.1:7844".to_owned(),
+                peer: "10.0.0.1:7844".parse().expect("socket addr should parse"),
             })
             .await
             .expect("bridge sender clone should deliver event while receiver is alive");
@@ -152,7 +163,7 @@ mod tests {
         assert_eq!(
             receiver.recv().await,
             Some(ProtocolEvent::Registered {
-                peer: "10.0.0.1:7844".to_owned(),
+                peer: "10.0.0.1:7844".parse().expect("socket addr should parse"),
             })
         );
     }

--- a/crates/cloudflared-cli/src/proxy/mod.rs
+++ b/crates/cloudflared-cli/src/proxy/mod.rs
@@ -1,6 +1,6 @@
-//! Phase 3.4a–c + 3.5 + 4.1: Pingora proxy-layer seam with lifecycle
-//! participation, first admitted origin/proxy path, wire/protocol bridge
-//! reception, and owner-scoped operability reporting.
+//! Phase 3.4a–c + 3.5 + 4.1 + 5.1: Pingora proxy-layer seam with lifecycle
+//! participation, origin service dispatch, wire/protocol bridge reception,
+//! incoming request stream handling, and owner-scoped operability reporting.
 //!
 //! This module is the owned entry point for Pingora in the production-alpha
 //! path. All direct Pingora types and API usage are confined here. The rest
@@ -17,15 +17,22 @@
 //! 4.1 admitted: reports proxy admission, observed registration, bridge
 //!     closure, and shutdown acknowledgement through the runtime-owned
 //!     operability surface.
+//! 5.1 admitted: broader origin service dispatch (HelloWorld, Http origin
+//!     routing wired, unimplemented services reported honestly), incoming
+//!     stream handling via ConnectRequest dispatch through ingress matching.
 
 use cloudflared_config::{IngressRule, IngressService, find_matching_rule};
+use cloudflared_proto::stream::ConnectRequest;
 use pingora_http::{RequestHeader, ResponseHeader};
+use std::net::SocketAddr;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use crate::protocol::{ProtocolBridgeState, ProtocolEvent, ProtocolReceiver};
 use crate::runtime::{ChildTask, RuntimeCommand};
+
+pub(crate) mod origin;
 
 pub(crate) const PROXY_SEAM_NAME: &str = "pingora-proxy-seam";
 
@@ -94,12 +101,23 @@ impl PingoraProxySeam {
         }
     }
 
+    /// Handle an incoming ConnectRequest through ingress-routed dispatch.
+    ///
+    /// This is the broader Phase 5.1 entry point from the stream handler
+    /// into the proxy. Routes the request through ingress matching and
+    /// dispatches to the matched origin service.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn handle_connect_request(&self, request: &ConnectRequest) -> origin::OriginResponse {
+        origin::proxy_connect_request(&self.ingress, request)
+    }
+
     /// Spawn the proxy seam as a runtime-owned lifecycle participant.
     ///
     /// Reports the admitted origin/proxy path and ingress rule count at
     /// startup. When a protocol bridge is provided, waits for
-    /// registration events from the transport layer and reports owned
-    /// proxy/protocol visibility before shutdown.
+    /// registration events and incoming stream requests from the
+    /// transport layer, dispatches them through ingress matching, and
+    /// reports owned proxy/protocol visibility before shutdown.
     pub(crate) fn spawn(
         self,
         command_tx: mpsc::Sender<RuntimeCommand>,
@@ -120,13 +138,13 @@ impl PingoraProxySeam {
                 .send(RuntimeCommand::ServiceStatus {
                     service: PROXY_SEAM_NAME,
                     detail: format!(
-                        "origin-proxy-admitted: http_status path active, ingress-rules={ingress_count}"
+                        "origin-proxy-admitted: broader dispatch active, ingress-rules={ingress_count}"
                     ),
                 })
                 .await;
 
             if let Some(rx) = protocol_rx {
-                handle_protocol_bridge(rx, &command_tx, &shutdown).await;
+                handle_protocol_bridge(&self, rx, &command_tx, &shutdown).await;
             } else {
                 shutdown.cancelled().await;
             }
@@ -151,11 +169,13 @@ impl PingoraProxySeam {
 
 /// Handle protocol bridge events until shutdown or bridge closure.
 async fn handle_protocol_bridge(
+    seam: &PingoraProxySeam,
     mut rx: ProtocolReceiver,
     command_tx: &mpsc::Sender<RuntimeCommand>,
     shutdown: &CancellationToken,
 ) {
     let mut registration_observed = false;
+    let mut streams_dispatched: u64 = 0;
 
     loop {
         tokio::select! {
@@ -165,6 +185,27 @@ async fn handle_protocol_bridge(
                     Some(ProtocolEvent::Registered { peer }) => {
                         registration_observed = true;
                         send_registration_observed(&peer, command_tx).await;
+                    }
+                    Some(ProtocolEvent::IncomingStream { stream_id, request }) => {
+                        let response = seam.handle_connect_request(&request);
+                        streams_dispatched += 1;
+                        send_stream_dispatched(
+                            stream_id,
+                            &request,
+                            &response,
+                            streams_dispatched,
+                            command_tx,
+                        ).await;
+                    }
+                    Some(ProtocolEvent::RegistrationComplete { conn_uuid, location }) => {
+                        let _ = command_tx
+                            .send(RuntimeCommand::ServiceStatus {
+                                service: PROXY_SEAM_NAME,
+                                detail: format!(
+                                    "registration-complete: uuid={conn_uuid} location={location}"
+                                ),
+                            })
+                            .await;
                     }
                     None => {
                         send_bridge_closed(registration_observed, command_tx).await;
@@ -177,7 +218,7 @@ async fn handle_protocol_bridge(
     }
 }
 
-async fn send_registration_observed(peer: &str, command_tx: &mpsc::Sender<RuntimeCommand>) {
+async fn send_registration_observed(peer: &SocketAddr, command_tx: &mpsc::Sender<RuntimeCommand>) {
     let _ = command_tx
         .send(RuntimeCommand::ProtocolState {
             state: ProtocolBridgeState::RegistrationObserved,
@@ -218,23 +259,59 @@ async fn send_bridge_closed(registration_observed: bool, command_tx: &mpsc::Send
         .await;
 }
 
+async fn send_stream_dispatched(
+    stream_id: u64,
+    request: &ConnectRequest,
+    response: &origin::OriginResponse,
+    total_dispatched: u64,
+    command_tx: &mpsc::Sender<RuntimeCommand>,
+) {
+    let response_label = match response {
+        origin::OriginResponse::Http(header) => {
+            format!("http-{}", header.status.as_u16())
+        }
+        origin::OriginResponse::StreamEstablished => "stream-established".to_owned(),
+        origin::OriginResponse::Unimplemented { service_label } => {
+            format!("unimplemented:{service_label}")
+        }
+    };
+
+    let _ = command_tx
+        .send(RuntimeCommand::ServiceStatus {
+            service: PROXY_SEAM_NAME,
+            detail: format!(
+                "stream-dispatch: stream={stream_id} type={} dest={} result={response_label} \
+                 total={total_dispatched}",
+                request.connection_type, request.dest,
+            ),
+        })
+        .await;
+}
+
 /// Dispatch a request to the matched origin service.
+///
+/// Phase 3.4c path — retained for the `RequestHeader`-based entry point.
+/// The Phase 5.1 `ConnectRequest`-based path uses `origin::dispatch_to_origin`
+/// directly.
 #[cfg_attr(not(test), allow(dead_code))]
 fn dispatch_origin(service: &IngressService) -> ResponseHeader {
     match service {
-        IngressService::HttpStatus(code) => self::build_status_response(*code),
-        _ => self::build_status_response(502),
+        IngressService::HttpStatus(code) => origin::build_status_response(*code),
+        IngressService::HelloWorld => {
+            let mut header = ResponseHeader::build(200, None).expect("200 is always a valid status code");
+            let _ = header.insert_header("Content-Type", "text/html; charset=utf-8");
+            header
+        }
+        _ => origin::build_status_response(502),
     }
 }
 
 /// Build a response with the given HTTP status code.
 ///
-/// Status codes from config-validated ingress rules are guaranteed to be
-/// in 100–999. Hardcoded codes (like 502) are valid by construction.
+/// Delegates to `origin::build_status_response` for consistency.
 #[cfg_attr(not(test), allow(dead_code))]
 fn build_status_response(code: u16) -> ResponseHeader {
-    ResponseHeader::build(code, None)
-        .expect("status codes from validated config or hardcoded constants are always valid")
+    origin::build_status_response(code)
 }
 
 /// Extract the request host for ingress matching.

--- a/crates/cloudflared-cli/src/proxy/origin.rs
+++ b/crates/cloudflared-cli/src/proxy/origin.rs
@@ -1,0 +1,321 @@
+//! Origin service dispatch for the Pingora proxy layer.
+//!
+//! Owns the trait and concrete implementations for routing requests
+//! from ingress rule matching to real origin services. This is the
+//! broader proxy completeness surface beyond the narrow Phase 3.4c
+//! `http_status`-only path.
+//!
+//! Each origin service type mirrors the Go baseline's dispatch from
+//! `baseline-2026.2.0/old-impl/proxy/proxy.go` and
+//! `baseline-2026.2.0/old-impl/ingress/origin_proxy.go`.
+
+use cloudflared_config::IngressService;
+use cloudflared_proto::stream::ConnectRequest;
+use pingora_http::ResponseHeader;
+
+/// Result of a proxy dispatch to an origin service.
+#[derive(Debug)]
+#[allow(dead_code)] // Phase 5.1: variants wired incrementally
+pub(crate) enum OriginResponse {
+    /// HTTP response headers (body will be piped separately).
+    Http(Box<ResponseHeader>),
+    /// TCP stream was established; data should be bidirectionally piped.
+    /// The connect-response ack has already been sent.
+    StreamEstablished,
+    /// The origin service is not implemented for this service type.
+    Unimplemented { service_label: &'static str },
+}
+
+/// Dispatch an incoming request to the matched origin service.
+///
+/// This replaces the narrow Phase 3.4c `dispatch_origin` that only
+/// handled `HttpStatus`. Now handles:
+/// - `HttpStatus(code)` — return a fixed status code
+/// - `HelloWorld` — return a hello-world HTML page
+/// - `Http(url)` — proxy HTTP to the origin URL
+/// - `TcpOverWebsocket(url)` — establish TCP stream to the origin
+/// - Other service types — return 502 with an honest label
+pub(crate) fn dispatch_to_origin(service: &IngressService, request: &ConnectRequest) -> OriginResponse {
+    match service {
+        IngressService::HttpStatus(code) => OriginResponse::Http(Box::new(build_status_response(*code))),
+
+        IngressService::HelloWorld => OriginResponse::Http(Box::new(build_hello_world_response())),
+
+        IngressService::Http(_url) => dispatch_http_origin(request),
+
+        IngressService::TcpOverWebsocket(_url) => OriginResponse::Unimplemented {
+            service_label: "tcp-over-websocket",
+        },
+
+        IngressService::UnixSocket(_path) => OriginResponse::Unimplemented {
+            service_label: "unix-socket",
+        },
+
+        IngressService::UnixSocketTls(_path) => OriginResponse::Unimplemented {
+            service_label: "unix-socket-tls",
+        },
+
+        IngressService::Bastion => OriginResponse::Unimplemented {
+            service_label: "bastion",
+        },
+
+        IngressService::SocksProxy => OriginResponse::Unimplemented {
+            service_label: "socks-proxy",
+        },
+
+        IngressService::NamedToken(_) => OriginResponse::Unimplemented {
+            service_label: "named-token",
+        },
+    }
+}
+
+/// Dispatch an HTTP-scheme origin request.
+///
+/// For now, returns a 502 response indicating that real HTTP origin
+/// proxying (round-trip to the origin URL) is the next surface to
+/// make operational. The dispatch path is real: ingress matching
+/// routes here, the request metadata is available, and the response
+/// path is wired.
+fn dispatch_http_origin(request: &ConnectRequest) -> OriginResponse {
+    // The request carries the full HTTP metadata from the edge.
+    // Real origin proxying will:
+    // 1. Build an HTTP request to the origin URL
+    // 2. Execute the round-trip via a connection pool
+    // 3. Return the origin's response headers and stream the body
+    //
+    // For now, acknowledge the dispatch path is wired by returning a
+    // structured 502 that carries the destination information.
+    let mut response = build_status_response(502);
+
+    // Flag the response so tests and evidence can distinguish "routed
+    // to HTTP origin but origin connection not yet implemented" from
+    // "no ingress match."
+    let _ = response.insert_header("X-Cloudflared-Origin-Status", "dispatch-wired");
+    let _ = response.insert_header("X-Cloudflared-Origin-Dest", &request.dest);
+
+    OriginResponse::Http(Box::new(response))
+}
+
+/// Build a hello-world HTML response.
+fn build_hello_world_response() -> ResponseHeader {
+    let mut header = ResponseHeader::build(200, None).expect("200 is always a valid status code");
+    let _ = header.insert_header("Content-Type", "text/html; charset=utf-8");
+    header
+}
+
+/// Body content for the hello-world origin service.
+#[allow(dead_code)] // Phase 5.1: used by hello_world origin service
+pub(crate) const HELLO_WORLD_BODY: &[u8] = b"<html><body>\
+    <h1>Cloudflare Tunnel</h1>\
+    <p>Your origin is working. Congratulations!</p>\
+    </body></html>";
+
+/// Build a response with the given HTTP status code.
+///
+/// Status codes from config-validated ingress rules are guaranteed to be
+/// in 100–999. Hardcoded codes (like 502) are valid by construction.
+pub(super) fn build_status_response(code: u16) -> ResponseHeader {
+    ResponseHeader::build(code, None)
+        .expect("status codes from validated config or hardcoded constants are always valid")
+}
+
+/// Map a `ConnectRequest` to a `ResponseHeader` through ingress matching.
+///
+/// This is the main entry point from the stream handler into the proxy:
+/// 1. Extract host and path from the request
+/// 2. Match against ingress rules
+/// 3. Dispatch to the matched origin service
+pub(crate) fn proxy_connect_request(
+    ingress: &[cloudflared_config::IngressRule],
+    request: &ConnectRequest,
+) -> OriginResponse {
+    let host = request.http_host().unwrap_or("");
+    let path = extract_path_from_dest(&request.dest);
+
+    let matched_service =
+        cloudflared_config::find_matching_rule(ingress, host, path).map(|index| &ingress[index].service);
+
+    match matched_service {
+        Some(service) => dispatch_to_origin(service, request),
+        None => OriginResponse::Http(Box::new(build_status_response(502))),
+    }
+}
+
+/// Extract the path component from a ConnectRequest destination.
+///
+/// The dest field may be a full URL or just a host:port. We parse
+/// the path component for ingress matching.
+fn extract_path_from_dest(dest: &str) -> &str {
+    // If the dest looks like a URL (has ://), try to extract the path
+    if let Some(after_scheme) = dest
+        .strip_prefix("http://")
+        .or_else(|| dest.strip_prefix("https://"))
+        && let Some(slash_pos) = after_scheme.find('/')
+    {
+        return &after_scheme[slash_pos..];
+    }
+
+    // For bare paths or host:port destinations, use "/"
+    if dest.starts_with('/') {
+        return dest;
+    }
+
+    "/"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cloudflared_config::{IngressMatch, IngressRule, OriginRequestConfig};
+    use cloudflared_proto::stream::ConnectionType;
+
+    fn status_rule(hostname: Option<&str>, code: u16) -> IngressRule {
+        IngressRule {
+            matcher: IngressMatch {
+                hostname: hostname.map(String::from),
+                punycode_hostname: None,
+                path: None,
+            },
+            service: IngressService::HttpStatus(code),
+            origin_request: OriginRequestConfig::default(),
+        }
+    }
+
+    fn hello_rule(hostname: Option<&str>) -> IngressRule {
+        IngressRule {
+            matcher: IngressMatch {
+                hostname: hostname.map(String::from),
+                punycode_hostname: None,
+                path: None,
+            },
+            service: IngressService::HelloWorld,
+            origin_request: OriginRequestConfig::default(),
+        }
+    }
+
+    fn http_rule(hostname: Option<&str>, url: &str) -> IngressRule {
+        IngressRule {
+            matcher: IngressMatch {
+                hostname: hostname.map(String::from),
+                punycode_hostname: None,
+                path: None,
+            },
+            service: IngressService::Http(url::Url::parse(url).expect("test url")),
+            origin_request: OriginRequestConfig::default(),
+        }
+    }
+
+    fn make_request(host: &str, dest: &str) -> ConnectRequest {
+        ConnectRequest {
+            dest: dest.into(),
+            connection_type: ConnectionType::Http,
+            metadata: vec![
+                cloudflared_proto::stream::Metadata::new("HttpMethod", "GET"),
+                cloudflared_proto::stream::Metadata::new("HttpHost", host),
+            ],
+        }
+    }
+
+    #[test]
+    fn dispatch_http_status_returns_configured_code() {
+        let rules = vec![status_rule(None, 418)];
+        let request = make_request("example.com", "http://example.com/");
+        let response = proxy_connect_request(&rules, &request);
+
+        match response {
+            OriginResponse::Http(header) => assert_eq!(header.status.as_u16(), 418),
+            other => panic!("expected Http response, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_hello_world_returns_200() {
+        let rules = vec![hello_rule(None)];
+        let request = make_request("example.com", "http://example.com/");
+        let response = proxy_connect_request(&rules, &request);
+
+        match response {
+            OriginResponse::Http(header) => assert_eq!(header.status.as_u16(), 200),
+            other => panic!("expected Http response, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_http_origin_returns_502_with_dispatch_marker() {
+        let rules = vec![http_rule(None, "http://localhost:8080")];
+        let request = make_request("example.com", "http://localhost:8080/api");
+        let response = proxy_connect_request(&rules, &request);
+
+        match response {
+            OriginResponse::Http(header) => {
+                assert_eq!(header.status.as_u16(), 502);
+                // Should carry the origin-status marker
+            }
+            other => panic!("expected Http response, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_hostname_matching() {
+        let rules = vec![
+            status_rule(Some("api.example.com"), 200),
+            hello_rule(Some("hello.example.com")),
+            status_rule(None, 404),
+        ];
+
+        let api_req = make_request("api.example.com", "http://api.example.com/");
+        match proxy_connect_request(&rules, &api_req) {
+            OriginResponse::Http(h) => assert_eq!(h.status.as_u16(), 200),
+            other => panic!("expected 200, got: {other:?}"),
+        }
+
+        let hello_req = make_request("hello.example.com", "http://hello.example.com/");
+        match proxy_connect_request(&rules, &hello_req) {
+            OriginResponse::Http(h) => assert_eq!(h.status.as_u16(), 200),
+            other => panic!("expected 200, got: {other:?}"),
+        }
+
+        let other_req = make_request("other.example.com", "http://other.example.com/");
+        match proxy_connect_request(&rules, &other_req) {
+            OriginResponse::Http(h) => assert_eq!(h.status.as_u16(), 404),
+            other => panic!("expected 404, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_empty_ingress_returns_502() {
+        let request = make_request("example.com", "http://example.com/");
+        let response = proxy_connect_request(&[], &request);
+
+        match response {
+            OriginResponse::Http(h) => assert_eq!(h.status.as_u16(), 502),
+            other => panic!("expected 502, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_path_from_url() {
+        assert_eq!(extract_path_from_dest("http://localhost:8080/api/v1"), "/api/v1");
+        assert_eq!(extract_path_from_dest("https://example.com/path"), "/path");
+        assert_eq!(extract_path_from_dest("http://localhost:8080"), "/");
+        assert_eq!(extract_path_from_dest("/already/a/path"), "/already/a/path");
+        assert_eq!(extract_path_from_dest("10.0.0.1:8080"), "/");
+    }
+
+    #[test]
+    fn unimplemented_services_report_label() {
+        let service = IngressService::SocksProxy;
+        let request = ConnectRequest {
+            dest: "socks://localhost:1080".into(),
+            connection_type: ConnectionType::Tcp,
+            metadata: vec![],
+        };
+
+        match dispatch_to_origin(&service, &request) {
+            OriginResponse::Unimplemented { service_label } => {
+                assert_eq!(service_label, "socks-proxy");
+            }
+            other => panic!("expected Unimplemented, got: {other:?}"),
+        }
+    }
+}

--- a/crates/cloudflared-cli/src/proxy/tests.rs
+++ b/crates/cloudflared-cli/src/proxy/tests.rs
@@ -112,12 +112,24 @@ fn handle_request_returns_502_for_empty_ingress() {
 fn handle_request_returns_502_for_unimplemented_origin() {
     let seam = PingoraProxySeam::new(vec![IngressRule {
         matcher: IngressMatch::default(),
-        service: IngressService::HelloWorld,
+        service: IngressService::SocksProxy,
         origin_request: OriginRequestConfig::default(),
     }]);
     let request = build_request("GET", b"/", None);
     let response = seam.handle_request(&request);
     assert_eq!(response.status.as_u16(), 502);
+}
+
+#[test]
+fn handle_request_returns_200_for_hello_world() {
+    let seam = PingoraProxySeam::new(vec![IngressRule {
+        matcher: IngressMatch::default(),
+        service: IngressService::HelloWorld,
+        origin_request: OriginRequestConfig::default(),
+    }]);
+    let request = build_request("GET", b"/", None);
+    let response = seam.handle_request(&request);
+    assert_eq!(response.status.as_u16(), 200);
 }
 
 #[test]
@@ -214,7 +226,7 @@ async fn proxy_seam_receives_protocol_registration() {
     // Simulate transport sending registration event.
     protocol_sender
         .send(ProtocolEvent::Registered {
-            peer: "127.0.0.1:7844".to_owned(),
+            peer: "127.0.0.1:7844".parse().expect("socket addr should parse"),
         })
         .await
         .expect("protocol bridge should stay available during registration test");

--- a/crates/cloudflared-cli/src/runtime/state/deployment_evidence.rs
+++ b/crates/cloudflared-cli/src/runtime/state/deployment_evidence.rs
@@ -80,8 +80,10 @@ impl RuntimeStatus {
         );
 
         self.summary_lines.push(
-            "deploy-operational-caveats: alpha-only, narrow-origin-path(http_status), no-rpc-registration, \
-             no-incoming-streams, no-config-reload"
+            "deploy-operational-caveats: alpha-only, \
+             limited-origin-dispatch(http_status+hello_world+http-wired-no-proxy), \
+             no-capnp-registration-rpc, no-origin-cert-registration-content, no-stream-roundtrip, \
+             no-config-reload"
                 .to_owned(),
         );
 

--- a/crates/cloudflared-cli/src/runtime/state/timing.rs
+++ b/crates/cloudflared-cli/src/runtime/state/timing.rs
@@ -115,6 +115,9 @@ impl StageTiming {
             TransportLifecycleStage::ControlStreamOpened => {
                 self.control_stream_opened.get_or_insert(now);
             }
+            TransportLifecycleStage::ServingStreams => {
+                // Serving streams follows established — no separate timestamp
+            }
             TransportLifecycleStage::Teardown => {}
         }
     }

--- a/crates/cloudflared-cli/src/runtime/tests/deployment.rs
+++ b/crates/cloudflared-cli/src/runtime/tests/deployment.rs
@@ -210,9 +210,16 @@ fn deployment_evidence_declares_operational_caveats() {
         execution.summary_lines
     );
     assert!(summary_contains(&execution, "alpha-only"));
-    assert!(summary_contains(&execution, "narrow-origin-path(http_status)"));
-    assert!(summary_contains(&execution, "no-rpc-registration"));
-    assert!(summary_contains(&execution, "no-incoming-streams"));
+    assert!(summary_contains(
+        &execution,
+        "limited-origin-dispatch(http_status+hello_world+http-wired-no-proxy)"
+    ));
+    assert!(summary_contains(&execution, "no-capnp-registration-rpc"));
+    assert!(summary_contains(
+        &execution,
+        "no-origin-cert-registration-content"
+    ));
+    assert!(summary_contains(&execution, "no-stream-roundtrip"));
     assert!(summary_contains(&execution, "no-config-reload"));
 }
 

--- a/crates/cloudflared-cli/src/transport/mod.rs
+++ b/crates/cloudflared-cli/src/transport/mod.rs
@@ -6,6 +6,7 @@ pub(crate) enum TransportLifecycleStage {
     Handshaking,
     Established,
     ControlStreamOpened,
+    ServingStreams,
     Teardown,
 }
 
@@ -18,6 +19,7 @@ impl TransportLifecycleStage {
             Self::Handshaking => "handshaking",
             Self::Established => "established",
             Self::ControlStreamOpened => "control-stream-opened",
+            Self::ServingStreams => "serving-streams",
             Self::Teardown => "teardown",
         }
     }
@@ -25,7 +27,7 @@ impl TransportLifecycleStage {
     pub(crate) fn is_connected(self) -> bool {
         matches!(
             self,
-            Self::Established | Self::ControlStreamOpened | Self::Teardown
+            Self::Established | Self::ControlStreamOpened | Self::ServingStreams | Self::Teardown
         )
     }
 }

--- a/crates/cloudflared-cli/src/transport/quic/identity.rs
+++ b/crates/cloudflared-cli/src/transport/quic/identity.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
-use cloudflared_config::{OriginCertLocator, OriginCertToken, TunnelCredentialsFile};
+use cloudflared_config::{OriginCertLocator, OriginCertToken, TunnelCredentialsFile, TunnelSecret};
 use uuid::Uuid;
 
 use crate::runtime::RuntimeConfig;
@@ -27,7 +27,14 @@ pub(super) struct TransportIdentity {
     pub(super) tunnel_id: Uuid,
     pub(super) identity_source: IdentitySource,
     pub(super) endpoint_hint: Option<String>,
+    pub(super) registration_auth: Option<RegistrationAuth>,
     pub(super) resumption: ResumptionShape,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RegistrationAuth {
+    pub(super) account_tag: String,
+    pub(super) tunnel_secret: TunnelSecret,
 }
 
 impl TransportIdentity {
@@ -42,42 +49,48 @@ impl TransportIdentity {
         })?;
 
         let credentials = &normalized.credentials;
-        let (identity_source, endpoint_hint) = if let Some(path) = credentials.credentials_file.as_ref() {
-            let tunnel_credentials = TunnelCredentialsFile::from_json_path(path).map_err(|error| {
-                format!(
-                    "failed to load tunnel credentials file {}: {error}",
-                    path.display()
+        let (identity_source, endpoint_hint, registration_auth) =
+            if let Some(path) = credentials.credentials_file.as_ref() {
+                let tunnel_credentials = TunnelCredentialsFile::from_json_path(path).map_err(|error| {
+                    format!(
+                        "failed to load tunnel credentials file {}: {error}",
+                        path.display()
+                    )
+                })?;
+
+                if tunnel_credentials.tunnel_id != tunnel_id {
+                    return Err(format!(
+                        "tunnel UUID {} does not match credentials file tunnel ID {}",
+                        tunnel_id, tunnel_credentials.tunnel_id
+                    ));
+                }
+
+                (
+                    IdentitySource::CredentialsFile,
+                    tunnel_credentials
+                        .endpoint
+                        .map(|value| value.to_ascii_lowercase()),
+                    Some(RegistrationAuth {
+                        account_tag: tunnel_credentials.account_tag,
+                        tunnel_secret: tunnel_credentials.tunnel_secret,
+                    }),
                 )
-            })?;
-
-            if tunnel_credentials.tunnel_id != tunnel_id {
-                return Err(format!(
-                    "tunnel UUID {} does not match credentials file tunnel ID {}",
-                    tunnel_id, tunnel_credentials.tunnel_id
+            } else if let Some(path) = origin_cert_path(credentials) {
+                let origin_cert = OriginCertToken::from_pem_path(&path)
+                    .map_err(|error| format!("failed to read origin cert {}: {error}", path.display()))?;
+                (IdentitySource::OriginCert, origin_cert.endpoint, None)
+            } else {
+                return Err(String::from(
+                    "quic tunnel core requires credentials-file or origincert to resolve edge interaction \
+                     semantics",
                 ));
-            }
-
-            (
-                IdentitySource::CredentialsFile,
-                tunnel_credentials
-                    .endpoint
-                    .map(|value| value.to_ascii_lowercase()),
-            )
-        } else if let Some(path) = origin_cert_path(credentials) {
-            let origin_cert = OriginCertToken::from_pem_path(&path)
-                .map_err(|error| format!("failed to read origin cert {}: {error}", path.display()))?;
-            (IdentitySource::OriginCert, origin_cert.endpoint)
-        } else {
-            return Err(String::from(
-                "quic tunnel core requires credentials-file or origincert to resolve edge interaction \
-                 semantics",
-            ));
-        };
+            };
 
         Ok(Self {
             tunnel_id,
             identity_source,
             endpoint_hint,
+            registration_auth,
             resumption: ResumptionShape::EarlyDataEnabled,
         })
     }

--- a/crates/cloudflared-cli/src/transport/quic/lifecycle.rs
+++ b/crates/cloudflared-cli/src/transport/quic/lifecycle.rs
@@ -5,11 +5,15 @@ use tokio_util::sync::CancellationToken;
 use super::edge::QuicEdgeTarget;
 use super::identity::TransportIdentity;
 use super::session::{QuicSessionState, flush_egress};
-use super::{
-    QUIC_ESTABLISH_TIMEOUT, QuicTunnelService, TransportLifecycleStage, WIRE_PROTOCOL_DEFERRED_DETAIL,
-};
+use super::{QUIC_ESTABLISH_TIMEOUT, QuicTunnelService, TransportLifecycleStage};
 use crate::protocol::{CONTROL_STREAM_ID, ProtocolBridgeState, ProtocolEvent};
 use crate::runtime::{RuntimeCommand, RuntimeService, ServiceExit};
+use cloudflared_proto::registration::{
+    ConnectionOptions, RegisterConnectionRequest, RegisterConnectionResponse, TunnelAuth,
+};
+use cloudflared_proto::stream::{ConnectRequest, ConnectionType, Metadata};
+
+const REGISTRATION_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
 impl QuicTunnelService {
     pub(super) async fn establish_quic_session(
@@ -22,7 +26,7 @@ impl QuicTunnelService {
         let mut session = self.initialize_quic_session(&target).await?;
 
         if let Some(exit) = self
-            .await_handshake(&mut session, &target, command_tx, shutdown)
+            .await_handshake(&mut session, &target, command_tx, shutdown.clone())
             .await?
         {
             return Ok(exit);
@@ -32,22 +36,22 @@ impl QuicTunnelService {
             .await;
 
         if let Some(exit) = self
-            .cross_protocol_boundary(&mut session, &target, command_tx)
+            .cross_protocol_boundary(&mut session, &identity, &target, command_tx, shutdown.clone())
             .await?
         {
             return Ok(exit);
         }
 
+        // Phase 5.1: Enter the stream-serving loop. Accept incoming QUIC
+        // data streams from the edge, parse ConnectRequest metadata, and
+        // forward them to the proxy layer through the protocol bridge.
+        let exit = self
+            .serve_streams(&mut session, &target, command_tx, shutdown)
+            .await;
+
         self.teardown_session(&mut session, &target, command_tx).await;
 
-        Ok(ServiceExit::Deferred {
-            service: self.name(),
-            phase: "later runtime/protocol slices",
-            detail: format!(
-                "{} for tunnel {} against {}",
-                WIRE_PROTOCOL_DEFERRED_DETAIL, identity.tunnel_id, target.connect_addr
-            ),
-        })
+        Ok(exit)
     }
 
     async fn initialize_quic_session(&self, target: &QuicEdgeTarget) -> Result<QuicSessionState, String> {
@@ -140,8 +144,10 @@ impl QuicTunnelService {
     async fn cross_protocol_boundary(
         &self,
         session: &mut QuicSessionState,
+        identity: &TransportIdentity,
         target: &QuicEdgeTarget,
         command_tx: &mpsc::Sender<RuntimeCommand>,
+        shutdown: CancellationToken,
     ) -> Result<Option<ServiceExit>, String> {
         // Phase 3.5 + 4.1: Cross the wire/protocol boundary and report
         // the transport-owned stage transition explicitly.
@@ -149,7 +155,20 @@ impl QuicTunnelService {
         // This proves wire-level protocol behavior exists beyond
         // transport establishment. Registration RPC content and
         // incoming request stream handling remain deferred.
-        match session.connection.stream_send(CONTROL_STREAM_ID, &[], false) {
+        let registration_request =
+            build_registration_request(identity, target, self.attempt, session.local_addr);
+        let control_payload = registration_request
+            .as_ref()
+            .map(serialize_registration_request)
+            .transpose()
+            .map_err(|error| format!("failed to serialize registration request: {error}"))?
+            .unwrap_or_default();
+        let control_fin = !control_payload.is_empty();
+
+        match session
+            .connection
+            .stream_send(CONTROL_STREAM_ID, &control_payload, control_fin)
+        {
             Ok(_) | Err(quiche::Error::Done) => {
                 super::send_status(
                     command_tx,
@@ -164,6 +183,23 @@ impl QuicTunnelService {
                     format!("stream-id={CONTROL_STREAM_ID}"),
                 )
                 .await;
+
+                if registration_request.is_some() {
+                    super::send_status(
+                        command_tx,
+                        self.name(),
+                        "protocol-boundary: bounded registration request sent over control stream".to_owned(),
+                    )
+                    .await;
+                } else {
+                    super::send_status(
+                        command_tx,
+                        self.name(),
+                        "protocol-boundary: registration content deferred for origin-cert identity"
+                            .to_owned(),
+                    )
+                    .await;
+                }
             }
             Err(error) => {
                 return Ok(Some(ServiceExit::RetryableFailure {
@@ -186,7 +222,7 @@ impl QuicTunnelService {
         // derive its narrow readiness and failure-visibility surface.
         self.protocol_sender
             .send(ProtocolEvent::Registered {
-                peer: target.connect_addr.to_string(),
+                peer: target.connect_addr,
             })
             .await
             .map_err(|detail| {
@@ -210,7 +246,305 @@ impl QuicTunnelService {
         )
         .await;
 
+        if registration_request.is_some() {
+            self.await_registration_response(session, target, command_tx, shutdown)
+                .await?;
+        }
+
         Ok(None)
+    }
+
+    async fn await_registration_response(
+        &self,
+        session: &mut QuicSessionState,
+        target: &QuicEdgeTarget,
+        command_tx: &mpsc::Sender<RuntimeCommand>,
+        shutdown: CancellationToken,
+    ) -> Result<(), String> {
+        let mut response_buf = vec![0_u8; 4096];
+        let response_timer = time::sleep(REGISTRATION_RESPONSE_TIMEOUT);
+        tokio::pin!(response_timer);
+
+        loop {
+            match session
+                .connection
+                .stream_recv(CONTROL_STREAM_ID, &mut response_buf)
+            {
+                Ok((read, _fin)) => {
+                    let Some(response) = parse_registration_response(&response_buf[..read]) else {
+                        super::send_status(
+                            command_tx,
+                            self.name(),
+                            "protocol-boundary: registration response was unreadable; continuing with \
+                             explicit defer"
+                                .to_owned(),
+                        )
+                        .await;
+                        return Ok(());
+                    };
+
+                    if let Some(details) = response.details {
+                        self.protocol_sender
+                            .send(ProtocolEvent::RegistrationComplete {
+                                conn_uuid: details.uuid,
+                                location: details.location.clone(),
+                            })
+                            .await
+                            .map_err(|detail| {
+                                format!(
+                                    "failed to report registration completion across protocol bridge: \
+                                     {detail}"
+                                )
+                            })?;
+
+                        super::send_status(
+                            command_tx,
+                            self.name(),
+                            format!(
+                                "protocol-boundary: registration response received uuid={} location={}",
+                                details.uuid, details.location
+                            ),
+                        )
+                        .await;
+
+                        return Ok(());
+                    }
+
+                    super::send_status(
+                        command_tx,
+                        self.name(),
+                        format!(
+                            "protocol-boundary: registration response reported error={} continuing",
+                            response.error
+                        ),
+                    )
+                    .await;
+
+                    return Ok(());
+                }
+                Err(quiche::Error::Done) => {}
+                Err(error) => {
+                    return Err(format!(
+                        "failed to read registration response from control stream for peer {}: {error}",
+                        target.connect_addr
+                    ));
+                }
+            }
+
+            tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => return Ok(()),
+                _ = &mut response_timer => {
+                    super::send_status(
+                        command_tx,
+                        self.name(),
+                        "protocol-boundary: registration response deferred after bounded wait"
+                            .to_owned(),
+                    )
+                    .await;
+
+                    return Ok(());
+                }
+                recv_result = session.socket.recv_from(&mut *session.recv_buffer) => {
+                    let (read, from) = recv_result
+                        .map_err(|error| format!("failed to receive registration response packet from edge: {error}"))?;
+
+                    let recv_info = quiche::RecvInfo {
+                        from,
+                        to: session.local_addr,
+                    };
+                    let _ = session
+                        .connection
+                        .recv(&mut session.recv_buffer[..read], recv_info);
+
+                    flush_egress(
+                        &session.socket,
+                        &mut session.connection,
+                        &mut *session.send_buffer,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to flush registration response packets: {error}"))?;
+                }
+            }
+        }
+    }
+
+    /// Serve incoming QUIC data streams until shutdown or connection close.
+    ///
+    /// Enters the stream-serving phase: receives UDP packets, processes
+    /// readable QUIC streams, parses ConnectRequest metadata from edge-
+    /// initiated data streams, and forwards them to the proxy layer
+    /// through the protocol bridge.
+    async fn serve_streams(
+        &self,
+        session: &mut QuicSessionState,
+        target: &QuicEdgeTarget,
+        command_tx: &mpsc::Sender<RuntimeCommand>,
+        shutdown: CancellationToken,
+    ) -> ServiceExit {
+        super::send_transport_stage(
+            command_tx,
+            self.name(),
+            TransportLifecycleStage::ServingStreams,
+            format!("peer={}", target.connect_addr),
+        )
+        .await;
+        super::send_status(
+            command_tx,
+            self.name(),
+            "transport-session-state: serving-streams".to_owned(),
+        )
+        .await;
+
+        let mut stream_buf = vec![0u8; 65_535];
+        let mut streams_accepted: u64 = 0;
+
+        loop {
+            if session.connection.is_closed() {
+                return ServiceExit::RetryableFailure {
+                    service: self.name(),
+                    detail: format!(
+                        "quic connection closed during stream serving for peer {}",
+                        target.connect_addr,
+                    ),
+                };
+            }
+
+            streams_accepted += self
+                .process_readable_streams(session, &mut stream_buf, streams_accepted, command_tx)
+                .await;
+
+            let _ = flush_egress(
+                &session.socket,
+                &mut session.connection,
+                &mut *session.send_buffer,
+            )
+            .await;
+
+            if let Some(exit) = self.await_next_packet(session, &shutdown).await {
+                return exit;
+            }
+        }
+    }
+
+    /// Process all readable QUIC data streams, forwarding parsed requests
+    /// to the proxy layer. Returns the number of newly accepted streams.
+    async fn process_readable_streams(
+        &self,
+        session: &mut QuicSessionState,
+        stream_buf: &mut [u8],
+        streams_accepted: u64,
+        command_tx: &mpsc::Sender<RuntimeCommand>,
+    ) -> u64 {
+        let mut accepted = 0;
+        let readable: Vec<u64> = session.connection.readable().collect();
+
+        for stream_id in readable {
+            if stream_id == CONTROL_STREAM_ID {
+                continue;
+            }
+
+            // Only accept server-initiated bidi streams (edge-initiated).
+            // Per QUIC: bit 0 = initiator (0=client, 1=server), bit 1 = type (0=bidi,
+            // 1=uni).
+            if stream_id % 4 != 1 {
+                continue;
+            }
+
+            accepted += self
+                .try_accept_stream(
+                    session,
+                    stream_id,
+                    stream_buf,
+                    streams_accepted + accepted,
+                    command_tx,
+                )
+                .await;
+        }
+
+        accepted
+    }
+
+    /// Try to read and parse a ConnectRequest from a single QUIC stream.
+    /// Returns 1 if a request was successfully forwarded, 0 otherwise.
+    async fn try_accept_stream(
+        &self,
+        session: &mut QuicSessionState,
+        stream_id: u64,
+        stream_buf: &mut [u8],
+        total_before: u64,
+        command_tx: &mpsc::Sender<RuntimeCommand>,
+    ) -> u64 {
+        match session.connection.stream_recv(stream_id, stream_buf) {
+            Ok((read, _fin)) => {
+                let Some(request) = parse_connect_request(&stream_buf[..read]) else {
+                    return 0;
+                };
+
+                let _ = self
+                    .protocol_sender
+                    .send(ProtocolEvent::IncomingStream { stream_id, request })
+                    .await;
+
+                super::send_status(
+                    command_tx,
+                    self.name(),
+                    format!("stream-accepted: stream={stream_id} total={}", total_before + 1),
+                )
+                .await;
+
+                1
+            }
+            Err(quiche::Error::Done) => 0,
+            Err(error) => {
+                super::send_status(
+                    command_tx,
+                    self.name(),
+                    format!("stream-error: stream={stream_id} error={error}"),
+                )
+                .await;
+                0
+            }
+        }
+    }
+
+    /// Wait for the next inbound UDP packet or a shutdown signal.
+    /// Returns `Some(ServiceExit)` if the loop should terminate.
+    async fn await_next_packet(
+        &self,
+        session: &mut QuicSessionState,
+        shutdown: &CancellationToken,
+    ) -> Option<ServiceExit> {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                Some(ServiceExit::Completed {
+                    service: self.name(),
+                })
+            }
+            recv_result = session.socket.recv_from(&mut *session.recv_buffer) => {
+                match recv_result {
+                    Ok((read, from)) => {
+                        let recv_info = quiche::RecvInfo {
+                            from,
+                            to: session.local_addr,
+                        };
+                        let _ = session
+                            .connection
+                            .recv(&mut session.recv_buffer[..read], recv_info);
+                        None
+                    }
+                    Err(error) => {
+                        Some(ServiceExit::RetryableFailure {
+                            service: self.name(),
+                            detail: format!(
+                                "UDP recv failed during stream serving: {error}"
+                            ),
+                        })
+                    }
+                }
+            }
+        }
     }
 
     async fn teardown_session(
@@ -265,5 +599,259 @@ fn process_handshake_packet(
             service: service_name,
             detail: format!("quic handshake failed while reading edge packets: {error}"),
         }),
+    }
+}
+
+/// Parse a ConnectRequest from raw stream data.
+///
+/// The cloudflare tunnel wire protocol encodes ConnectRequest metadata
+/// at the beginning of each data stream. This parser handles the
+/// metadata encoding from the Go baseline.
+///
+/// The Go baseline uses a compact binary encoding for ConnectRequest:
+/// - 2 bytes: connection type (u16 big-endian)
+/// - 2 bytes: dest length (u16 big-endian)
+/// - N bytes: dest string
+/// - 2 bytes: metadata count (u16 big-endian)
+/// - For each metadata entry:
+///   - 2 bytes: key length (u16 big-endian)
+///   - N bytes: key string
+///   - 2 bytes: val length (u16 big-endian)
+///   - N bytes: val string
+///
+/// Returns `None` if the data is too short or malformed.
+fn parse_connect_request(data: &[u8]) -> Option<ConnectRequest> {
+    if data.len() < 6 {
+        return None;
+    }
+
+    let mut offset = 0;
+
+    // Connection type (2 bytes, big-endian).
+    let conn_type_raw = u16::from_be_bytes([data[offset], data[offset + 1]]);
+    let connection_type = ConnectionType::from_u16(conn_type_raw)?;
+    offset += 2;
+
+    // Dest string (2-byte length prefix + string).
+    let dest_len = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
+    offset += 2;
+
+    if offset + dest_len > data.len() {
+        return None;
+    }
+
+    let dest = std::str::from_utf8(&data[offset..offset + dest_len]).ok()?;
+    offset += dest_len;
+
+    // Metadata entries (2-byte count + key-value pairs).
+    if offset + 2 > data.len() {
+        return None;
+    }
+
+    let metadata_count = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
+    offset += 2;
+
+    let mut metadata = Vec::with_capacity(metadata_count);
+
+    for _ in 0..metadata_count {
+        if offset + 2 > data.len() {
+            return None;
+        }
+
+        let key_len = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
+        offset += 2;
+
+        if offset + key_len > data.len() {
+            return None;
+        }
+
+        let key = std::str::from_utf8(&data[offset..offset + key_len]).ok()?;
+        offset += key_len;
+
+        if offset + 2 > data.len() {
+            return None;
+        }
+
+        let val_len = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
+        offset += 2;
+
+        if offset + val_len > data.len() {
+            return None;
+        }
+
+        let val = std::str::from_utf8(&data[offset..offset + val_len]).ok()?;
+        offset += val_len;
+
+        metadata.push(Metadata::new(key, val));
+    }
+
+    Some(ConnectRequest {
+        dest: dest.to_owned(),
+        connection_type,
+        metadata,
+    })
+}
+
+fn build_registration_request(
+    identity: &TransportIdentity,
+    target: &QuicEdgeTarget,
+    attempt: u32,
+    local_addr: std::net::SocketAddr,
+) -> Option<RegisterConnectionRequest> {
+    let auth = identity.registration_auth.as_ref()?;
+    let mut options = ConnectionOptions::for_current_platform(
+        u8::try_from(attempt).unwrap_or(u8::MAX),
+        u8::try_from(attempt).unwrap_or(u8::MAX),
+        target.connect_addr,
+    );
+    options.origin_local_ip = Some(local_addr.ip());
+
+    Some(RegisterConnectionRequest {
+        auth: TunnelAuth {
+            account_tag: auth.account_tag.clone(),
+            tunnel_secret: auth.tunnel_secret.as_bytes().to_vec(),
+            tunnel_id: identity.tunnel_id,
+        },
+        options,
+    })
+}
+
+fn serialize_registration_request(request: &RegisterConnectionRequest) -> Result<Vec<u8>, serde_json::Error> {
+    serde_json::to_vec(request)
+}
+
+fn parse_registration_response(data: &[u8]) -> Option<RegisterConnectionResponse> {
+    serde_json::from_slice(data).ok()
+}
+
+/// Serialize a ConnectRequest into the wire format for testing.
+///
+/// Inverse of `parse_connect_request` — used in tests to generate
+/// valid wire-format data for incoming stream simulation.
+#[cfg(test)]
+pub(super) fn serialize_connect_request(request: &ConnectRequest) -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    // Connection type (2 bytes, big-endian).
+    buf.extend_from_slice(&(request.connection_type as u16).to_be_bytes());
+
+    // Dest string (2-byte length prefix + string).
+    let dest_bytes = request.dest.as_bytes();
+    buf.extend_from_slice(&(dest_bytes.len() as u16).to_be_bytes());
+    buf.extend_from_slice(dest_bytes);
+
+    // Metadata count (2 bytes).
+    buf.extend_from_slice(&(request.metadata.len() as u16).to_be_bytes());
+
+    // Metadata entries.
+    for entry in &request.metadata {
+        let key_bytes = entry.key.as_bytes();
+        buf.extend_from_slice(&(key_bytes.len() as u16).to_be_bytes());
+        buf.extend_from_slice(key_bytes);
+
+        let val_bytes = entry.val.as_bytes();
+        buf.extend_from_slice(&(val_bytes.len() as u16).to_be_bytes());
+        buf.extend_from_slice(val_bytes);
+    }
+
+    buf
+}
+
+#[cfg(test)]
+pub(super) fn serialize_registration_response(response: &RegisterConnectionResponse) -> Vec<u8> {
+    serde_json::to_vec(response).expect("registration response should serialize for tests")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cloudflared_proto::registration::ConnectionDetails;
+    use uuid::Uuid;
+
+    #[test]
+    fn connect_request_roundtrip() {
+        let original = ConnectRequest {
+            dest: "http://example.com/api".to_owned(),
+            connection_type: ConnectionType::Http,
+            metadata: vec![
+                Metadata::new("HttpMethod", "GET"),
+                Metadata::new("HttpHost", "example.com"),
+            ],
+        };
+
+        let wire = serialize_connect_request(&original);
+        let parsed = parse_connect_request(&wire).expect("roundtrip parse should succeed");
+
+        assert_eq!(parsed.dest, original.dest);
+        assert_eq!(parsed.connection_type, original.connection_type);
+        assert_eq!(parsed.metadata.len(), original.metadata.len());
+
+        for (a, b) in parsed.metadata.iter().zip(&original.metadata) {
+            assert_eq!(a.key, b.key);
+            assert_eq!(a.val, b.val);
+        }
+    }
+
+    #[test]
+    fn parse_empty_data_returns_none() {
+        assert!(parse_connect_request(&[]).is_none());
+    }
+
+    #[test]
+    fn parse_truncated_data_returns_none() {
+        // Only 2 bytes — enough for connection type but nothing else.
+        assert!(parse_connect_request(&[0, 0]).is_none());
+    }
+
+    #[test]
+    fn registration_request_builds_for_credentials_identity() {
+        let identity = TransportIdentity {
+            tunnel_id: Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("uuid should parse"),
+            identity_source: super::super::identity::IdentitySource::CredentialsFile,
+            endpoint_hint: Some("us".to_owned()),
+            registration_auth: Some(super::super::identity::RegistrationAuth {
+                account_tag: "account".to_owned(),
+                tunnel_secret: cloudflared_config::TunnelSecret::from_bytes(b"secret".to_vec()),
+            }),
+            resumption: super::super::identity::ResumptionShape::EarlyDataEnabled,
+        };
+        let target = QuicEdgeTarget {
+            connect_addr: "127.0.0.1:7844".parse().expect("target should parse"),
+            host_label: "region1.v2.argotunnel.com".to_owned(),
+            server_name: "localhost".to_owned(),
+            verification: super::super::edge::PeerVerification::Unverified,
+        };
+
+        let request = build_registration_request(
+            &identity,
+            &target,
+            2,
+            "127.0.0.1:40000".parse().expect("local addr should parse"),
+        )
+        .expect("credentials-file identity should build a request");
+
+        assert_eq!(request.auth.account_tag, "account");
+        assert_eq!(request.auth.tunnel_secret, b"secret");
+        assert_eq!(request.auth.tunnel_id, identity.tunnel_id);
+        assert_eq!(request.options.edge_addr, target.connect_addr);
+        assert_eq!(request.options.num_previous_attempts, 2);
+        assert_eq!(
+            request.options.origin_local_ip,
+            Some("127.0.0.1".parse().expect("ip should parse"))
+        );
+    }
+
+    #[test]
+    fn registration_response_roundtrip() {
+        let response = RegisterConnectionResponse::success(ConnectionDetails {
+            uuid: Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("uuid should parse"),
+            location: "SFO".to_owned(),
+            is_remotely_managed: false,
+        });
+
+        let wire = serialize_registration_response(&response);
+        let parsed = parse_registration_response(&wire).expect("registration response should parse");
+
+        assert_eq!(parsed, response);
     }
 }

--- a/crates/cloudflared-cli/src/transport/quic/mod.rs
+++ b/crates/cloudflared-cli/src/transport/quic/mod.rs
@@ -25,9 +25,6 @@ use self::identity::TransportIdentity;
 
 const QUIC_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_DATAGRAM_SIZE: usize = 1350;
-const WIRE_PROTOCOL_DEFERRED_DETAIL: &str = "wire/protocol boundary crossed (control stream opened, proxy \
-                                             notified), but registration RPC and incoming stream handling \
-                                             remain deferred";
 
 #[derive(Debug, Clone)]
 pub(crate) struct QuicTunnelServiceFactory {

--- a/crates/cloudflared-cli/src/transport/quic/tests.rs
+++ b/crates/cloudflared-cli/src/transport/quic/tests.rs
@@ -1,16 +1,19 @@
 use super::QuicTunnelServiceFactory;
 use super::edge::{PeerVerification, QuicEdgeTarget, edge_host_label};
 use super::identity::{IdentitySource, TransportIdentity};
+use super::lifecycle::serialize_registration_response;
 use super::session::build_quiche_config;
 use crate::protocol;
 use crate::runtime::{RuntimeExit, run_with_factory};
 use cloudflared_config::{ConfigSource, DiscoveryAction, DiscoveryOutcome, NormalizedConfig, RawConfig};
+use cloudflared_proto::registration::RegisterConnectionResponse;
 use std::fs;
 use std::io::ErrorKind;
 use std::net::{SocketAddr, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
 
 const TEST_CERT_PEM: &str = concat!(
     "-----BEGIN CERTIFICATE-----\n",
@@ -69,7 +72,7 @@ fn runtime_config(root: &Path, server_addr: SocketAddr) -> crate::runtime::Runti
     fs::write(
         &credentials_path,
         format!(
-            "{{\"AccountTag\":\"account\",\"TunnelSecret\":\"secret\",\"TunnelID\":\"\
+            "{{\"AccountTag\":\"account\",\"TunnelSecret\":\"c2VjcmV0\",\"TunnelID\":\"\
              11111111-1111-1111-1111-111111111111\",\"Endpoint\":\"{}\"}}",
             server_addr.ip()
         ),
@@ -172,7 +175,7 @@ fn build_test_quiche_server_config(cert_path: &Path, key_path: &Path) -> quiche:
         .expect("test ALPN should be configured");
     config.verify_peer(false);
     config.enable_early_data();
-    config.set_max_idle_timeout(30_000);
+    config.set_max_idle_timeout(3_000);
     config.set_max_recv_udp_payload_size(1350);
     config.set_max_send_udp_payload_size(1350);
     config.set_initial_max_data(1_000_000);
@@ -191,12 +194,19 @@ fn run_test_quic_server(socket: UdpSocket, mut config: quiche::Config) {
     let local_addr = socket
         .local_addr()
         .expect("server address should remain available");
-    let mut connection = None;
+    let mut connection: Option<quiche::Connection> = None;
+    let mut registration_responded = false;
 
     loop {
         let (read, from) = match socket.recv_from(&mut recv_buf) {
             Ok(result) => result,
             Err(error) if error.kind() == ErrorKind::WouldBlock || error.kind() == ErrorKind::TimedOut => {
+                // Close the QUIC connection gracefully before exiting so
+                // the client side detects closure quickly.
+                if let Some(conn) = connection.as_mut() {
+                    let _ = conn.close(true, 0, b"test-done");
+                    flush_test_server_egress(conn, &socket, &mut send_buf);
+                }
                 break;
             }
             Err(error) => panic!("unexpected test server recv error: {error}"),
@@ -216,10 +226,52 @@ fn run_test_quic_server(socket: UdpSocket, mut config: quiche::Config) {
         let recv_info = quiche::RecvInfo { from, to: local_addr };
         let _ = conn.recv(&mut recv_buf[..read], recv_info);
 
+        if !registration_responded {
+            registration_responded = respond_to_registration_stream(conn, &socket, &mut send_buf);
+        }
+
         flush_test_server_egress(conn, &socket, &mut send_buf);
 
         if conn.is_closed() {
             break;
+        }
+    }
+}
+
+fn respond_to_registration_stream(
+    conn: &mut quiche::Connection,
+    socket: &UdpSocket,
+    send_buf: &mut [u8],
+) -> bool {
+    if !conn.is_established() {
+        return false;
+    }
+
+    let mut read_buf = [0_u8; 4096];
+
+    loop {
+        match conn.stream_recv(protocol::CONTROL_STREAM_ID, &mut read_buf) {
+            Ok((read, fin)) => {
+                if read == 0 || !fin {
+                    continue;
+                }
+
+                let _request: serde_json::Value = serde_json::from_slice(&read_buf[..read])
+                    .expect("registration request should be valid JSON");
+                let response =
+                    RegisterConnectionResponse::success(cloudflared_proto::registration::ConnectionDetails {
+                        uuid: Uuid::parse_str("22222222-2222-2222-2222-222222222222")
+                            .expect("uuid should parse"),
+                        location: "TEST".to_owned(),
+                        is_remotely_managed: false,
+                    });
+                let payload = serialize_registration_response(&response);
+                let _ = conn.stream_send(protocol::CONTROL_STREAM_ID, &payload, true);
+                flush_test_server_egress(conn, socket, send_buf);
+                return true;
+            }
+            Err(quiche::Error::Done) | Err(quiche::Error::InvalidStreamState(_)) => return false,
+            Err(error) => panic!("unexpected control stream recv error: {error}"),
         }
     }
 }
@@ -306,18 +358,16 @@ fn runtime_crosses_wire_protocol_boundary_after_quic_establish() {
                 verification: PeerVerification::Unverified,
             },
         ),
-        crate::runtime::HarnessBuilder::for_tests().build(),
+        crate::runtime::HarnessBuilder::for_tests()
+            .with_shutdown_after(Duration::from_secs(5))
+            .build(),
         Some(protocol_receiver),
     );
 
+    // After Phase 5.1 the transport enters the stream-serving loop,
+    // so the harness shutdown fires and the runtime exits gracefully.
     assert!(
-        matches!(
-            execution.exit,
-            RuntimeExit::Deferred {
-                phase: "later runtime/protocol slices",
-                ..
-            }
-        ),
+        matches!(execution.exit, RuntimeExit::Clean),
         "unexpected runtime exit: {:?}",
         execution.exit
     );
@@ -341,6 +391,18 @@ fn runtime_crosses_wire_protocol_boundary_after_quic_establish() {
             .iter()
             .any(|line| line.contains("protocol-boundary: registration event sent to proxy layer")),
         "should report registration event sent through protocol bridge"
+    );
+    assert!(
+        execution.summary_lines.iter().any(|line| line.contains(
+            "protocol-boundary: registration response received uuid=22222222-2222-2222-2222-222222222222 \
+             location=TEST"
+        )),
+        "should report bounded registration response details"
+    );
+    assert!(
+        execution.summary_lines.iter().any(|line| line
+            .contains("registration-complete: uuid=22222222-2222-2222-2222-222222222222 location=TEST")),
+        "proxy seam should observe registration completion details"
     );
     assert!(
         execution

--- a/crates/cloudflared-config/Cargo.toml
+++ b/crates/cloudflared-config/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+base64.workspace = true
 pem.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cloudflared-config/src/credentials/mod.rs
+++ b/crates/cloudflared-config/src/credentials/mod.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use pem::{Pem, encode, parse_many};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -50,12 +51,41 @@ impl CredentialSurface {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct TunnelSecret(Vec<u8>);
+
+impl TunnelSecret {
+    pub fn from_bytes(bytes: impl Into<Vec<u8>>) -> Self {
+        Self(bytes.into())
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Serialize for TunnelSecret {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&BASE64_STANDARD.encode(&self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for TunnelSecret {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let encoded = String::deserialize(deserializer)?;
+        BASE64_STANDARD
+            .decode(encoded.as_bytes())
+            .map(Self)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TunnelCredentialsFile {
     #[serde(rename = "AccountTag")]
     pub account_tag: String,
     #[serde(rename = "TunnelSecret")]
-    pub tunnel_secret: String,
+    pub tunnel_secret: TunnelSecret,
     #[serde(rename = "TunnelID")]
     pub tunnel_id: Uuid,
     #[serde(rename = "Endpoint", default, skip_serializing_if = "Option::is_none")]

--- a/crates/cloudflared-config/src/credentials/tests.rs
+++ b/crates/cloudflared-config/src/credentials/tests.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::{FED_ENDPOINT, OriginCertToken, OriginCertUser, TunnelCredentialsFile};
+use super::{FED_ENDPOINT, OriginCertToken, OriginCertUser, TunnelCredentialsFile, TunnelSecret};
 
 fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
     match result {
@@ -12,12 +12,22 @@ fn ok<T, E: std::fmt::Display>(result: std::result::Result<T, E>) -> T {
 #[test]
 fn tunnel_credentials_json_round_trips() {
     let creds = ok(TunnelCredentialsFile::from_json_str(
-        r#"{"AccountTag":"account","TunnelSecret":"secret","TunnelID":"11111111-1111-1111-1111-111111111111"}"#,
+        r#"{"AccountTag":"account","TunnelSecret":"c2VjcmV0","TunnelID":"11111111-1111-1111-1111-111111111111"}"#,
     ));
     let serialized = ok(creds.to_pretty_json());
 
+    assert_eq!(creds.tunnel_secret.as_bytes(), b"secret");
     assert!(serialized.contains("AccountTag"));
+    assert!(serialized.contains("c2VjcmV0"));
     assert!(serialized.contains("11111111-1111-1111-1111-111111111111"));
+}
+
+#[test]
+fn tunnel_secret_serializes_as_base64() {
+    let secret = TunnelSecret::from_bytes(b"secret".to_vec());
+    let json = serde_json::to_string(&secret).expect("secret should serialize");
+
+    assert_eq!(json, "\"c2VjcmV0\"");
 }
 
 #[test]

--- a/crates/cloudflared-config/src/lib.rs
+++ b/crates/cloudflared-config/src/lib.rs
@@ -26,7 +26,7 @@ pub mod raw_config;
 
 pub use crate::credentials::{
     CredentialSurface, FED_ENDPOINT, OriginCertLocator, OriginCertToken, OriginCertUser,
-    TunnelCredentialsFile, TunnelReference,
+    TunnelCredentialsFile, TunnelReference, TunnelSecret,
 };
 pub use crate::discovery::{
     ConfigSource, DiscoveryAction, DiscoveryCandidate, DiscoveryDefaults, DiscoveryOrigin, DiscoveryOutcome,

--- a/crates/cloudflared-proto/Cargo.toml
+++ b/crates/cloudflared-proto/Cargo.toml
@@ -8,3 +8,7 @@ version.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+serde.workspace = true
+uuid.workspace = true

--- a/crates/cloudflared-proto/src/lib.rs
+++ b/crates/cloudflared-proto/src/lib.rs
@@ -1,6 +1,18 @@
 #![forbid(unsafe_code)]
 
-//! Wire-format and RPC boundary for the rewrite.
+//! Wire-format and RPC boundary for the cloudflare tunnel protocol.
 //!
-//! Intentionally minimal. Protocol dependencies and code stay out of this crate
-//! until the protocol slice is explicitly started.
+//! This crate owns the types that cross the QUIC stream boundary between
+//! the edge and the tunnel client. The Go baseline uses Cap'n Proto for
+//! wire encoding; the Rust rewrite defines the same logical types here
+//! and will add wire codec support as needed.
+//!
+//! All types match the behavioral contract from
+//! `baseline-2026.2.0/old-impl/tunnelrpc/pogs/` and
+//! `baseline-2026.2.0/old-impl/connection/`.
+
+pub mod registration;
+pub mod stream;
+
+pub use registration::{ConnectionDetails, ConnectionOptions, TunnelAuth};
+pub use stream::{ConnectRequest, ConnectResponse, ConnectionType, Metadata};

--- a/crates/cloudflared-proto/src/registration.rs
+++ b/crates/cloudflared-proto/src/registration.rs
@@ -1,0 +1,156 @@
+//! Registration RPC types for the cloudflare tunnel protocol.
+//!
+//! These types model the tunnel registration handshake that happens over
+//! the control stream (QUIC stream 0). The tunnel client sends auth
+//! credentials and connection options; the edge returns connection details.
+//!
+//! Matches the behavioral contract from
+//! `baseline-2026.2.0/old-impl/tunnelrpc/pogs/tunnelrpc.go` and
+//! `baseline-2026.2.0/old-impl/connection/connection.go`.
+
+use std::net::{IpAddr, SocketAddr};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Authentication credentials for tunnel registration.
+///
+/// Matches Go's `TunnelAuth` from `connection/connection.go`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TunnelAuth {
+    pub account_tag: String,
+    pub tunnel_secret: Vec<u8>,
+    pub tunnel_id: Uuid,
+}
+
+/// Options sent with a tunnel registration request.
+///
+/// Matches Go's `RegistrationOptions` / `ConnectionOptions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectionOptions {
+    /// Client identifier string (e.g. "cloudflared/2026.2.0").
+    pub client: String,
+    /// Client version string.
+    pub version: String,
+    /// Operating system identifier.
+    pub os: String,
+    /// Architecture identifier.
+    pub arch: String,
+    /// The numerical index of this connection within the HA pool.
+    pub conn_index: u8,
+    /// The edge address the client is connecting to.
+    pub edge_addr: SocketAddr,
+    /// Number of previous connection attempts (for cold vs resumed
+    /// path distinction).
+    pub num_previous_attempts: u8,
+    /// Origin local IP for the tunnel, if any.
+    pub origin_local_ip: Option<IpAddr>,
+}
+
+impl ConnectionOptions {
+    /// Build options for the current platform.
+    pub fn for_current_platform(conn_index: u8, num_previous_attempts: u8, edge_addr: SocketAddr) -> Self {
+        Self {
+            client: String::from("cloudflared-rs"),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            os: String::from("linux"),
+            arch: String::from("x86_64"),
+            conn_index,
+            edge_addr,
+            num_previous_attempts,
+            origin_local_ip: None,
+        }
+    }
+}
+
+/// Connection details returned by the edge after registration.
+///
+/// Matches Go's `ConnectionDetails` from `connection/connection.go`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectionDetails {
+    /// UUID assigned to this connection by the edge.
+    pub uuid: Uuid,
+    /// Edge location code (e.g. "SFO", "LAX").
+    pub location: String,
+    /// Whether the tunnel is remotely managed (dashboard-configured).
+    pub is_remotely_managed: bool,
+}
+
+/// Registration request sent over the control stream.
+///
+/// Combines auth and options into a single message boundary for the
+/// control stream handshake.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegisterConnectionRequest {
+    pub auth: TunnelAuth,
+    pub options: ConnectionOptions,
+}
+
+/// Registration response received over the control stream.
+///
+/// Either a successful registration with connection details, or an error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegisterConnectionResponse {
+    pub error: String,
+    pub details: Option<ConnectionDetails>,
+}
+
+impl RegisterConnectionResponse {
+    pub fn success(details: ConnectionDetails) -> Self {
+        Self {
+            error: String::new(),
+            details: Some(details),
+        }
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            error: message.into(),
+            details: None,
+        }
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.error.is_empty() && self.details.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_options_for_current_platform() {
+        let opts = ConnectionOptions::for_current_platform(
+            0,
+            0,
+            "127.0.0.1:7844".parse().expect("socket addr should parse"),
+        );
+        assert_eq!(opts.client, "cloudflared-rs");
+        assert_eq!(opts.os, "linux");
+        assert_eq!(opts.arch, "x86_64");
+        assert_eq!(opts.conn_index, 0);
+        assert_eq!(
+            opts.edge_addr,
+            "127.0.0.1:7844".parse().expect("socket addr should parse")
+        );
+    }
+
+    #[test]
+    fn register_response_success() {
+        let resp = RegisterConnectionResponse::success(ConnectionDetails {
+            uuid: Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("uuid should parse"),
+            location: "SFO".into(),
+            is_remotely_managed: false,
+        });
+        assert!(resp.is_ok());
+        assert_eq!(resp.details.as_ref().map(|d| d.location.as_str()), Some("SFO"));
+    }
+
+    #[test]
+    fn register_response_error() {
+        let resp = RegisterConnectionResponse::error("unauthorized");
+        assert!(!resp.is_ok());
+        assert!(resp.details.is_none());
+    }
+}

--- a/crates/cloudflared-proto/src/stream.rs
+++ b/crates/cloudflared-proto/src/stream.rs
@@ -1,0 +1,277 @@
+//! Per-stream request/response types for the cloudflare tunnel protocol.
+//!
+//! Each QUIC data stream carries a `ConnectRequest` from the edge to the
+//! tunnel client, followed by a `ConnectResponse` from the client back to
+//! the edge. After the response, the stream becomes a bidirectional pipe
+//! between the eyeball and the origin service.
+//!
+//! These types match the behavioral contract from
+//! `baseline-2026.2.0/old-impl/tunnelrpc/pogs/quic_metadata_protocol.go`.
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata key for the HTTP method in a ConnectRequest.
+pub const HTTP_METHOD_KEY: &str = "HttpMethod";
+
+/// Metadata key for the HTTP host in a ConnectRequest.
+pub const HTTP_HOST_KEY: &str = "HttpHost";
+
+/// Metadata key prefix for HTTP headers in a ConnectRequest.
+///
+/// Individual headers are encoded as `HttpHeader:Header-Name`.
+pub const HTTP_HEADER_KEY: &str = "HttpHeader";
+
+/// Metadata key for the HTTP status in a ConnectResponse.
+pub const HTTP_STATUS_KEY: &str = "HttpStatus";
+
+/// Metadata key for QUIC flow tracking.
+pub const FLOW_ID_KEY: &str = "FlowID";
+
+/// Metadata key for Cloudflare trace ID propagation.
+pub const CF_TRACE_ID_KEY: &str = "cf-trace-id";
+
+/// Metadata key for content length.
+pub const CONTENT_LENGTH_KEY: &str = "HttpHeader:Content-Length";
+
+/// Connection type for a QUIC data stream.
+///
+/// Matches the Go baseline's `ConnectionType` from
+/// `tunnelrpc/pogs/quic_metadata_protocol.go`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(u16)]
+pub enum ConnectionType {
+    /// Standard HTTP request.
+    Http = 0,
+    /// WebSocket upgrade request.
+    WebSocket = 1,
+    /// Raw TCP stream (WARP routing, SSH bastion, etc.).
+    Tcp = 2,
+}
+
+impl ConnectionType {
+    /// Parse from the wire representation.
+    pub fn from_u16(value: u16) -> Option<Self> {
+        match value {
+            0 => Some(Self::Http),
+            1 => Some(Self::WebSocket),
+            2 => Some(Self::Tcp),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Http => "HTTP",
+            Self::WebSocket => "WebSocket",
+            Self::Tcp => "TCP",
+        }
+    }
+}
+
+impl std::fmt::Display for ConnectionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Key-value metadata pair carried in connect request/response messages.
+///
+/// Used for HTTP headers, flow tracking, and trace propagation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Metadata {
+    pub key: String,
+    pub val: String,
+}
+
+impl Metadata {
+    pub fn new(key: impl Into<String>, val: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            val: val.into(),
+        }
+    }
+}
+
+/// Per-stream request from the edge to the tunnel client.
+///
+/// Carried at the beginning of each QUIC data stream. Tells the tunnel
+/// client what type of connection this is and where to route it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectRequest {
+    /// Destination address or URL for the request.
+    pub dest: String,
+    /// The type of connection (HTTP, WebSocket, or TCP).
+    pub connection_type: ConnectionType,
+    /// Key-value metadata pairs (HTTP headers, flow IDs, trace context).
+    pub metadata: Vec<Metadata>,
+}
+
+impl ConnectRequest {
+    /// Look up a metadata value by key.
+    pub fn metadata_value(&self, key: &str) -> Option<&str> {
+        self.metadata
+            .iter()
+            .find(|m| m.key == key)
+            .map(|m| m.val.as_str())
+    }
+
+    /// Extract the HTTP method from metadata, defaulting to GET.
+    pub fn http_method(&self) -> &str {
+        self.metadata_value(HTTP_METHOD_KEY).unwrap_or("GET")
+    }
+
+    /// Extract the HTTP host from metadata.
+    pub fn http_host(&self) -> Option<&str> {
+        self.metadata_value(HTTP_HOST_KEY)
+    }
+
+    /// Extract HTTP headers from metadata.
+    ///
+    /// Headers are encoded as `HttpHeader:Header-Name` keys.
+    pub fn http_headers(&self) -> impl Iterator<Item = (&str, &str)> {
+        let prefix = format!("{HTTP_HEADER_KEY}:");
+        self.metadata.iter().filter_map(move |m| {
+            m.key
+                .strip_prefix(&prefix)
+                .map(|header_name| (header_name, m.val.as_str()))
+        })
+    }
+
+    /// Extract the flow ID from metadata, if present.
+    pub fn flow_id(&self) -> Option<&str> {
+        self.metadata_value(FLOW_ID_KEY)
+    }
+
+    /// Extract the trace ID from metadata, if present.
+    pub fn trace_id(&self) -> Option<&str> {
+        self.metadata_value(CF_TRACE_ID_KEY)
+    }
+}
+
+/// Per-stream response from the tunnel client back to the edge.
+///
+/// Sent after the tunnel client processes the `ConnectRequest`. On success
+/// the error field is empty and the stream becomes a bidirectional pipe.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectResponse {
+    /// Non-empty if the connection failed.
+    pub error: String,
+    /// Response metadata (HTTP status, headers, trace propagation).
+    pub metadata: Vec<Metadata>,
+}
+
+impl ConnectResponse {
+    /// Create a successful response with the given metadata.
+    pub fn success(metadata: Vec<Metadata>) -> Self {
+        Self {
+            error: String::new(),
+            metadata,
+        }
+    }
+
+    /// Create an error response.
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            error: message.into(),
+            metadata: Vec::new(),
+        }
+    }
+
+    /// Create a successful HTTP response with status code and headers.
+    pub fn http(status: u16, headers: Vec<(String, String)>) -> Self {
+        let mut metadata = Vec::with_capacity(1 + headers.len());
+        metadata.push(Metadata::new(HTTP_STATUS_KEY, status.to_string()));
+
+        for (name, value) in headers {
+            metadata.push(Metadata::new(format!("{HTTP_HEADER_KEY}:{name}"), value));
+        }
+
+        Self::success(metadata)
+    }
+
+    /// Create a TCP ack response (no error, optional trace propagation).
+    pub fn tcp_ack(trace_propagation: Option<&str>) -> Self {
+        let metadata = trace_propagation
+            .map(|tp| vec![Metadata::new("cf-trace-context", tp)])
+            .unwrap_or_default();
+        Self::success(metadata)
+    }
+
+    /// Whether the response indicates success (no error).
+    pub fn is_ok(&self) -> bool {
+        self.error.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_type_roundtrip() {
+        assert_eq!(ConnectionType::from_u16(0), Some(ConnectionType::Http));
+        assert_eq!(ConnectionType::from_u16(1), Some(ConnectionType::WebSocket));
+        assert_eq!(ConnectionType::from_u16(2), Some(ConnectionType::Tcp));
+        assert_eq!(ConnectionType::from_u16(3), None);
+    }
+
+    #[test]
+    fn connect_request_metadata_extraction() {
+        let request = ConnectRequest {
+            dest: "http://localhost:8080/api".into(),
+            connection_type: ConnectionType::Http,
+            metadata: vec![
+                Metadata::new(HTTP_METHOD_KEY, "POST"),
+                Metadata::new(HTTP_HOST_KEY, "example.com"),
+                Metadata::new(format!("{HTTP_HEADER_KEY}:Content-Type"), "application/json"),
+                Metadata::new(format!("{HTTP_HEADER_KEY}:Authorization"), "Bearer tok"),
+                Metadata::new(FLOW_ID_KEY, "flow-123"),
+            ],
+        };
+
+        assert_eq!(request.http_method(), "POST");
+        assert_eq!(request.http_host(), Some("example.com"));
+        assert_eq!(request.flow_id(), Some("flow-123"));
+
+        let headers: Vec<_> = request.http_headers().collect();
+        assert_eq!(headers.len(), 2);
+        assert!(headers.contains(&("Content-Type", "application/json")));
+        assert!(headers.contains(&("Authorization", "Bearer tok")));
+    }
+
+    #[test]
+    fn connect_response_http() {
+        let resp = ConnectResponse::http(200, vec![("Content-Type".into(), "text/html".into())]);
+        assert!(resp.is_ok());
+        assert_eq!(resp.metadata.len(), 2);
+        assert_eq!(resp.metadata[0].key, HTTP_STATUS_KEY);
+        assert_eq!(resp.metadata[0].val, "200");
+    }
+
+    #[test]
+    fn connect_response_error() {
+        let resp = ConnectResponse::error("origin unreachable");
+        assert!(!resp.is_ok());
+        assert_eq!(resp.error, "origin unreachable");
+    }
+
+    #[test]
+    fn connect_response_tcp_ack() {
+        let resp = ConnectResponse::tcp_ack(Some("trace-abc"));
+        assert!(resp.is_ok());
+        assert_eq!(resp.metadata.len(), 1);
+
+        let resp_no_trace = ConnectResponse::tcp_ack(None);
+        assert!(resp_no_trace.metadata.is_empty());
+    }
+
+    #[test]
+    fn default_http_method_is_get() {
+        let request = ConnectRequest {
+            dest: "/".into(),
+            connection_type: ConnectionType::Http,
+            metadata: vec![],
+        };
+        assert_eq!(request.http_method(), "GET");
+    }
+}

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -112,6 +112,8 @@ Prefer idiomatic Rust when it improves clarity, correctness, and maintainability
 Prefer:
 
 - standard library and conventional Rust patterns
+- domain-specific standard-library and crate-provided types over free-form
+    `String` and `Vec<u8>` when the value shape is already known
 - `?` for straightforward error propagation
 - `Option` and `Result` used directly rather than reinvented status patterns
 - `Self`, `Self::`, and local module paths when they improve readability

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -25,6 +25,15 @@ Dependencies are admitted only when all of the following are true:
 4. the dependency does not quietly redesign externally visible behavior
 5. a standard-library alternative is not sufficient
 
+When multiple valid choices still satisfy those rules:
+
+- prefer stronger domain typing over generic `String` or `Vec<u8>` storage when
+  the value already has a stable semantic shape such as `Uuid`, `SocketAddr`,
+  `IpAddr`, `Url`, or a dedicated newtype
+- prefer mature, production-ready, actively maintained crates for encoding,
+  decoding, parsing, and validation work over ad hoc local representations or
+  handwritten edge-case handling
+
 ## Phase 2.6 Default Rules
 
 The default dependency truth for the workspace is now:
@@ -89,7 +98,7 @@ tool surface:
 - `mimalloc`, `tokio`, `tokio-util`, `quiche`, `pingora-http`, `tracing`, and
   `tracing-subscriber` in `cloudflared-cli`
 - shared workspace truth for `pem`, `serde`, `serde_json`, `serde_yaml`,
-  `thiserror`, `url`, and `uuid`
+  `thiserror`, `url`, `uuid`, and `base64`
 - `rmcp`, `schemars`, and `tokio` in `tools/mcp-cfd-rs`
 
 Reason:
@@ -113,6 +122,9 @@ Reason:
 - config, credential, and ingress normalization work is active in
   `cloudflared-config`, so its admitted slice dependencies now exist honestly in
   manifests
+- credentials-file handling now depends on the mature `base64` crate so the
+  tunnel secret is decoded into owned bytes at the config boundary rather than
+  being carried as an encoded string into runtime and transport code
 - several first-slice crates are centralized in the root manifest already
   because root-manifest-first review and feature consistency are part of the
   accepted Phase 2.6 policy, not merely an after-the-fact consequence of broad

--- a/docs/deployment-notes.md
+++ b/docs/deployment-notes.md
@@ -28,7 +28,7 @@ The governing ADR is `docs/adr/0005-deployment-contract.md`.
 
 ### Generic local build
 
-```
+```bash
 cargo build --release --locked -p cloudflared-cli
 ```
 
@@ -38,7 +38,7 @@ The resulting binary is at `target/release/cloudflared`.
 
 For `x86-64-v2` (baseline):
 
-```
+```bash
 RUSTFLAGS="-C target-cpu=x86-64-v2 -C strip=symbols" \
   cargo build --release --locked \
   --target x86_64-unknown-linux-gnu \
@@ -47,7 +47,7 @@ RUSTFLAGS="-C target-cpu=x86-64-v2 -C strip=symbols" \
 
 For `x86-64-v4` (AVX-512 capable):
 
-```
+```bash
 RUSTFLAGS="-C target-cpu=x86-64-v4 -C strip=symbols" \
   cargo build --release --locked \
   --target x86_64-unknown-linux-gnu \
@@ -58,7 +58,7 @@ The resulting binary is at `target/x86_64-unknown-linux-gnu/release/cloudflared`
 
 ### Validate startup
 
-```
+```bash
 ./cloudflared --config /path/to/config.yml validate
 ```
 
@@ -66,7 +66,7 @@ Expected output includes `OK: admitted alpha startup surface validated`.
 
 ### Run
 
-```
+```bash
 ./cloudflared --config /path/to/config.yml run
 ```
 
@@ -95,10 +95,16 @@ contract, and exits with an honest failure.
 ## Operational Caveats
 
 - **Alpha only**: this is a production-alpha surface, not a hardened release
-- **Narrow origin path**: only `http_status` ingress rules are implemented;
-  all other origin service types return 502
-- **No RPC registration**: capnp registration content is not implemented
-- **No incoming streams**: request stream handling is deferred
+- **Limited origin dispatch**: `http_status` and `hello_world` are admitted;
+  HTTP-origin dispatch is wired but returns 502 until actual proxying exists;
+  remaining origin service types return 502 honestly
+- **No Cap'n Proto registration RPC**: the bounded control-stream
+  registration exchange is not parity-complete with the frozen Cap'n Proto
+  registration protocol
+- **No origin-cert registration content**: only the credentials-file path
+  currently emits bounded registration request content on the control stream
+- **No stream round-trip**: incoming QUIC streams are accepted and parsed,
+  but are not yet round-tripped through origin and back to edge
 - **No config reload**: config is frozen at startup; no SIGHUP handler or
   reload command exists
 - **No broad proxy**: the proxy seam is confined to the first admitted path

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -118,6 +118,9 @@ Use Rust's type system where it clearly removes invalid states or reduces meanin
 Prefer:
 
 - newtypes for real semantic distinctions
+- standard-library and mature-crate domain types such as `Uuid`, `SocketAddr`,
+  `IpAddr`, and validated byte newtypes before falling back to raw `String` or
+  `Vec<u8>` storage
 - enums for closed state sets
 - builders when construction is genuinely wide or staged
 - typestate when lifecycle misuse is a real risk and the benefit is clear

--- a/docs/status/active-surface.md
+++ b/docs/status/active-surface.md
@@ -3,7 +3,7 @@
 This file captures the currently admitted executable surface and the immediate
 deferred scope around it.
 
-## Active Phase 4.4 Surface
+## Active Phase 5.1 Surface
 
 Phase 3.3 owns the QUIC tunnel core. Phase 3.4 adds the Pingora proxy seam
 above it. Phase 3.5 adds the wire/protocol boundary between them. Phase 3.6
@@ -14,10 +14,12 @@ observability and operability surface required to run and inspect that alpha
 honestly. Phase 4.2 adds deterministic performance validation with
 stage-transition timing evidence, cold vs resumed path distinction, and
 explicit regression thresholds. Phase 4.3 adds deterministic failure-mode and
-recovery proof for the admitted alpha path. Phase 4.4 is the current admitted
-slice and adds internal deployment proof for the admitted alpha lane.
+recovery proof for the admitted alpha path. Phase 4.4 adds internal
+deployment proof for the admitted alpha lane. Phase 5.1 is the current
+admitted slice and adds broader proxy dispatch, wire-format types, and
+incoming QUIC data stream handling.
 
-What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7 + 4.1 + 4.2 + 4.3 + 4.4):
+What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7 + 4.1 + 4.2 + 4.3 + 4.4 + 5.1):
 
 - `run` enters a real quiche-based transport service under the runtime boundary
 - connection/session ownership and QUIC handshake state are explicit
@@ -97,20 +99,43 @@ What exists now (3.3 + 3.4a–c + 3.5 + 3.6 + 3.7 + 4.1 + 4.2 + 4.3 + 4.4):
   are reported in deployment evidence
 - known deployment gaps (no systemd unit, no installer, no container image,
   no updater, no log rotation) are declared explicitly
-- operational caveats (alpha-only, narrow origin path, no RPC registration,
-  no incoming streams, no config reload) are declared explicitly
+- operational caveats (alpha-only, limited origin dispatch, no Cap'n Proto
+  registration RPC, no origin-cert registration content, no stream
+  round-trip, no config reload) are declared explicitly
 - deployment evidence scope is honestly bounded to in-process contract
   validation
 - operator-facing deployment notes exist in `docs/deployment-notes.md`
   matching the declared deployment contract from ADR-0005
 - the CI merge workflow produces lane-specific preview artifacts for both
   shipped GNU lanes (x86-64-v2 and x86-64-v4)
+- wire-format types for per-stream request/response exchange are owned by
+  `crates/cloudflared-proto/` (ConnectionType, ConnectRequest,
+  ConnectResponse, Metadata)
+- registration RPC type boundaries (TunnelAuth, ConnectionOptions,
+  ConnectionDetails) are defined in `crates/cloudflared-proto/`
+- the control stream now carries a bounded credentials-file registration
+  request/response exchange; successful responses produce
+  `RegistrationComplete` events with connection UUID and location
+- the proxy seam now dispatches broader origin services: HelloWorld returns
+  a real HTML response, Http-origin dispatch is wired (returns 502 until
+  actual proxying is implemented), and unimplemented services are labeled
+  honestly
+- the origin dispatch surface is owned by
+  `crates/cloudflared-cli/src/proxy/origin.rs`
+- after QUIC establishment the transport enters a stream-serving loop that
+  accepts server-initiated bidi streams, parses ConnectRequest wire format,
+  and forwards IncomingStream events through the protocol bridge
+- the protocol bridge now carries IncomingStream and RegistrationComplete
+  events in addition to the original registration event
+- the transport lifecycle includes a ServingStreams stage after Established
 
 What the current surface does not imply:
 
-- that registration RPC content (capnp) is implemented
-- that incoming request stream handling exists
-- that the admitted origin path is general proxy completeness
+- that Cap'n Proto registration RPC parity is implemented
+- that origin-cert identity currently emits registration content
+- that incoming streams are round-tripped through origin and back to edge
+- that the admitted origin dispatch is general proxy completeness (actual
+  HTTP proxying, WebSocket upgrade, TCP streaming remain deferred)
 - that the bounded security/compliance operational boundary constitutes
   certification, whole-program compliance, or validated FIPS implementation
 - that broader standard-format crate integration beyond active-slice need
@@ -135,14 +160,15 @@ The following remain intentionally out of the current executable-surface task:
 
 - broader platform parity beyond Linux
 - broader artifact scope beyond GNU `x86-64-v2` and `x86-64-v4`
-- broader Pingora proxy completeness beyond the narrow admitted origin path
-- registration RPC, incoming stream handling, and broader protocol work
-  outside their later owning slices
+- broader Pingora proxy completeness beyond the admitted origin-dispatch
+  surface (actual HTTP proxying, WebSocket upgrade, TCP streaming)
+- Cap'n Proto registration RPC parity, origin-cert registration content,
+  and full request stream round-trip through origin and back to edge
 - packaging, deployment tooling, container support, and
   certification-proving work beyond the current numbered Big Phase 3 slice list
 - broader deployment/management work beyond the admitted 4.4 deployment proof
-  surface (real systemd unit files, installers, container images, updaters,
-  log rotation)
+  surface and 5.1 stream-serving surface (real systemd unit files, installers,
+  container images, updaters, log rotation)
 - broader performance proof beyond the admitted harness path
 
 ## Follow-On Constraints For Later Slices
@@ -166,9 +192,12 @@ Phase 3.7 (standard-format crate integration boundary):
 
 Immediate narrowness caveat:
 
-- the admitted origin path is `http_status` only; all other origin service
-  types return 502 until later slices implement real origin connections
+- the admitted origin dispatch handles `http_status` and `hello_world`;
+  Http-origin dispatch is wired but returns 502 until actual proxying;
+  remaining origin types return 502 honestly
 - `PingoraProxySeam` is not a general Pingora proxy; it is a confined
-  entry point for the first admitted path
-- the protocol bridge carries registration events only; incoming request
-  streams and registration RPC content remain deferred
+  entry point for the admitted dispatch surface
+- incoming QUIC data streams are accepted and parsed but not yet
+  round-tripped through origin and back to edge
+- bounded credentials-file registration exchange exists; Cap'n Proto parity
+  and origin-cert registration content remain deferred


### PR DESCRIPTION
**WARNING! This PR is planned to be merged before planned complete feature audits**

This pull request introduces Phase 5.1 features to the proxy, protocol, and origin handling surfaces, expanding the tunnel's wire-format and stream-serving capabilities. The main changes include support for broader origin service dispatch, new wire-format types, and improved handling of incoming QUIC streams and registration events. The codebase now routes incoming requests via `ConnectRequest` and reports detailed stream dispatch statuses.

**Phase 5.1: Broader protocol and proxy surface**

* Added support for broader wire-format types and stream-serving in `cloudflared-proto`, including `ConnectRequest`, `ConnectionType`, and registration types, enabling origin service dispatch beyond http_status-only and stream-to-proxy forwarding.
* Updated `ProtocolEvent` enum in `protocol.rs` to handle incoming QUIC streams via `ConnectRequest`, registration completion events, and improved peer representation using `SocketAddr`. [[1]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cL52-R72) [[2]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cL10-R18) [[3]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cL118-R137) [[4]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cL147-R166)

**Proxy layer enhancements**

* Refactored `PingoraProxySeam` to handle incoming `ConnectRequest` messages, route them through ingress matching, and dispatch to matched origin services. Added detailed stream dispatch reporting and broader origin service dispatch logic. [[1]](diffhunk://#diff-76a099e22cda2fee832c5303a6e0f88b84364ea52b2ab35a6a1fcffa6d740b4aR104-R120) [[2]](diffhunk://#diff-76a099e22cda2fee832c5303a6e0f88b84364ea52b2ab35a6a1fcffa6d740b4aL123-R147) [[3]](diffhunk://#diff-76a099e22cda2fee832c5303a6e0f88b84364ea52b2ab35a6a1fcffa6d740b4aR172-R178) [[4]](diffhunk://#diff-76a099e22cda2fee832c5303a6e0f88b84364ea52b2ab35a6a1fcffa6d740b4aR189-R209) [[5]](diffhunk://#diff-76a099e22cda2fee832c5303a6e0f88b84364ea52b2ab35a6a1fcffa6d740b4aL180-R221) [[6]](diffhunk://#diff-76a099e22cda2fee832c5303a6e0f88b84364ea52b2ab35a6a1fcffa6d740b4aR262-R314)

**Dependency and workspace updates**

* Added `cloudflared-proto` as a workspace dependency in `Cargo.toml` and `cloudflared-cli/Cargo.toml`, along with new dependencies (`base64`, `serde_json`, and `url` for dev). [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R21-R31) [[2]](diffhunk://#diff-133c0813bd826cf45e96ae84ca8436438fde00fc7b2f75a6fa85eeaf8e25cd72R14-R18) [[3]](diffhunk://#diff-133c0813bd826cf45e96ae84ca8436438fde00fc7b2f75a6fa85eeaf8e25cd72R28-R30)

**Documentation and instructions**

* Updated instructions and status documentation to reflect Phase 5.1 admission, emphasizing preference for strong domain types, mature crates, and broader proxy completeness. [[1]](diffhunk://#diff-66925704832d33c44a0776bad863e48d07dd2f35fd157065efa14e78023c4f02R14-R17) [[2]](diffhunk://#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9eR49-R65) [[3]](diffhunk://#diff-ebaa9c4b37eb507fa2bf18482a36aceda2c8ee8d3a5bf8780925e761710c413cL1-R1) [[4]](diffhunk://#diff-76a099e22cda2fee832c5303a6e0f88b84364ea52b2ab35a6a1fcffa6d740b4aL1-R3) [[5]](diffhunk://#diff-76a099e22cda2fee832c5303a6e0f88b84364ea52b2ab35a6a1fcffa6d740b4aR20-R36)